### PR TITLE
feat: add thermostat panel and N-page swipe navigation orchestrator

### DIFF
--- a/esp32-alarm-keypad.yaml
+++ b/esp32-alarm-keypad.yaml
@@ -43,10 +43,17 @@ substitutions:
   backlight_pin: "GPIO38"
   # Alarm panel entity
   alarm_entity_id: alarm_control_panel.home_alarm
+  # Thermostat entity
+  thermostat_entity_id: climate.thermostat
+  thermostat_temp_min: "16.0"
+  thermostat_temp_max: "30.0"
+  thermostat_temp_step: "0.5"
 
 packages:
   board: !include packages/board.yaml
   alarm_ui: !include packages/alarm-keypad-ui.yaml
+  thermostat_ui: !include packages/thermostat-ui.yaml
+  nav: !include packages/nav.yaml
 
 esphome:
   name: ${name}
@@ -89,6 +96,6 @@ wifi:
 captive_portal:
 
 # LVGL top-level settings — rotation is board-specific;
-# pages are contributed by UI packages (alarm_ui, etc.)
+# pages are contributed by UI packages (alarm_ui, thermostat_ui, etc.)
 lvgl:
   rotation: ${display_rotation}

--- a/packages/alarm-keypad-ui.yaml
+++ b/packages/alarm-keypad-ui.yaml
@@ -139,7 +139,7 @@ font:
 
 lvgl:
   pages:
-    - id: keypad_page
+    - id: alarm_page
       widgets:
         - obj:
             width: ${display_width}

--- a/packages/board.yaml
+++ b/packages/board.yaml
@@ -72,7 +72,30 @@ display:
       green: [ 8, 20,  3, 46,  9, 10]
       blue:  [ 4,  5,  6,  7, 15]
 
+# Touch-state globals — populated by on_touch, consumed by nav.yaml scripts
+globals:
+  - id: nav_swipe_start_x
+    type: int
+    restore_value: no
+    initial_value: '-1'
+  - id: nav_last_touch_x
+    type: int
+    restore_value: no
+    initial_value: '0'
+  - id: nav_swipe_dx
+    type: int
+    restore_value: no
+    initial_value: '0'
+
+# Contract: nav.yaml must define scripts nav_touch and nav_release
 touchscreen:
   - platform: ${touchscreen_platform}
     id: tft_touch
     display: tft_display
+    on_touch:
+      - lambda: |-
+          if (id(nav_swipe_start_x) == -1) id(nav_swipe_start_x) = touch.x;
+          id(nav_last_touch_x) = touch.x;
+      - script.execute: nav_touch
+    on_release:
+      - script.execute: nav_release

--- a/packages/nav.yaml
+++ b/packages/nav.yaml
@@ -1,0 +1,47 @@
+# nav.yaml — Page navigation orchestrator
+#
+# Manages swipe navigation and auto-return between any number of LVGL pages.
+# Panels (alarm_ui, thermostat_ui, etc.) are completely unaware of this file.
+#
+# Default behaviour (override in your instance YAML):
+#   nav_home_page:          alarm_page   — page shown on boot and after timeout
+#   nav_auto_return_delay:  30s          — idle time before returning home
+#
+# Contract with board.yaml:
+#   board.yaml populates nav_swipe_start_x / nav_last_touch_x / nav_swipe_dx
+#   and calls nav_touch / nav_release on each touch event.
+
+substitutions:
+  nav_home_page: alarm_page
+  nav_auto_return_delay: 30s
+
+script:
+  # Called by board.yaml on every touch — resets the idle timer
+  - id: nav_touch
+    mode: restart
+    then:
+      - script.execute: auto_return   # restart the 30-s countdown
+
+  # Called by board.yaml on touch release — detects swipe direction
+  - id: nav_release
+    then:
+      - lambda: |-
+          id(nav_swipe_dx) = id(nav_last_touch_x) - id(nav_swipe_start_x);
+          id(nav_swipe_start_x) = -1;
+      - if:
+          condition:
+            lambda: return id(nav_swipe_dx) < -80;
+          then:
+            - lvgl.page.next:
+      - if:
+          condition:
+            lambda: return id(nav_swipe_dx) > 80;
+          then:
+            - lvgl.page.previous:
+
+  # Auto-return: returns to home page after idle timeout
+  - id: auto_return
+    mode: restart
+    then:
+      - delay: ${nav_auto_return_delay}
+      - lvgl.page.show: ${nav_home_page}

