### PR TITLE
feat(alarm-keypad): add alarm_entity_id substitution and PIN label feedback

### DIFF
--- a/esp32-alarm-keypad.yaml
+++ b/esp32-alarm-keypad.yaml
@@ -41,6 +41,8 @@ substitutions:
   touchscreen_platform: "gt911"
   # Backlight
   backlight_pin: "GPIO38"
+  # Alarm panel entity
+  alarm_entity_id: alarm_control_panel.home_alarm
 
 packages:
   board: !include packages/board.yaml

--- a/packages/alarm-keypad-ui.yaml
+++ b/packages/alarm-keypad-ui.yaml
@@ -29,19 +29,19 @@ globals:
 text_sensor:
   - platform: homeassistant
     id: alarm_code_arm_required
-    entity_id: alarm_control_panel.home_alarm
+    entity_id: ${alarm_entity_id}
     attribute: code_arm_required
     on_value:
       - lambda: id(arm_requires_code) = (x == "true");
   - platform: homeassistant
     id: alarm_code_disarm_required
-    entity_id: alarm_control_panel.home_alarm
+    entity_id: ${alarm_entity_id}
     attribute: code_disarm_required
     on_value:
       - lambda: id(disarm_requires_code) = (x == "true");
   - platform: homeassistant
     id: alarm_state
-    entity_id: alarm_control_panel.home_alarm
+    entity_id: ${alarm_entity_id}
     on_value:
       - lvgl.label.update:
           id: lbl_status
@@ -432,6 +432,10 @@ lvgl:
                               then:
                                 - lvgl.widget.hide:
                                     id: code_display
+                                - lvgl.label.update:
+                                    id: lbl_disarm_btn
+                                    text: "\U000F0FF2"
+                                    text_font: mdi_icons
                         widgets:
                           - label:
                               text: "CLR"
@@ -467,7 +471,7 @@ lvgl:
                                 - homeassistant.service:
                                     service: alarm_control_panel.alarm_disarm
                                     data:
-                                      entity_id: alarm_control_panel.home_alarm
+                                      entity_id: ${alarm_entity_id}
                                       code: !lambda return id(entered_code);
                           - if:
                               condition:
@@ -476,7 +480,7 @@ lvgl:
                                 - homeassistant.service:
                                     service: alarm_control_panel.alarm_arm_away
                                     data:
-                                      entity_id: alarm_control_panel.home_alarm
+                                      entity_id: ${alarm_entity_id}
                                       code: !lambda return id(entered_code);
                           - if:
                               condition:
@@ -485,7 +489,7 @@ lvgl:
                                 - homeassistant.service:
                                     service: alarm_control_panel.alarm_arm_home
                                     data:
-                                      entity_id: alarm_control_panel.home_alarm
+                                      entity_id: ${alarm_entity_id}
                                       code: !lambda return id(entered_code);
                           - if:
                               condition:
@@ -494,7 +498,7 @@ lvgl:
                                 - homeassistant.service:
                                     service: alarm_control_panel.alarm_arm_night
                                     data:
-                                      entity_id: alarm_control_panel.home_alarm
+                                      entity_id: ${alarm_entity_id}
                                       code: !lambda return id(entered_code);
                           - lambda: id(entered_code) = ""; id(pending_action) = 0;
                           - lvgl.label.update:
@@ -502,6 +506,10 @@ lvgl:
                               text: ""
                           - lvgl.widget.hide:
                               id: code_display
+                          - lvgl.label.update:
+                              id: lbl_disarm_btn
+                              text: "\U000F0FF2"
+                              text_font: mdi_icons
                         widgets:
                           - label:
                               text: "OK"
@@ -543,7 +551,7 @@ lvgl:
                                 - homeassistant.service:
                                     service: alarm_control_panel.alarm_arm_away
                                     data:
-                                      entity_id: alarm_control_panel.home_alarm
+                                      entity_id: ${alarm_entity_id}
                         widgets:
                           - label:
                               text: "\U000F033E"
@@ -566,7 +574,7 @@ lvgl:
                                 - homeassistant.service:
                                     service: alarm_control_panel.alarm_arm_home
                                     data:
-                                      entity_id: alarm_control_panel.home_alarm
+                                      entity_id: ${alarm_entity_id}
                         widgets:
                           - label:
                               text: "\uF015"
@@ -589,7 +597,7 @@ lvgl:
                                 - homeassistant.service:
                                     service: alarm_control_panel.alarm_arm_night
                                     data:
-                                      entity_id: alarm_control_panel.home_alarm
+                                      entity_id: ${alarm_entity_id}
                         widgets:
                           - label:
                               text: "\U000F0594"
@@ -614,14 +622,19 @@ lvgl:
                         then:
                           - lvgl.widget.show:
                               id: code_display
+                          - lvgl.label.update:
+                              id: lbl_disarm_btn
+                              text: "PIN"
+                              text_font: montserrat_28
                         else:
                           - homeassistant.service:
                               service: alarm_control_panel.alarm_disarm
                               data:
-                                entity_id: alarm_control_panel.home_alarm
+                                entity_id: ${alarm_entity_id}
                                 code: ""
                   widgets:
                     - label:
+                        id: lbl_disarm_btn
                         text: "\U000F0FF2"
                         align: CENTER
                         text_font: mdi_icons


### PR DESCRIPTION
## Changes

- Add \larm_entity_id\ substitution (default: \larm_control_panel.home_alarm\) so the package works with any HA alarm panel entity without editing the package file
- DISARM button label switches to **PIN** when code entry is required; restores shield-off icon after OK or when CLR empties the buffer

## Test plan

- [ ] Compile with default substitution — confirm no regression
- [ ] Override \larm_entity_id\ in an instance YAML — confirm correct entity subscribed
- [ ] Arm panel, press DISARM with \code_disarm_required: true\ — confirm label changes to PIN
- [ ] Press CLR to empty buffer — confirm shield-off icon restored
- [ ] Press OK — confirm shield-off icon restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)