--- a/packages/thermostat-ui.yaml
+++ b/packages/thermostat-ui.yaml
@@ -1,0 +1,489 @@
+# Thermostat UI — LVGL interface wired to Home Assistant climate entity
+# Board-independent; include alongside board.yaml and alarm-keypad-ui.yaml.
+# Swipe right from this page returns to alarm_page.
+
+globals:
+  - id: target_temp
+    type: float
+    restore_value: no
+    initial_value: '22.0'
+
+sensor:
+  - platform: homeassistant
+    id: clim_current_temp
+    entity_id: ${thermostat_entity_id}
+    attribute: current_temperature
+    on_value:
+      - lvgl.label.update:
+          id: lbl_current_temp
+          text: !lambda return str_sprintf("%.1f°", x);
+
+  - platform: homeassistant
+    id: clim_target_temp_sensor
+    entity_id: ${thermostat_entity_id}
+    attribute: temperature
+    on_value:
+      - lambda: id(target_temp) = x;
+      - lvgl.label.update:
+          id: lbl_target_temp
+          text: !lambda return str_sprintf("%.1f°", x);
+
+text_sensor:
+  - platform: homeassistant
+    id: clim_hvac_mode
+    entity_id: ${thermostat_entity_id}
+    on_value:
+      - if:
+          condition: {lambda: return x == "off";}
+          then: [{lvgl.button.update: {id: btn_mode_off,  bg_color: 0x555555}}]
+          else: [{lvgl.button.update: {id: btn_mode_off,  bg_color: 0x16213e}}]
+      - if:
+          condition: {lambda: return x == "heat";}
+          then: [{lvgl.button.update: {id: btn_mode_heat, bg_color: 0xcc4400}}]
+          else: [{lvgl.button.update: {id: btn_mode_heat, bg_color: 0x16213e}}]
+      - if:
+          condition: {lambda: return x == "cool";}
+          then: [{lvgl.button.update: {id: btn_mode_cool, bg_color: 0x0066aa}}]
+          else: [{lvgl.button.update: {id: btn_mode_cool, bg_color: 0x16213e}}]
+      - if:
+          condition: {lambda: return x == "heat_cool";}
+          then: [{lvgl.button.update: {id: btn_mode_auto, bg_color: 0x006644}}]
+          else: [{lvgl.button.update: {id: btn_mode_auto, bg_color: 0x16213e}}]
+      - if:
+          condition: {lambda: return x == "fan_only";}
+          then: [{lvgl.button.update: {id: btn_mode_fan,  bg_color: 0x6633aa}}]
+          else: [{lvgl.button.update: {id: btn_mode_fan,  bg_color: 0x16213e}}]
+      - if:
+          condition: {lambda: return x == "dry";}
+          then: [{lvgl.button.update: {id: btn_mode_dry,  bg_color: 0xaa6600}}]
+          else: [{lvgl.button.update: {id: btn_mode_dry,  bg_color: 0x16213e}}]
+
+  - platform: homeassistant
+    id: clim_preset_mode
+    entity_id: ${thermostat_entity_id}
+    attribute: preset_mode
+    on_value:
+      - if:
+          condition: {lambda: return x == "home";}
+          then: [{lvgl.button.update: {id: btn_preset_home,    bg_color: 0x0f3460}}]
+          else: [{lvgl.button.update: {id: btn_preset_home,    bg_color: 0x16213e}}]
+      - if:
+          condition: {lambda: return x == "away";}
+          then: [{lvgl.button.update: {id: btn_preset_away,    bg_color: 0x0f3460}}]
+          else: [{lvgl.button.update: {id: btn_preset_away,    bg_color: 0x16213e}}]
+      - if:
+          condition: {lambda: return x == "sleep";}
+          then: [{lvgl.button.update: {id: btn_preset_sleep,   bg_color: 0x0f3460}}]
+          else: [{lvgl.button.update: {id: btn_preset_sleep,   bg_color: 0x16213e}}]
+      - if:
+          condition: {lambda: return x == "eco";}
+          then: [{lvgl.button.update: {id: btn_preset_eco,     bg_color: 0x0f3460}}]
+          else: [{lvgl.button.update: {id: btn_preset_eco,     bg_color: 0x16213e}}]
+      - if:
+          condition: {lambda: return x == "boost";}
+          then: [{lvgl.button.update: {id: btn_preset_boost,   bg_color: 0x0f3460}}]
+          else: [{lvgl.button.update: {id: btn_preset_boost,   bg_color: 0x16213e}}]
+      - if:
+          condition: {lambda: return x == "comfort";}
+          then: [{lvgl.button.update: {id: btn_preset_comfort, bg_color: 0x0f3460}}]
+          else: [{lvgl.button.update: {id: btn_preset_comfort, bg_color: 0x16213e}}]
+
+lvgl:
+  pages:
+    - id: thermostat_page
+      widgets:
+        - obj:
+            width: ${display_width}
+            height: ${display_height}
+            pad_all: 0
+            bg_color: 0x1a1a2e
+            border_width: 0
+            scrollbar_mode: "off"
+            scrollable: false
+            widgets:
+
+              # Current temperature — large display
+              - label:
+                  id: lbl_current_temp
+                  x: 10
+                  y: 8
+                  width: 460
+                  text: "--°"
+                  align: TOP_MID
+                  text_align: CENTER
+                  text_font: montserrat_48
+                  text_color: 0xffffff
+
+              - label:
+                  x: 10
+                  y: 68
+                  width: 460
+                  text: "CURRENT"
+                  align: TOP_MID
+                  text_align: CENTER
+                  text_font: montserrat_14
+                  text_color: 0x888888
+
+              # Target temperature row: [−]  22.0°  [+]
+              - obj:
+                  x: 10
+                  y: 92
+                  width: 460
+                  height: 80
+                  bg_color: 0x1a1a2e
+                  border_width: 0
+                  pad_all: 0
+                  scrollbar_mode: "off"
+                  scrollable: false
+                  layout:
+                    type: FLEX
+                    flex_flow: ROW
+                    flex_align_main: SPACE_BETWEEN
+                    flex_align_cross: CENTER
+                  widgets:
+                    - button:
+                        width: 80
+                        height: 70
+                        bg_color: 0x0f3460
+                        on_press:
+                          - lambda: |-
+                              float next = id(target_temp) - ${thermostat_temp_step};
+                              if (next >= ${thermostat_temp_min}) id(target_temp) = next;
+                          - lvgl.label.update:
+                              id: lbl_target_temp
+                              text: !lambda return str_sprintf("%.1f°", id(target_temp));
+                          - homeassistant.service:
+                              service: climate.set_temperature
+                              data:
+                                entity_id: ${thermostat_entity_id}
+                                temperature: !lambda return id(target_temp);
+                        widgets:
+                          - label:
+                              text: "−"
+                              align: CENTER
+                              text_font: montserrat_48
+                              text_color: 0xffffff
+                    - label:
+                        id: lbl_target_temp
+                        text: "--°"
+                        align: CENTER
+                        text_align: CENTER
+                        text_font: montserrat_48
+                        text_color: 0xe94560
+                    - button:
+                        width: 80
+                        height: 70
+                        bg_color: 0x0f3460
+                        on_press:
+                          - lambda: |-
+                              float next = id(target_temp) + ${thermostat_temp_step};
+                              if (next <= ${thermostat_temp_max}) id(target_temp) = next;
+                          - lvgl.label.update:
+                              id: lbl_target_temp
+                              text: !lambda return str_sprintf("%.1f°", id(target_temp));
+                          - homeassistant.service:
+                              service: climate.set_temperature
+                              data:
+                                entity_id: ${thermostat_entity_id}
+                                temperature: !lambda return id(target_temp);
+                        widgets:
+                          - label:
+                              text: "+"
+                              align: CENTER
+                              text_font: montserrat_48
+                              text_color: 0xffffff
+
+              # MODE section label
+              - label:
+                  x: 10
+                  y: 180
+                  width: 460
+                  text: "MODE"
+                  text_font: montserrat_14
+                  text_color: 0x888888
+
+              # Mode row 1: OFF  HEAT  COOL
+              - obj:
+                  x: 10
+                  y: 200
+                  width: 460
+                  height: 52
+                  bg_color: 0x1a1a2e
+                  border_width: 0
+                  pad_all: 0
+                  scrollbar_mode: "off"
+                  scrollable: false
+                  layout:
+                    type: FLEX
+                    flex_flow: ROW
+                    flex_align_main: SPACE_BETWEEN
+                    flex_align_cross: STRETCH
+                  widgets:
+                    - button:
+                        id: btn_mode_off
+                        width: 148
+                        height: 52
+                        bg_color: 0x16213e
+                        on_press:
+                          - homeassistant.service:
+                              service: climate.set_hvac_mode
+                              data:
+                                entity_id: ${thermostat_entity_id}
+                                hvac_mode: "off"
+                        widgets:
+                          - label:
+                              text: "OFF"
+                              align: CENTER
+                              text_font: montserrat_22
+                              text_color: 0xffffff
+                    - button:
+                        id: btn_mode_heat
+                        width: 148
+                        height: 52
+                        bg_color: 0x16213e
+                        on_press:
+                          - homeassistant.service:
+                              service: climate.set_hvac_mode
+                              data:
+                                entity_id: ${thermostat_entity_id}
+                                hvac_mode: "heat"
+                        widgets:
+                          - label:
+                              text: "HEAT"
+                              align: CENTER
+                              text_font: montserrat_22
+                              text_color: 0xffffff
+                    - button:
+                        id: btn_mode_cool
+                        width: 148
+                        height: 52
+                        bg_color: 0x16213e
+                        on_press:
+                          - homeassistant.service:
+                              service: climate.set_hvac_mode
+                              data:
+                                entity_id: ${thermostat_entity_id}
+                                hvac_mode: "cool"
+                        widgets:
+                          - label:
+                              text: "COOL"
+                              align: CENTER
+                              text_font: montserrat_22
+                              text_color: 0xffffff
+
+              # Mode row 2: AUTO  FAN  DRY
+              - obj:
+                  x: 10
+                  y: 256
+                  width: 460
+                  height: 52
+                  bg_color: 0x1a1a2e
+                  border_width: 0
+                  pad_all: 0
+                  scrollbar_mode: "off"
+                  scrollable: false
+                  layout:
+                    type: FLEX
+                    flex_flow: ROW
+                    flex_align_main: SPACE_BETWEEN
+                    flex_align_cross: STRETCH
+                  widgets:
+                    - button:
+                        id: btn_mode_auto
+                        width: 148
+                        height: 52
+                        bg_color: 0x16213e
+                        on_press:
+                          - homeassistant.service:
+                              service: climate.set_hvac_mode
+                              data:
+                                entity_id: ${thermostat_entity_id}
+                                hvac_mode: "heat_cool"
+                        widgets:
+                          - label:
+                              text: "AUTO"
+                              align: CENTER
+                              text_font: montserrat_22
+                              text_color: 0xffffff
+                    - button:
+                        id: btn_mode_fan
+                        width: 148
+                        height: 52
+                        bg_color: 0x16213e
+                        on_press:
+                          - homeassistant.service:
+                              service: climate.set_hvac_mode
+                              data:
+                                entity_id: ${thermostat_entity_id}
+                                hvac_mode: "fan_only"
+                        widgets:
+                          - label:
+                              text: "FAN"
+                              align: CENTER
+                              text_font: montserrat_22
+                              text_color: 0xffffff
+                    - button:
+                        id: btn_mode_dry
+                        width: 148
+                        height: 52
+                        bg_color: 0x16213e
+                        on_press:
+                          - homeassistant.service:
+                              service: climate.set_hvac_mode
+                              data:
+                                entity_id: ${thermostat_entity_id}
+                                hvac_mode: "dry"
+                        widgets:
+                          - label:
+                              text: "DRY"
+                              align: CENTER
+                              text_font: montserrat_22
+                              text_color: 0xffffff
+
+              # PRESET section label
+              - label:
+                  x: 10
+                  y: 316
+                  width: 460
+                  text: "PRESET"
+                  text_font: montserrat_14
+                  text_color: 0x888888
+
+              # Preset row 1: HOME  AWAY  SLEEP
+              - obj:
+                  x: 10
+                  y: 336
+                  width: 460
+                  height: 52
+                  bg_color: 0x1a1a2e
+                  border_width: 0
+                  pad_all: 0
+                  scrollbar_mode: "off"
+                  scrollable: false
+                  layout:
+                    type: FLEX
+                    flex_flow: ROW
+                    flex_align_main: SPACE_BETWEEN
+                    flex_align_cross: STRETCH
+                  widgets:
+                    - button:
+                        id: btn_preset_home
+                        width: 148
+                        height: 52
+                        bg_color: 0x16213e
+                        on_press:
+                          - homeassistant.service:
+                              service: climate.set_preset_mode
+                              data:
+                                entity_id: ${thermostat_entity_id}
+                                preset_mode: "home"
+                        widgets:
+                          - label:
+                              text: "\uF015"
+                              align: CENTER
+                              text_font: montserrat_28
+                              text_color: 0xffffff
+                    - button:
+                        id: btn_preset_away
+                        width: 148
+                        height: 52
+                        bg_color: 0x16213e
+                        on_press:
+                          - homeassistant.service:
+                              service: climate.set_preset_mode
+                              data:
+                                entity_id: ${thermostat_entity_id}
+                                preset_mode: "away"
+                        widgets:
+                          - label:
+                              text: "AWAY"
+                              align: CENTER
+                              text_font: montserrat_22
+                              text_color: 0xffffff
+                    - button:
+                        id: btn_preset_sleep
+                        width: 148
+                        height: 52
+                        bg_color: 0x16213e
+                        on_press:
+                          - homeassistant.service:
+                              service: climate.set_preset_mode
+                              data:
+                                entity_id: ${thermostat_entity_id}
+                                preset_mode: "sleep"
+                        widgets:
+                          - label:
+                              text: "\U000F0594"
+                              align: CENTER
+                              text_font: mdi_icons
+                              text_color: 0xffffff
+
+              # Preset row 2: ECO  BOOST  COMFORT
+              - obj:
+                  x: 10
+                  y: 392
+                  width: 460
+                  height: 52
+                  bg_color: 0x1a1a2e
+                  border_width: 0
+                  pad_all: 0
+                  scrollbar_mode: "off"
+                  scrollable: false
+                  layout:
+                    type: FLEX
+                    flex_flow: ROW
+                    flex_align_main: SPACE_BETWEEN
+                    flex_align_cross: STRETCH
+                  widgets:
+                    - button:
+                        id: btn_preset_eco
+                        width: 148
+                        height: 52
+                        bg_color: 0x16213e
+                        on_press:
+                          - homeassistant.service:
+                              service: climate.set_preset_mode
+                              data:
+                                entity_id: ${thermostat_entity_id}
+                                preset_mode: "eco"
+                        widgets:
+                          - label:
+                              text: "ECO"
+                              align: CENTER
+                              text_font: montserrat_22
+                              text_color: 0xffffff
+                    - button:
+                        id: btn_preset_boost
+                        width: 148
+                        height: 52
+                        bg_color: 0x16213e
+                        on_press:
+                          - homeassistant.service:
+                              service: climate.set_preset_mode
+                              data:
+                                entity_id: ${thermostat_entity_id}
+                                preset_mode: "boost"
+                        widgets:
+                          - label:
+                              text: "BOOST"
+                              align: CENTER
+                              text_font: montserrat_22
+                              text_color: 0xffffff
+                    - button:
+                        id: btn_preset_comfort
+                        width: 148
+                        height: 52
+                        bg_color: 0x16213e
+                        on_press:
+                          - homeassistant.service:
+                              service: climate.set_preset_mode
+                              data:
+                                entity_id: ${thermostat_entity_id}
+                                preset_mode: "comfort"
+                        widgets:
+                          - label:
+                              text: "COMF"
+                              align: CENTER
+                              text_font: montserrat_22
+                              text_color: 0xffffff
+


### PR DESCRIPTION
## Summary

- **nav.yaml** — new orchestrator package; owns \
av_home_page\ (default: \larm_page\) and \
av_auto_return_delay\ (default: \30s\) as substitutions; swipe left/right calls \lvgl.page.next\/\previous\ so it never references specific panel IDs; auto-return script returns to home page after idle timeout
- **thermostat-ui.yaml** — new panel for \climate.smart_climate\: current temp, target temp (+/−), 6 HVAC modes with per-mode highlight colors, 6 presets; completely isolated from nav and other panels
- **board.yaml** — touchscreen captures swipe coords into globals and delegates to \
av_touch\/\
av_release\ scripts
- **alarm-keypad-ui.yaml** — page renamed \keypad_page\ → \larm_page\
- **esp32-alarm-keypad.yaml** — adds thermostat substitutions, includes new packages

## Adding a new panel (N-page extensibility)

1. Create \packages/my-panel.yaml\ with an \lvgl: pages:\ entry
2. Add \my_panel: !include packages/my-panel.yaml\ to the instance YAML
3. Done — nav cycles it automatically; zero changes to any other file

## Test plan

- [ ] Compile succeeds
- [ ] Swipe left shows thermostat, swipe right returns to alarm
- [ ] 30 s idle returns to alarm page automatically
- [ ] Thermostat current/target temp update from HA
- [ ] Mode buttons highlight active mode; pressing changes HA state
- [ ] Preset buttons highlight active preset; pressing changes HA state

🤖 Generated with [Claude Code](https://claude.com/claude-code)