### PR TITLE
feat: add persistent navbar
   with left/right arrows and status label

### DIFF
--- a/packages/alarm-keypad-ui.yaml
+++ b/packages/alarm-keypad-ui.yaml
@@ -4,12 +4,11 @@
 #
 # Layout (480×480 display, nav_bar_height=60):
 #   y=  0..59  — navbar (top_layer, handled by nav.yaml)
-#   y= 65..108 — code-entry display bar (always visible; empty when idle)
-#   y=115..178 — keypad row 0  (1 2 3)
-#   y=185..248 — keypad row 1  (4 5 6)
-#   y=255..318 — keypad row 2  (7 8 9)
-#   y=325..388 — keypad row 3  (CLR 0 OK)
-#   y=395..458 — ARM / DISARM row
+#   y= 65..128 — keypad row 0  (1 2 3)
+#   y=135..198 — keypad row 1  (4 5 6)
+#   y=205..268 — keypad row 2  (7 8 9)
+#   y=275..338 — keypad row 3  (CLR 0 OK)
+#   y=345..408 — ARM / DISARM row
 #
 # Navbar contract (nav.yaml):
 #   Writes formatted alarm state to any nav slot mapped to alarm_page, then calls
@@ -68,7 +67,7 @@ text_sensor:
           if (strcmp("${nav_page_1}", "alarm_page") == 0) id(g_nav_status_1) = txt;
           if (strcmp("${nav_page_2}", "alarm_page") == 0) id(g_nav_status_2) = txt;
           if (strcmp("${nav_page_3}", "alarm_page") == 0) id(g_nav_status_3) = txt;
-      - script.execute: nav_refresh_status
+      - script.execute: code_overlay_refresh
       # Drive ARM/DISARM button visibility and animations
       - script.stop: anim_arming
       - script.stop: anim_triggered
@@ -111,6 +110,20 @@ text_sensor:
                 bg_color: 0xe94560
 
 script:
+  # When digits are entered, show * overlay in navbar status; otherwise restore
+  # the live status text from nav.yaml.
+  - id: code_overlay_refresh
+    then:
+      - if:
+          condition:
+            lambda: return id(entered_code).empty();
+          then:
+            - script.execute: nav_refresh_status
+          else:
+            - lvgl.label.update:
+                id: lbl_nav_status
+                text: !lambda return std::string(id(entered_code).size(), '*');
+
   # Slow orange pulse — arming / pending / disarming
   - id: anim_arming
     mode: restart
@@ -168,32 +181,10 @@ lvgl:
             scrollable: false
             widgets:
 
-              # ── Code display bar ─────────────────────────────────
-              # Always visible below the navbar; shows asterisks while typing.
+              # ── Row 0: 1 2 3  y=65 ──────────────────────────────
               - obj:
-                  id: code_display
                   x: 10
                   y: 65
-                  width: 460
-                  height: 44
-                  bg_color: 0x16213e
-                  radius: 8
-                  border_width: 1
-                  border_color: 0x0f3460
-                  scrollbar_mode: "off"
-                  scrollable: false
-                  widgets:
-                    - label:
-                        id: lbl_code
-                        align: CENTER
-                        text: ""
-                        text_font: montserrat_28
-                        text_color: 0xe94560
-
-              # ── Row 0: 1 2 3  y=115 ─────────────────────────────
-              - obj:
-                  x: 10
-                  y: 115
                   width: 460
                   height: 64
                   bg_color: 0x1a1a2e
@@ -213,9 +204,7 @@ lvgl:
                         bg_color: 0x16213e
                         on_press:
                           - lambda: id(entered_code) += "1";
-                          - lvgl.label.update:
-                              id: lbl_code
-                              text: !lambda return std::string(id(entered_code).size(), '*');
+                          - script.execute: code_overlay_refresh
                         widgets:
                           - label: {text: "1", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
                     - button:
@@ -224,9 +213,7 @@ lvgl:
                         bg_color: 0x16213e
                         on_press:
                           - lambda: id(entered_code) += "2";
-                          - lvgl.label.update:
-                              id: lbl_code
-                              text: !lambda return std::string(id(entered_code).size(), '*');
+                          - script.execute: code_overlay_refresh
                         widgets:
                           - label: {text: "2", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
                     - button:
@@ -235,16 +222,14 @@ lvgl:
                         bg_color: 0x16213e
                         on_press:
                           - lambda: id(entered_code) += "3";
-                          - lvgl.label.update:
-                              id: lbl_code
-                              text: !lambda return std::string(id(entered_code).size(), '*');
+                          - script.execute: code_overlay_refresh
                         widgets:
                           - label: {text: "3", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
 
-              # ── Row 1: 4 5 6  y=185 ─────────────────────────────
+              # ── Row 1: 4 5 6  y=135 ─────────────────────────────
               - obj:
                   x: 10
-                  y: 185
+                  y: 135
                   width: 460
                   height: 64
                   bg_color: 0x1a1a2e
@@ -264,9 +249,7 @@ lvgl:
                         bg_color: 0x16213e
                         on_press:
                           - lambda: id(entered_code) += "4";
-                          - lvgl.label.update:
-                              id: lbl_code
-                              text: !lambda return std::string(id(entered_code).size(), '*');
+                          - script.execute: code_overlay_refresh
                         widgets:
                           - label: {text: "4", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
                     - button:
@@ -275,9 +258,7 @@ lvgl:
                         bg_color: 0x16213e
                         on_press:
                           - lambda: id(entered_code) += "5";
-                          - lvgl.label.update:
-                              id: lbl_code
-                              text: !lambda return std::string(id(entered_code).size(), '*');
+                          - script.execute: code_overlay_refresh
                         widgets:
                           - label: {text: "5", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
                     - button:
@@ -286,16 +267,14 @@ lvgl:
                         bg_color: 0x16213e
                         on_press:
                           - lambda: id(entered_code) += "6";
-                          - lvgl.label.update:
-                              id: lbl_code
-                              text: !lambda return std::string(id(entered_code).size(), '*');
+                          - script.execute: code_overlay_refresh
                         widgets:
                           - label: {text: "6", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
 
-              # ── Row 2: 7 8 9  y=255 ─────────────────────────────
+              # ── Row 2: 7 8 9  y=205 ─────────────────────────────
               - obj:
                   x: 10
-                  y: 255
+                  y: 205
                   width: 460
                   height: 64
                   bg_color: 0x1a1a2e
@@ -315,9 +294,7 @@ lvgl:
                         bg_color: 0x16213e
                         on_press:
                           - lambda: id(entered_code) += "7";
-                          - lvgl.label.update:
-                              id: lbl_code
-                              text: !lambda return std::string(id(entered_code).size(), '*');
+                          - script.execute: code_overlay_refresh
                         widgets:
                           - label: {text: "7", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
                     - button:
@@ -326,9 +303,7 @@ lvgl:
                         bg_color: 0x16213e
                         on_press:
                           - lambda: id(entered_code) += "8";
-                          - lvgl.label.update:
-                              id: lbl_code
-                              text: !lambda return std::string(id(entered_code).size(), '*');
+                          - script.execute: code_overlay_refresh
                         widgets:
                           - label: {text: "8", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
                     - button:
@@ -337,16 +312,14 @@ lvgl:
                         bg_color: 0x16213e
                         on_press:
                           - lambda: id(entered_code) += "9";
-                          - lvgl.label.update:
-                              id: lbl_code
-                              text: !lambda return std::string(id(entered_code).size(), '*');
+                          - script.execute: code_overlay_refresh
                         widgets:
                           - label: {text: "9", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
 
-              # ── Row 3: CLR 0 OK  y=325 ──────────────────────────
+              # ── Row 3: CLR 0 OK  y=275 ──────────────────────────
               - obj:
                   x: 10
-                  y: 325
+                  y: 275
                   width: 460
                   height: 64
                   bg_color: 0x1a1a2e
@@ -368,9 +341,7 @@ lvgl:
                           - lambda: |-
                               if (!id(entered_code).empty())
                                 id(entered_code).pop_back();
-                          - lvgl.label.update:
-                              id: lbl_code
-                              text: !lambda return std::string(id(entered_code).size(), '*');
+                          - script.execute: code_overlay_refresh
                           - if:
                               condition:
                                 lambda: return id(entered_code).empty();
@@ -387,9 +358,7 @@ lvgl:
                         bg_color: 0x16213e
                         on_press:
                           - lambda: id(entered_code) += "0";
-                          - lvgl.label.update:
-                              id: lbl_code
-                              text: !lambda return std::string(id(entered_code).size(), '*');
+                          - script.execute: code_overlay_refresh
                         widgets:
                           - label: {text: "0", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
                     - button:
@@ -434,9 +403,7 @@ lvgl:
                                       entity_id: ${alarm_entity_id}
                                       code: !lambda return id(entered_code);
                           - lambda: id(entered_code) = ""; id(pending_action) = 0;
-                          - lvgl.label.update:
-                              id: lbl_code
-                              text: ""
+                          - script.execute: code_overlay_refresh
                           - lvgl.label.update:
                               id: lbl_disarm_btn
                               text: "\U000F0FF2"
@@ -444,11 +411,11 @@ lvgl:
                         widgets:
                           - label: {text: "OK", align: CENTER, text_font: montserrat_22, text_color: 0xffffff}
 
-              # ── ARM buttons row  y=395 — shown when disarmed ─────
+              # ── ARM buttons row  y=345 — shown when disarmed ─────
               - obj:
                   id: arm_buttons_row
                   x: 10
-                  y: 395
+                  y: 345
                   width: 460
                   height: 64
                   bg_color: 0x1a1a2e
@@ -472,9 +439,8 @@ lvgl:
                               condition:
                                 lambda: return id(arm_requires_code);
                               then:
-                                - lvgl.label.update:
-                                    id: lbl_code
-                                    text: ""
+                                - lambda: id(entered_code) = "";
+                                - script.execute: code_overlay_refresh
                               else:
                                 - homeassistant.service:
                                     service: alarm_control_panel.alarm_arm_away
@@ -496,9 +462,8 @@ lvgl:
                               condition:
                                 lambda: return id(arm_requires_code);
                               then:
-                                - lvgl.label.update:
-                                    id: lbl_code
-                                    text: ""
+                                - lambda: id(entered_code) = "";
+                                - script.execute: code_overlay_refresh
                               else:
                                 - homeassistant.service:
                                     service: alarm_control_panel.alarm_arm_home
@@ -520,9 +485,8 @@ lvgl:
                               condition:
                                 lambda: return id(arm_requires_code);
                               then:
-                                - lvgl.label.update:
-                                    id: lbl_code
-                                    text: ""
+                                - lambda: id(entered_code) = "";
+                                - script.execute: code_overlay_refresh
                               else:
                                 - homeassistant.service:
                                     service: alarm_control_panel.alarm_arm_night
@@ -535,11 +499,11 @@ lvgl:
                               text_font: mdi_icons
                               text_color: 0xffffff
 
-              # ── DISARM button  y=395 — shown when armed/triggered ─
+              # ── DISARM button  y=345 — shown when armed/triggered ─
               - button:
                   id: disarm_btn
                   x: 10
-                  y: 395
+                  y: 345
                   width: 460
                   height: 64
                   bg_color: 0xe94560

--- a/packages/alarm-keypad-ui.yaml
+++ b/packages/alarm-keypad-ui.yaml
@@ -12,7 +12,8 @@
 #   y=395..458 — ARM / DISARM row
 #
 # Navbar contract (nav.yaml):
-#   Writes formatted alarm state to g_nav_alarm_status and calls nav_refresh_status.
+#   Writes formatted alarm state to any nav slot mapped to alarm_page, then calls
+#   nav_refresh_status.
 
 globals:
   - id: entered_code
@@ -63,7 +64,10 @@ text_sensor:
           else if (x == "pending")    txt = "PENDING...";
           else if (x == "triggered")  txt = "!! TRIGGERED !!";
           else txt = x;
-          id(g_nav_alarm_status) = txt;
+          if (strcmp("${nav_home_page}", "alarm_page") == 0) id(g_nav_status_0) = txt;
+          if (strcmp("${nav_page_1}", "alarm_page") == 0) id(g_nav_status_1) = txt;
+          if (strcmp("${nav_page_2}", "alarm_page") == 0) id(g_nav_status_2) = txt;
+          if (strcmp("${nav_page_3}", "alarm_page") == 0) id(g_nav_status_3) = txt;
       - script.execute: nav_refresh_status
       # Drive ARM/DISARM button visibility and animations
       - script.stop: anim_arming

--- a/packages/alarm-keypad-ui.yaml
+++ b/packages/alarm-keypad-ui.yaml
@@ -1,10 +1,19 @@
 # Alarm keypad UI — LVGL interface wired to Home Assistant alarm_control_panel
 # This package provides an LVGL page with the alarm keypad.
 # It is board-independent — include it alongside a board package.
-# To add more UI panels (e.g. thermostat), add another package that
-# contributes its own lvgl page; the main YAML wires them together.
+#
+# Layout (480×480 display, nav_bar_height=60):
+#   y=  0..59  — navbar (top_layer, handled by nav.yaml)
+#   y= 65..108 — code-entry display bar (always visible; empty when idle)
+#   y=115..178 — keypad row 0  (1 2 3)
+#   y=185..248 — keypad row 1  (4 5 6)
+#   y=255..318 — keypad row 2  (7 8 9)
+#   y=325..388 — keypad row 3  (CLR 0 OK)
+#   y=395..458 — ARM / DISARM row
+#
+# Navbar contract (nav.yaml):
+#   Writes formatted alarm state to g_nav_alarm_status and calls nav_refresh_status.
 
-# Entered PIN — cleared after each arm/disarm attempt
 globals:
   - id: entered_code
     type: std::string
@@ -14,7 +23,6 @@ globals:
     type: bool
     restore_value: no
     initial_value: 'true'
-  # false = code_arm_required: false in Home Assistant alarm config
   - id: arm_requires_code
     type: bool
     restore_value: no
@@ -25,7 +33,6 @@ globals:
     restore_value: no
     initial_value: '0'
 
-# Subscribe to alarm state and code requirements from Home Assistant
 text_sensor:
   - platform: homeassistant
     id: alarm_code_arm_required
@@ -33,27 +40,32 @@ text_sensor:
     attribute: code_arm_required
     on_value:
       - lambda: id(arm_requires_code) = (x == "true");
+
   - platform: homeassistant
     id: alarm_code_disarm_required
     entity_id: ${alarm_entity_id}
     attribute: code_disarm_required
     on_value:
       - lambda: id(disarm_requires_code) = (x == "true");
+
   - platform: homeassistant
     id: alarm_state
     entity_id: ${alarm_entity_id}
     on_value:
-      - lvgl.label.update:
-          id: lbl_status
-          text: !lambda |-
-            if (x == "disarmed")    return "DISARMED";
-            if (x == "armed_away")  return "ARMED AWAY";
-            if (x == "armed_home")  return "ARMED HOME";
-            if (x == "arming")      return "ARMING...";
-            if (x == "disarming")   return "DISARMING...";
-            if (x == "pending")     return "PENDING...";
-            if (x == "triggered")   return "!! TRIGGERED !!";
-            return x.c_str();
+      # Feed navbar status label
+      - lambda: |-
+          std::string txt;
+          if      (x == "disarmed")   txt = "DISARMED";
+          else if (x == "armed_away") txt = "ARMED AWAY";
+          else if (x == "armed_home") txt = "ARMED HOME";
+          else if (x == "arming")     txt = "ARMING...";
+          else if (x == "disarming")  txt = "DISARMING...";
+          else if (x == "pending")    txt = "PENDING...";
+          else if (x == "triggered")  txt = "!! TRIGGERED !!";
+          else txt = x;
+          id(g_nav_alarm_status) = txt;
+      - script.execute: nav_refresh_status
+      # Drive ARM/DISARM button visibility and animations
       - script.stop: anim_arming
       - script.stop: anim_triggered
       - if:
@@ -111,6 +123,7 @@ script:
                 id: disarm_btn
                 bg_color: 0x3a2000
             - delay: 700ms
+
   # Fast red strobe — triggered
   - id: anim_triggered
     mode: restart
@@ -151,52 +164,34 @@ lvgl:
             scrollable: false
             widgets:
 
-              # Status area — PIN overlay appears here when entering digits
-              # y=5  h=48  bottom=53
+              # ── Code display bar ─────────────────────────────────
+              # Always visible below the navbar; shows asterisks while typing.
               - obj:
+                  id: code_display
                   x: 10
-                  y: 5
+                  y: 65
                   width: 460
-                  height: 48
-                  bg_color: 0x1a1a2e
-                  border_width: 0
-                  pad_all: 0
+                  height: 44
+                  bg_color: 0x16213e
+                  radius: 8
+                  border_width: 1
+                  border_color: 0x0f3460
                   scrollbar_mode: "off"
                   scrollable: false
                   widgets:
                     - label:
-                        id: lbl_status
+                        id: lbl_code
                         align: CENTER
-                        text_align: CENTER
-                        text: "Connecting..."
+                        text: ""
                         text_font: montserrat_28
-                        text_color: 0xffffff
-                    - obj:
-                        id: code_display
-                        align: CENTER
-                        width: 460
-                        height: 48
-                        bg_color: 0x16213e
-                        radius: 8
-                        border_width: 1
-                        border_color: 0x0f3460
-                        scrollbar_mode: "off"
-                        scrollable: false
-                        hidden: true
-                        widgets:
-                          - label:
-                              id: lbl_code
-                              align: CENTER
-                              text: ""
-                              text_font: montserrat_28
-                              text_color: 0xe94560
+                        text_color: 0xe94560
 
-              # Row 1: 1 2 3  — y=56  h=78  bottom=134
+              # ── Row 0: 1 2 3  y=115 ─────────────────────────────
               - obj:
                   x: 10
-                  y: 56
+                  y: 115
                   width: 460
-                  height: 78
+                  height: 64
                   bg_color: 0x1a1a2e
                   border_width: 0
                   pad_all: 0
@@ -210,62 +205,44 @@ lvgl:
                   widgets:
                     - button:
                         width: 148
-                        height: 78
+                        height: 64
                         bg_color: 0x16213e
                         on_press:
-                          - lvgl.widget.show:
-                              id: code_display
                           - lambda: id(entered_code) += "1";
                           - lvgl.label.update:
                               id: lbl_code
                               text: !lambda return std::string(id(entered_code).size(), '*');
                         widgets:
-                          - label:
-                              text: "1"
-                              align: CENTER
-                              text_font: montserrat_28
-                              text_color: 0xffffff
+                          - label: {text: "1", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
                     - button:
                         width: 148
-                        height: 78
+                        height: 64
                         bg_color: 0x16213e
                         on_press:
-                          - lvgl.widget.show:
-                              id: code_display
                           - lambda: id(entered_code) += "2";
                           - lvgl.label.update:
                               id: lbl_code
                               text: !lambda return std::string(id(entered_code).size(), '*');
                         widgets:
-                          - label:
-                              text: "2"
-                              align: CENTER
-                              text_font: montserrat_28
-                              text_color: 0xffffff
+                          - label: {text: "2", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
                     - button:
                         width: 148
-                        height: 78
+                        height: 64
                         bg_color: 0x16213e
                         on_press:
-                          - lvgl.widget.show:
-                              id: code_display
                           - lambda: id(entered_code) += "3";
                           - lvgl.label.update:
                               id: lbl_code
                               text: !lambda return std::string(id(entered_code).size(), '*');
                         widgets:
-                          - label:
-                              text: "3"
-                              align: CENTER
-                              text_font: montserrat_28
-                              text_color: 0xffffff
+                          - label: {text: "3", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
 
-              # Row 2: 4 5 6  — y=137  h=78  bottom=215
+              # ── Row 1: 4 5 6  y=185 ─────────────────────────────
               - obj:
                   x: 10
-                  y: 137
+                  y: 185
                   width: 460
-                  height: 78
+                  height: 64
                   bg_color: 0x1a1a2e
                   border_width: 0
                   pad_all: 0
@@ -279,62 +256,44 @@ lvgl:
                   widgets:
                     - button:
                         width: 148
-                        height: 78
+                        height: 64
                         bg_color: 0x16213e
                         on_press:
-                          - lvgl.widget.show:
-                              id: code_display
                           - lambda: id(entered_code) += "4";
                           - lvgl.label.update:
                               id: lbl_code
                               text: !lambda return std::string(id(entered_code).size(), '*');
                         widgets:
-                          - label:
-                              text: "4"
-                              align: CENTER
-                              text_font: montserrat_28
-                              text_color: 0xffffff
+                          - label: {text: "4", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
                     - button:
                         width: 148
-                        height: 78
+                        height: 64
                         bg_color: 0x16213e
                         on_press:
-                          - lvgl.widget.show:
-                              id: code_display
                           - lambda: id(entered_code) += "5";
                           - lvgl.label.update:
                               id: lbl_code
                               text: !lambda return std::string(id(entered_code).size(), '*');
                         widgets:
-                          - label:
-                              text: "5"
-                              align: CENTER
-                              text_font: montserrat_28
-                              text_color: 0xffffff
+                          - label: {text: "5", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
                     - button:
                         width: 148
-                        height: 78
+                        height: 64
                         bg_color: 0x16213e
                         on_press:
-                          - lvgl.widget.show:
-                              id: code_display
                           - lambda: id(entered_code) += "6";
                           - lvgl.label.update:
                               id: lbl_code
                               text: !lambda return std::string(id(entered_code).size(), '*');
                         widgets:
-                          - label:
-                              text: "6"
-                              align: CENTER
-                              text_font: montserrat_28
-                              text_color: 0xffffff
+                          - label: {text: "6", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
 
-              # Row 3: 7 8 9  — y=218  h=78  bottom=296
+              # ── Row 2: 7 8 9  y=255 ─────────────────────────────
               - obj:
                   x: 10
-                  y: 218
+                  y: 255
                   width: 460
-                  height: 78
+                  height: 64
                   bg_color: 0x1a1a2e
                   border_width: 0
                   pad_all: 0
@@ -348,62 +307,44 @@ lvgl:
                   widgets:
                     - button:
                         width: 148
-                        height: 78
+                        height: 64
                         bg_color: 0x16213e
                         on_press:
-                          - lvgl.widget.show:
-                              id: code_display
                           - lambda: id(entered_code) += "7";
                           - lvgl.label.update:
                               id: lbl_code
                               text: !lambda return std::string(id(entered_code).size(), '*');
                         widgets:
-                          - label:
-                              text: "7"
-                              align: CENTER
-                              text_font: montserrat_28
-                              text_color: 0xffffff
+                          - label: {text: "7", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
                     - button:
                         width: 148
-                        height: 78
+                        height: 64
                         bg_color: 0x16213e
                         on_press:
-                          - lvgl.widget.show:
-                              id: code_display
                           - lambda: id(entered_code) += "8";
                           - lvgl.label.update:
                               id: lbl_code
                               text: !lambda return std::string(id(entered_code).size(), '*');
                         widgets:
-                          - label:
-                              text: "8"
-                              align: CENTER
-                              text_font: montserrat_28
-                              text_color: 0xffffff
+                          - label: {text: "8", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
                     - button:
                         width: 148
-                        height: 78
+                        height: 64
                         bg_color: 0x16213e
                         on_press:
-                          - lvgl.widget.show:
-                              id: code_display
                           - lambda: id(entered_code) += "9";
                           - lvgl.label.update:
                               id: lbl_code
                               text: !lambda return std::string(id(entered_code).size(), '*');
                         widgets:
-                          - label:
-                              text: "9"
-                              align: CENTER
-                              text_font: montserrat_28
-                              text_color: 0xffffff
+                          - label: {text: "9", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
 
-              # Row 4: CLR 0 OK  — y=299  h=78  bottom=377
+              # ── Row 3: CLR 0 OK  y=325 ──────────────────────────
               - obj:
                   x: 10
-                  y: 299
+                  y: 325
                   width: 460
-                  height: 78
+                  height: 64
                   bg_color: 0x1a1a2e
                   border_width: 0
                   pad_all: 0
@@ -417,7 +358,7 @@ lvgl:
                   widgets:
                     - button:
                         width: 148
-                        height: 78
+                        height: 64
                         bg_color: 0x0f3460
                         on_press:
                           - lambda: |-
@@ -430,38 +371,26 @@ lvgl:
                               condition:
                                 lambda: return id(entered_code).empty();
                               then:
-                                - lvgl.widget.hide:
-                                    id: code_display
                                 - lvgl.label.update:
                                     id: lbl_disarm_btn
                                     text: "\U000F0FF2"
                                     text_font: mdi_icons
                         widgets:
-                          - label:
-                              text: "CLR"
-                              align: CENTER
-                              text_font: montserrat_22
-                              text_color: 0xffffff
+                          - label: {text: "CLR", align: CENTER, text_font: montserrat_22, text_color: 0xffffff}
                     - button:
                         width: 148
-                        height: 78
+                        height: 64
                         bg_color: 0x16213e
                         on_press:
-                          - lvgl.widget.show:
-                              id: code_display
                           - lambda: id(entered_code) += "0";
                           - lvgl.label.update:
                               id: lbl_code
                               text: !lambda return std::string(id(entered_code).size(), '*');
                         widgets:
-                          - label:
-                              text: "0"
-                              align: CENTER
-                              text_font: montserrat_28
-                              text_color: 0xffffff
+                          - label: {text: "0", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
                     - button:
                         width: 148
-                        height: 78
+                        height: 64
                         bg_color: 0x0f3460
                         on_press:
                           - if:
@@ -504,26 +433,20 @@ lvgl:
                           - lvgl.label.update:
                               id: lbl_code
                               text: ""
-                          - lvgl.widget.hide:
-                              id: code_display
                           - lvgl.label.update:
                               id: lbl_disarm_btn
                               text: "\U000F0FF2"
                               text_font: mdi_icons
                         widgets:
-                          - label:
-                              text: "OK"
-                              align: CENTER
-                              text_font: montserrat_22
-                              text_color: 0xffffff
+                          - label: {text: "OK", align: CENTER, text_font: montserrat_22, text_color: 0xffffff}
 
-              # ARM buttons — y=382  h=78  bottom=460
+              # ── ARM buttons row  y=395 — shown when disarmed ─────
               - obj:
                   id: arm_buttons_row
                   x: 10
-                  y: 382
+                  y: 395
                   width: 460
-                  height: 78
+                  height: 64
                   bg_color: 0x1a1a2e
                   border_width: 0
                   pad_all: 0
@@ -537,7 +460,7 @@ lvgl:
                   widgets:
                     - button:
                         width: 148
-                        height: 78
+                        height: 64
                         bg_color: 0x0f3460
                         on_press:
                           - lambda: id(pending_action) = 1;
@@ -545,8 +468,9 @@ lvgl:
                               condition:
                                 lambda: return id(arm_requires_code);
                               then:
-                                - lvgl.widget.show:
-                                    id: code_display
+                                - lvgl.label.update:
+                                    id: lbl_code
+                                    text: ""
                               else:
                                 - homeassistant.service:
                                     service: alarm_control_panel.alarm_arm_away
@@ -560,7 +484,7 @@ lvgl:
                               text_color: 0xffffff
                     - button:
                         width: 148
-                        height: 78
+                        height: 64
                         bg_color: 0x0f3460
                         on_press:
                           - lambda: id(pending_action) = 2;
@@ -568,8 +492,9 @@ lvgl:
                               condition:
                                 lambda: return id(arm_requires_code);
                               then:
-                                - lvgl.widget.show:
-                                    id: code_display
+                                - lvgl.label.update:
+                                    id: lbl_code
+                                    text: ""
                               else:
                                 - homeassistant.service:
                                     service: alarm_control_panel.alarm_arm_home
@@ -583,7 +508,7 @@ lvgl:
                               text_color: 0xffffff
                     - button:
                         width: 148
-                        height: 78
+                        height: 64
                         bg_color: 0x0f3460
                         on_press:
                           - lambda: id(pending_action) = 3;
@@ -591,8 +516,9 @@ lvgl:
                               condition:
                                 lambda: return id(arm_requires_code);
                               then:
-                                - lvgl.widget.show:
-                                    id: code_display
+                                - lvgl.label.update:
+                                    id: lbl_code
+                                    text: ""
                               else:
                                 - homeassistant.service:
                                     service: alarm_control_panel.alarm_arm_night
@@ -605,13 +531,13 @@ lvgl:
                               text_font: mdi_icons
                               text_color: 0xffffff
 
-              # DISARM button — shown when armed, hidden when disarmed
+              # ── DISARM button  y=395 — shown when armed/triggered ─
               - button:
                   id: disarm_btn
                   x: 10
-                  y: 382
+                  y: 395
                   width: 460
-                  height: 78
+                  height: 64
                   bg_color: 0xe94560
                   hidden: true
                   on_press:
@@ -620,8 +546,6 @@ lvgl:
                         condition:
                           lambda: return id(disarm_requires_code);
                         then:
-                          - lvgl.widget.show:
-                              id: code_display
                           - lvgl.label.update:
                               id: lbl_disarm_btn
                               text: "PIN"

--- a/packages/nav.yaml
+++ b/packages/nav.yaml
@@ -1,6 +1,8 @@
 # nav.yaml — Navigation orchestrator
 #
 # Responsibilities:
+#   - Persistent top navbar with left/right arrows and a status label.
+#     The status label shows alarm state (alarm page) or preset·temp (tstat page).
 #   - Full-screen "Connecting..." overlay shown on boot and when HA disconnects.
 #     Panels never see or handle this state.
 #   - Swipe left/right cycles the registered panel pages by index.
@@ -19,6 +21,11 @@
 # Contract with board.yaml:
 #   board.yaml populates globals nav_swipe_start_x / nav_last_touch_x / nav_swipe_dx
 #   and calls scripts nav_touch / nav_release on every touch event.
+#
+# Contract with UI packages (alarm-keypad-ui, thermostat-ui):
+#   Each panel writes its formatted status string to g_nav_alarm_status or
+#   g_nav_tstat_status, then calls nav_refresh_status.  nav.yaml renders
+#   whichever string matches the active nav_idx.
 
 substitutions:
   nav_home_page: alarm_page
@@ -27,6 +34,7 @@ substitutions:
   nav_page_3: alarm_page
   nav_page_count: "1"
   nav_auto_return_delay: 30s
+  nav_bar_height: "60"        # pixels — page content must start below this value
 
 globals:
   - id: nav_connected
@@ -37,22 +45,33 @@ globals:
     type: int
     restore_value: no
     initial_value: '0'
+  # Status strings written by UI packages; nav_refresh_status picks the right one.
+  - id: g_nav_alarm_status
+    type: std::string
+    restore_value: no
+    initial_value: '""'
+  - id: g_nav_tstat_status
+    type: std::string
+    restore_value: no
+    initial_value: '""'
 
-# Show connecting page on boot; switch to home when HA API connects
+# Show connecting overlay on boot; switch to home page when HA API connects.
 binary_sensor:
   - platform: status
     id: nav_api_status
     on_press:
       - lambda: id(nav_connected) = true; id(nav_idx) = 0;
-      - script.stop: connecting_anim
       - lvgl.widget.hide:
           id: connecting_overlay
-      - lvgl.page.show: ${nav_home_page}
+      - lvgl.widget.show:
+          id: navbar
+      - script.execute: nav_show_page
     on_release:
       - lambda: id(nav_connected) = false; id(nav_idx) = 0;
+      - lvgl.widget.hide:
+          id: navbar
       - lvgl.widget.show:
           id: connecting_overlay
-      - script.execute: connecting_anim
 
 esphome:
   on_boot:
@@ -60,16 +79,15 @@ esphome:
     then:
       - lvgl.widget.show:
           id: connecting_overlay
-      - script.execute: connecting_anim
 
 script:
-  # Called by board.yaml on every touch — resets idle timer
+  # Called by board.yaml on every touch — resets idle timer.
   - id: nav_touch
     mode: restart
     then:
       - script.execute: auto_return
 
-  # Called by board.yaml on touch release — detects swipe direction
+  # Called by board.yaml on touch release — detects swipe direction.
   - id: nav_release
     then:
       - lambda: |-
@@ -81,38 +99,43 @@ script:
             lambda: return id(nav_connected) && id(nav_swipe_dx) < -80;
           then:
             - lambda: id(nav_idx) = (id(nav_idx) + 1) % ${nav_page_count};
-            - if:
-                condition: {lambda: return id(nav_idx) == 0;}
-                then: [{lvgl.page.show: "${nav_home_page}"}]
-            - if:
-                condition: {lambda: return id(nav_idx) == 1;}
-                then: [{lvgl.page.show: "${nav_page_1}"}]
-            - if:
-                condition: {lambda: return id(nav_idx) == 2;}
-                then: [{lvgl.page.show: "${nav_page_2}"}]
-            - if:
-                condition: {lambda: return id(nav_idx) == 3;}
-                then: [{lvgl.page.show: "${nav_page_3}"}]
+            - script.execute: nav_show_page
       # Swipe right → previous panel
       - if:
           condition:
             lambda: return id(nav_connected) && id(nav_swipe_dx) > 80;
           then:
             - lambda: id(nav_idx) = (id(nav_idx) + ${nav_page_count} - 1) % ${nav_page_count};
-            - if:
-                condition: {lambda: return id(nav_idx) == 0;}
-                then: [{lvgl.page.show: "${nav_home_page}"}]
-            - if:
-                condition: {lambda: return id(nav_idx) == 1;}
-                then: [{lvgl.page.show: "${nav_page_1}"}]
-            - if:
-                condition: {lambda: return id(nav_idx) == 2;}
-                then: [{lvgl.page.show: "${nav_page_2}"}]
-            - if:
-                condition: {lambda: return id(nav_idx) == 3;}
-                then: [{lvgl.page.show: "${nav_page_3}"}]
+            - script.execute: nav_show_page
 
-  # Auto-return: only fires when connected; goes home and resets index
+  # Show the page that matches nav_idx, then refresh the status label.
+  - id: nav_show_page
+    then:
+      - if:
+          condition: {lambda: return id(nav_idx) == 0;}
+          then: [{lvgl.page.show: "${nav_home_page}"}]
+      - if:
+          condition: {lambda: return id(nav_idx) == 1;}
+          then: [{lvgl.page.show: "${nav_page_1}"}]
+      - if:
+          condition: {lambda: return id(nav_idx) == 2;}
+          then: [{lvgl.page.show: "${nav_page_2}"}]
+      - if:
+          condition: {lambda: return id(nav_idx) == 3;}
+          then: [{lvgl.page.show: "${nav_page_3}"}]
+      - script.execute: nav_refresh_status
+
+  # Update the navbar status label from the active panel's status string.
+  # UI packages call this after updating g_nav_alarm_status / g_nav_tstat_status.
+  - id: nav_refresh_status
+    then:
+      - lambda: |-
+          if (id(nav_idx) == 0)
+            lv_label_set_text(id(lbl_nav_status), id(g_nav_alarm_status).c_str());
+          else
+            lv_label_set_text(id(lbl_nav_status), id(g_nav_tstat_status).c_str());
+
+  # Auto-return: only fires when connected; resets to home page.
   - id: auto_return
     mode: restart
     then:
@@ -122,28 +145,91 @@ script:
             lambda: return id(nav_connected);
           then:
             - lambda: id(nav_idx) = 0;
-            - lvgl.page.show: ${nav_home_page}
+            - script.execute: nav_show_page
 
-  # Three-dot animation while connecting
-  - id: connecting_anim
-    mode: restart
-    then:
-      - while:
-          condition:
-            lambda: return true;
-          then:
-            - lvgl.label.update: {id: lbl_connecting_dots, text: "●  ○  ○"}
-            - delay: 400ms
-            - lvgl.label.update: {id: lbl_connecting_dots, text: "○  ●  ○"}
-            - delay: 400ms
-            - lvgl.label.update: {id: lbl_connecting_dots, text: "○  ○  ●"}
-            - delay: 400ms
-
-# Connecting overlay — full-screen, shown above whatever page is active.
-# Hidden once HA API connects; reshown on disconnect.
+# top_layer — always rendered above pages.
+# Declaration order: navbar first (lower z), connecting_overlay second (higher z).
+# When the overlay is shown it covers the navbar completely.
 lvgl:
   top_layer:
     widgets:
+
+      # ── Navbar ─────────────────────────────────────────────────────
+      # Hidden until HA connects (connecting_overlay covers anyway, but hidden
+      # prevents it briefly flashing on first boot before the overlay renders).
+      - obj:
+          id: navbar
+          x: 0
+          y: 0
+          width: ${display_width}
+          height: ${nav_bar_height}
+          bg_color: 0x16213e
+          bg_opa: COVER
+          radius: 0
+          border_width: 0
+          border_side: BOTTOM
+          border_color: 0x0f3460
+          pad_all: 0
+          hidden: true
+          widgets:
+
+            # Left arrow — go to previous page
+            - button:
+                id: btn_nav_left
+                x: 0
+                y: 0
+                width: ${nav_bar_height}
+                height: ${nav_bar_height}
+                bg_color: 0x16213e
+                bg_opa: COVER
+                radius: 0
+                border_width: 0
+                widgets:
+                  - label:
+                      align: CENTER
+                      text: "<"
+                      text_font: montserrat_28
+                      text_color: 0x4060a0
+                on_press:
+                  - lambda: id(nav_idx) = (id(nav_idx) + ${nav_page_count} - 1) % ${nav_page_count};
+                  - script.execute: nav_show_page
+
+            # Status label — filled by nav_refresh_status
+            - label:
+                id: lbl_nav_status
+                x: ${nav_bar_height}
+                y: 0
+                width: 360   # display_width(480) − 2 × nav_bar_height(60)
+                height: ${nav_bar_height}
+                text: ""
+                text_align: CENTER
+                text_color: 0xffffff
+                text_font: montserrat_20
+                long_mode: SCROLL_CIRCULAR
+
+            # Right arrow — go to next page
+            - button:
+                id: btn_nav_right
+                x: 420      # display_width(480) − nav_bar_height(60)
+                y: 0
+                width: ${nav_bar_height}
+                height: ${nav_bar_height}
+                bg_color: 0x16213e
+                bg_opa: COVER
+                radius: 0
+                border_width: 0
+                widgets:
+                  - label:
+                      align: CENTER
+                      text: ">"
+                      text_font: montserrat_28
+                      text_color: 0x4060a0
+                on_press:
+                  - lambda: id(nav_idx) = (id(nav_idx) + 1) % ${nav_page_count};
+                  - script.execute: nav_show_page
+
+      # ── Connecting overlay ─────────────────────────────────────────
+      # Full-screen, covers navbar. Static text only — no animation.
       - obj:
           id: connecting_overlay
           x: 0
@@ -160,20 +246,13 @@ lvgl:
           widgets:
             - label:
                 align: CENTER
-                y: -30
+                y: -20
                 text: "Connecting"
                 text_font: montserrat_28
                 text_color: 0xffffff
             - label:
-                id: lbl_connecting_dots
                 align: CENTER
-                y: 10
-                text: "●  ○  ○"
-                text_font: montserrat_28
-                text_color: 0xe94560
-            - label:
-                align: CENTER
-                y: 55
+                y: 20
                 text: "to Home Assistant"
                 text_font: montserrat_14
                 text_color: 0x555555

--- a/packages/nav.yaml
+++ b/packages/nav.yaml
@@ -185,13 +185,16 @@ lvgl:
           border_color: 0x0f3460
           pad_all: 0
           hidden: true
+          layout:
+            type: FLEX
+            flex_flow: ROW
+            flex_align_main: START
+            flex_align_cross: CENTER
           widgets:
 
             # Left arrow — go to previous page
             - button:
                 id: btn_nav_left
-                x: 0
-                y: 0
                 width: ${nav_bar_height}
                 height: ${nav_bar_height}
                 bg_color: 0x16213e
@@ -211,9 +214,7 @@ lvgl:
             # Status label — filled by nav_refresh_status
             - label:
                 id: lbl_nav_status
-                x: ${nav_bar_height}
-                y: 0
-                width: 360   # display_width(480) − 2 × nav_bar_height(60)
+                flex_grow: 1
                 height: ${nav_bar_height}
                 text: ""
                 text_align: CENTER
@@ -224,8 +225,6 @@ lvgl:
             # Right arrow — go to next page
             - button:
                 id: btn_nav_right
-                x: 420      # display_width(480) − nav_bar_height(60)
-                y: 0
                 width: ${nav_bar_height}
                 height: ${nav_bar_height}
                 bg_color: 0x16213e

--- a/packages/nav.yaml
+++ b/packages/nav.yaml
@@ -147,6 +147,28 @@ script:
             - lambda: id(nav_idx) = 0;
             - script.execute: nav_show_page
 
+font:
+  - file: "https://fonts.google.com/download?family=Montserrat"
+    id: montserrat_14
+    size: 14
+    glyphs: "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+  - file: "https://fonts.google.com/download?family=Montserrat"
+    id: montserrat_20
+    size: 20
+    glyphs: "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+  - file: "https://fonts.google.com/download?family=Montserrat"
+    id: montserrat_22
+    size: 22
+    glyphs: "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+  - file: "https://fonts.google.com/download?family=Montserrat"
+    id: montserrat_28
+    size: 28
+    glyphs: "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+  - file: "https://fonts.google.com/download?family=Montserrat"
+    id: montserrat_48
+    size: 48
+    glyphs: "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+
 # top_layer — always rendered above pages.
 # Declaration order: navbar first (lower z), connecting_overlay second (higher z).
 # When the overlay is shown it covers the navbar completely.

--- a/packages/nav.yaml
+++ b/packages/nav.yaml
@@ -23,9 +23,9 @@
 #   and calls scripts nav_touch / nav_release on every touch event.
 #
 # Contract with UI packages (alarm-keypad-ui, thermostat-ui):
-#   Each panel writes its formatted status string to g_nav_alarm_status or
-#   g_nav_tstat_status, then calls nav_refresh_status.  nav.yaml renders
-#   whichever string matches the active nav_idx.
+#   Each panel writes its formatted status string to the nav slot(s) that map to
+#   that page (g_nav_status_0..g_nav_status_3), then calls nav_refresh_status.
+#   nav.yaml renders whichever slot matches the active nav_idx.
 
 substitutions:
   nav_home_page: alarm_page
@@ -45,12 +45,20 @@ globals:
     type: int
     restore_value: no
     initial_value: '0'
-  # Status strings written by UI packages; nav_refresh_status picks the right one.
-  - id: g_nav_alarm_status
+  # Per-slot status strings written by UI packages; nav_refresh_status picks by nav_idx.
+  - id: g_nav_status_0
     type: std::string
     restore_value: no
     initial_value: '""'
-  - id: g_nav_tstat_status
+  - id: g_nav_status_1
+    type: std::string
+    restore_value: no
+    initial_value: '""'
+  - id: g_nav_status_2
+    type: std::string
+    restore_value: no
+    initial_value: '""'
+  - id: g_nav_status_3
     type: std::string
     restore_value: no
     initial_value: '""'
@@ -126,14 +134,20 @@ script:
       - script.execute: nav_refresh_status
 
   # Update the navbar status label from the active panel's status string.
-  # UI packages call this after updating g_nav_alarm_status / g_nav_tstat_status.
+  # UI packages call this after updating the per-slot status globals.
   - id: nav_refresh_status
     then:
       - lambda: |-
           if (id(nav_idx) == 0)
-            lv_label_set_text(id(lbl_nav_status), id(g_nav_alarm_status).c_str());
+            lv_label_set_text(id(lbl_nav_status), id(g_nav_status_0).c_str());
+          else if (id(nav_idx) == 1)
+            lv_label_set_text(id(lbl_nav_status), id(g_nav_status_1).c_str());
+          else if (id(nav_idx) == 2)
+            lv_label_set_text(id(lbl_nav_status), id(g_nav_status_2).c_str());
+          else if (id(nav_idx) == 3)
+            lv_label_set_text(id(lbl_nav_status), id(g_nav_status_3).c_str());
           else
-            lv_label_set_text(id(lbl_nav_status), id(g_nav_tstat_status).c_str());
+            lv_label_set_text(id(lbl_nav_status), "");
 
   # Auto-return: only fires when connected; resets to home page.
   - id: auto_return
@@ -146,28 +160,6 @@ script:
           then:
             - lambda: id(nav_idx) = 0;
             - script.execute: nav_show_page
-
-font:
-  - file: "https://fonts.google.com/download?family=Montserrat"
-    id: montserrat_14
-    size: 14
-    glyphs: "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
-  - file: "https://fonts.google.com/download?family=Montserrat"
-    id: montserrat_20
-    size: 20
-    glyphs: "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
-  - file: "https://fonts.google.com/download?family=Montserrat"
-    id: montserrat_22
-    size: 22
-    glyphs: "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
-  - file: "https://fonts.google.com/download?family=Montserrat"
-    id: montserrat_28
-    size: 28
-    glyphs: "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
-  - file: "https://fonts.google.com/download?family=Montserrat"
-    id: montserrat_48
-    size: 48
-    glyphs: "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
 
 # top_layer — always rendered above pages.
 # Declaration order: navbar first (lower z), connecting_overlay second (higher z).

--- a/packages/thermostat-ui.yaml
+++ b/packages/thermostat-ui.yaml
@@ -33,12 +33,12 @@ sensor:
       - lvgl.label.update:
           id: lbl_current_temp
           text: !lambda return str_sprintf("%.1f°", x);
-      # Update navbar status: "Preset · XX.X°"
+      # Update navbar status using ASCII-only text for guaranteed rendering.
       - lambda: |-
           std::string preset = id(clim_preset_mode).state;
           if (preset.empty()) preset = "--";
           char buf[64];
-          snprintf(buf, sizeof(buf), "%s · %.1f°", preset.c_str(), x);
+          snprintf(buf, sizeof(buf), "%s - %.1f C", preset.c_str(), x);
           if (strcmp("${nav_home_page}", "thermostat_page") == 0) id(g_nav_status_0) = buf;
           if (strcmp("${nav_page_1}", "thermostat_page") == 0) id(g_nav_status_1) = buf;
           if (strcmp("${nav_page_2}", "thermostat_page") == 0) id(g_nav_status_2) = buf;
@@ -114,10 +114,10 @@ text_sensor:
           condition: {lambda: return x == "comfort";}
           then: [{lvgl.button.update: {id: btn_preset_comfort, bg_color: 0x0f3460}}]
           else: [{lvgl.button.update: {id: btn_preset_comfort, bg_color: 0x16213e}}]
-      # Update navbar status: "Preset · XX.X°"
+      # Update navbar status using ASCII-only text for guaranteed rendering.
       - lambda: |-
           char buf[64];
-          snprintf(buf, sizeof(buf), "%s · %.1f°", x.c_str(), id(clim_current_temp).state);
+          snprintf(buf, sizeof(buf), "%s - %.1f C", x.c_str(), id(clim_current_temp).state);
           if (strcmp("${nav_home_page}", "thermostat_page") == 0) id(g_nav_status_0) = buf;
           if (strcmp("${nav_page_1}", "thermostat_page") == 0) id(g_nav_status_1) = buf;
           if (strcmp("${nav_page_2}", "thermostat_page") == 0) id(g_nav_status_2) = buf;

--- a/packages/thermostat-ui.yaml
+++ b/packages/thermostat-ui.yaml
@@ -1,6 +1,21 @@
 # Thermostat UI — LVGL interface wired to Home Assistant climate entity
 # Board-independent; include alongside board.yaml and alarm-keypad-ui.yaml.
-# Swipe right from this page returns to alarm_page.
+#
+# Layout (480×480 display, nav_bar_height=60):
+#   y=  0..59  — navbar (top_layer, handled by nav.yaml)
+#   y= 65..120 — current temperature (large)
+#   y=122..139 — "CURRENT" sub-label
+#   y=145..214 — setpoint row  [−]  XX.X°  [+]
+#   y=220..237 — "MODE" label
+#   y=241..288 — HVAC mode row 1  (OFF HEAT COOL)
+#   y=294..341 — HVAC mode row 2  (AUTO FAN DRY)
+#   y=348..365 — "PRESET" label
+#   y=369..415 — preset row 1  (HOME AWAY SLEEP)
+#   y=421..467 — preset row 2  (ECO BOOST COMF)
+#
+# Navbar contract (nav.yaml):
+#   Writes "Preset · XX.X°" to g_nav_tstat_status and calls nav_refresh_status
+#   whenever either current temperature or preset mode changes.
 
 globals:
   - id: target_temp
@@ -17,6 +32,14 @@ sensor:
       - lvgl.label.update:
           id: lbl_current_temp
           text: !lambda return str_sprintf("%.1f°", x);
+      # Update navbar status: "Preset · XX.X°"
+      - lambda: |-
+          std::string preset = id(clim_preset_mode).state;
+          if (preset.empty()) preset = "--";
+          char buf[64];
+          snprintf(buf, sizeof(buf), "%s · %.1f°", preset.c_str(), x);
+          id(g_nav_tstat_status) = buf;
+      - script.execute: nav_refresh_status
 
   - platform: homeassistant
     id: clim_target_temp_sensor
@@ -87,6 +110,12 @@ text_sensor:
           condition: {lambda: return x == "comfort";}
           then: [{lvgl.button.update: {id: btn_preset_comfort, bg_color: 0x0f3460}}]
           else: [{lvgl.button.update: {id: btn_preset_comfort, bg_color: 0x16213e}}]
+      # Update navbar status: "Preset · XX.X°"
+      - lambda: |-
+          char buf[64];
+          snprintf(buf, sizeof(buf), "%s · %.1f°", x.c_str(), id(clim_current_temp).state);
+          id(g_nav_tstat_status) = buf;
+      - script.execute: nav_refresh_status
 
 lvgl:
   pages:
@@ -102,11 +131,11 @@ lvgl:
             scrollable: false
             widgets:
 
-              # Current temperature — large display
+              # ── Current temperature — large display ───────────────
               - label:
                   id: lbl_current_temp
                   x: 10
-                  y: 8
+                  y: 65
                   width: 460
                   text: "--°"
                   align: TOP_MID
@@ -116,7 +145,7 @@ lvgl:
 
               - label:
                   x: 10
-                  y: 68
+                  y: 122
                   width: 460
                   text: "CURRENT"
                   align: TOP_MID
@@ -124,12 +153,12 @@ lvgl:
                   text_font: montserrat_14
                   text_color: 0x888888
 
-              # Target temperature row: [−]  22.0°  [+]
+              # ── Setpoint row: [−]  22.0°  [+] ────────────────────
               - obj:
                   x: 10
-                  y: 92
+                  y: 145
                   width: 460
-                  height: 80
+                  height: 70
                   bg_color: 0x1a1a2e
                   border_width: 0
                   pad_all: 0
@@ -143,7 +172,7 @@ lvgl:
                   widgets:
                     - button:
                         width: 80
-                        height: 70
+                        height: 60
                         bg_color: 0x0f3460
                         on_press:
                           - lambda: |-
@@ -172,7 +201,7 @@ lvgl:
                         text_color: 0xe94560
                     - button:
                         width: 80
-                        height: 70
+                        height: 60
                         bg_color: 0x0f3460
                         on_press:
                           - lambda: |-
@@ -193,21 +222,21 @@ lvgl:
                               text_font: montserrat_48
                               text_color: 0xffffff
 
-              # MODE section label
+              # ── MODE section ──────────────────────────────────────
               - label:
                   x: 10
-                  y: 180
+                  y: 220
                   width: 460
                   text: "MODE"
                   text_font: montserrat_14
                   text_color: 0x888888
 
-              # Mode row 1: OFF  HEAT  COOL
+              # Mode row 1: OFF  HEAT  COOL  y=241
               - obj:
                   x: 10
-                  y: 200
+                  y: 241
                   width: 460
-                  height: 52
+                  height: 48
                   bg_color: 0x1a1a2e
                   border_width: 0
                   pad_all: 0
@@ -222,61 +251,43 @@ lvgl:
                     - button:
                         id: btn_mode_off
                         width: 148
-                        height: 52
+                        height: 48
                         bg_color: 0x16213e
                         on_press:
                           - homeassistant.service:
                               service: climate.set_hvac_mode
-                              data:
-                                entity_id: ${thermostat_entity_id}
-                                hvac_mode: "off"
+                              data: {entity_id: "${thermostat_entity_id}", hvac_mode: "off"}
                         widgets:
-                          - label:
-                              text: "OFF"
-                              align: CENTER
-                              text_font: montserrat_22
-                              text_color: 0xffffff
+                          - label: {text: "OFF", align: CENTER, text_font: montserrat_22, text_color: 0xffffff}
                     - button:
                         id: btn_mode_heat
                         width: 148
-                        height: 52
+                        height: 48
                         bg_color: 0x16213e
                         on_press:
                           - homeassistant.service:
                               service: climate.set_hvac_mode
-                              data:
-                                entity_id: ${thermostat_entity_id}
-                                hvac_mode: "heat"
+                              data: {entity_id: "${thermostat_entity_id}", hvac_mode: "heat"}
                         widgets:
-                          - label:
-                              text: "HEAT"
-                              align: CENTER
-                              text_font: montserrat_22
-                              text_color: 0xffffff
+                          - label: {text: "HEAT", align: CENTER, text_font: montserrat_22, text_color: 0xffffff}
                     - button:
                         id: btn_mode_cool
                         width: 148
-                        height: 52
+                        height: 48
                         bg_color: 0x16213e
                         on_press:
                           - homeassistant.service:
                               service: climate.set_hvac_mode
-                              data:
-                                entity_id: ${thermostat_entity_id}
-                                hvac_mode: "cool"
+                              data: {entity_id: "${thermostat_entity_id}", hvac_mode: "cool"}
                         widgets:
-                          - label:
-                              text: "COOL"
-                              align: CENTER
-                              text_font: montserrat_22
-                              text_color: 0xffffff
+                          - label: {text: "COOL", align: CENTER, text_font: montserrat_22, text_color: 0xffffff}
 
-              # Mode row 2: AUTO  FAN  DRY
+              # Mode row 2: AUTO  FAN  DRY  y=294
               - obj:
                   x: 10
-                  y: 256
+                  y: 294
                   width: 460
-                  height: 52
+                  height: 48
                   bg_color: 0x1a1a2e
                   border_width: 0
                   pad_all: 0
@@ -291,70 +302,52 @@ lvgl:
                     - button:
                         id: btn_mode_auto
                         width: 148
-                        height: 52
+                        height: 48
                         bg_color: 0x16213e
                         on_press:
                           - homeassistant.service:
                               service: climate.set_hvac_mode
-                              data:
-                                entity_id: ${thermostat_entity_id}
-                                hvac_mode: "heat_cool"
+                              data: {entity_id: "${thermostat_entity_id}", hvac_mode: "heat_cool"}
                         widgets:
-                          - label:
-                              text: "AUTO"
-                              align: CENTER
-                              text_font: montserrat_22
-                              text_color: 0xffffff
+                          - label: {text: "AUTO", align: CENTER, text_font: montserrat_22, text_color: 0xffffff}
                     - button:
                         id: btn_mode_fan
                         width: 148
-                        height: 52
+                        height: 48
                         bg_color: 0x16213e
                         on_press:
                           - homeassistant.service:
                               service: climate.set_hvac_mode
-                              data:
-                                entity_id: ${thermostat_entity_id}
-                                hvac_mode: "fan_only"
+                              data: {entity_id: "${thermostat_entity_id}", hvac_mode: "fan_only"}
                         widgets:
-                          - label:
-                              text: "FAN"
-                              align: CENTER
-                              text_font: montserrat_22
-                              text_color: 0xffffff
+                          - label: {text: "FAN", align: CENTER, text_font: montserrat_22, text_color: 0xffffff}
                     - button:
                         id: btn_mode_dry
                         width: 148
-                        height: 52
+                        height: 48
                         bg_color: 0x16213e
                         on_press:
                           - homeassistant.service:
                               service: climate.set_hvac_mode
-                              data:
-                                entity_id: ${thermostat_entity_id}
-                                hvac_mode: "dry"
+                              data: {entity_id: "${thermostat_entity_id}", hvac_mode: "dry"}
                         widgets:
-                          - label:
-                              text: "DRY"
-                              align: CENTER
-                              text_font: montserrat_22
-                              text_color: 0xffffff
+                          - label: {text: "DRY", align: CENTER, text_font: montserrat_22, text_color: 0xffffff}
 
-              # PRESET section label
+              # ── PRESET section ────────────────────────────────────
               - label:
                   x: 10
-                  y: 316
+                  y: 348
                   width: 460
                   text: "PRESET"
                   text_font: montserrat_14
                   text_color: 0x888888
 
-              # Preset row 1: HOME  AWAY  SLEEP
+              # Preset row 1: HOME  AWAY  SLEEP  y=369
               - obj:
                   x: 10
-                  y: 336
+                  y: 369
                   width: 460
-                  height: 52
+                  height: 46
                   bg_color: 0x1a1a2e
                   border_width: 0
                   pad_all: 0
@@ -369,61 +362,43 @@ lvgl:
                     - button:
                         id: btn_preset_home
                         width: 148
-                        height: 52
+                        height: 46
                         bg_color: 0x16213e
                         on_press:
                           - homeassistant.service:
                               service: climate.set_preset_mode
-                              data:
-                                entity_id: ${thermostat_entity_id}
-                                preset_mode: "home"
+                              data: {entity_id: "${thermostat_entity_id}", preset_mode: "home"}
                         widgets:
-                          - label:
-                              text: "\uF015"
-                              align: CENTER
-                              text_font: montserrat_28
-                              text_color: 0xffffff
+                          - label: {text: "\uF015", align: CENTER, text_font: montserrat_28, text_color: 0xffffff}
                     - button:
                         id: btn_preset_away
                         width: 148
-                        height: 52
+                        height: 46
                         bg_color: 0x16213e
                         on_press:
                           - homeassistant.service:
                               service: climate.set_preset_mode
-                              data:
-                                entity_id: ${thermostat_entity_id}
-                                preset_mode: "away"
+                              data: {entity_id: "${thermostat_entity_id}", preset_mode: "away"}
                         widgets:
-                          - label:
-                              text: "AWAY"
-                              align: CENTER
-                              text_font: montserrat_22
-                              text_color: 0xffffff
+                          - label: {text: "AWAY", align: CENTER, text_font: montserrat_22, text_color: 0xffffff}
                     - button:
                         id: btn_preset_sleep
                         width: 148
-                        height: 52
+                        height: 46
                         bg_color: 0x16213e
                         on_press:
                           - homeassistant.service:
                               service: climate.set_preset_mode
-                              data:
-                                entity_id: ${thermostat_entity_id}
-                                preset_mode: "sleep"
+                              data: {entity_id: "${thermostat_entity_id}", preset_mode: "sleep"}
                         widgets:
-                          - label:
-                              text: "\U000F0594"
-                              align: CENTER
-                              text_font: mdi_icons
-                              text_color: 0xffffff
+                          - label: {text: "\U000F0594", align: CENTER, text_font: mdi_icons, text_color: 0xffffff}
 
-              # Preset row 2: ECO  BOOST  COMFORT
+              # Preset row 2: ECO  BOOST  COMFORT  y=421
               - obj:
                   x: 10
-                  y: 392
+                  y: 421
                   width: 460
-                  height: 52
+                  height: 46
                   bg_color: 0x1a1a2e
                   border_width: 0
                   pad_all: 0
@@ -438,52 +413,33 @@ lvgl:
                     - button:
                         id: btn_preset_eco
                         width: 148
-                        height: 52
+                        height: 46
                         bg_color: 0x16213e
                         on_press:
                           - homeassistant.service:
                               service: climate.set_preset_mode
-                              data:
-                                entity_id: ${thermostat_entity_id}
-                                preset_mode: "eco"
+                              data: {entity_id: "${thermostat_entity_id}", preset_mode: "eco"}
                         widgets:
-                          - label:
-                              text: "ECO"
-                              align: CENTER
-                              text_font: montserrat_22
-                              text_color: 0xffffff
+                          - label: {text: "ECO", align: CENTER, text_font: montserrat_22, text_color: 0xffffff}
                     - button:
                         id: btn_preset_boost
                         width: 148
-                        height: 52
+                        height: 46
                         bg_color: 0x16213e
                         on_press:
                           - homeassistant.service:
                               service: climate.set_preset_mode
-                              data:
-                                entity_id: ${thermostat_entity_id}
-                                preset_mode: "boost"
+                              data: {entity_id: "${thermostat_entity_id}", preset_mode: "boost"}
                         widgets:
-                          - label:
-                              text: "BOOST"
-                              align: CENTER
-                              text_font: montserrat_22
-                              text_color: 0xffffff
+                          - label: {text: "BOOST", align: CENTER, text_font: montserrat_22, text_color: 0xffffff}
                     - button:
                         id: btn_preset_comfort
                         width: 148
-                        height: 52
+                        height: 46
                         bg_color: 0x16213e
                         on_press:
                           - homeassistant.service:
                               service: climate.set_preset_mode
-                              data:
-                                entity_id: ${thermostat_entity_id}
-                                preset_mode: "comfort"
+                              data: {entity_id: "${thermostat_entity_id}", preset_mode: "comfort"}
                         widgets:
-                          - label:
-                              text: "COMF"
-                              align: CENTER
-                              text_font: montserrat_22
-                              text_color: 0xffffff
-
+                          - label: {text: "COMF", align: CENTER, text_font: montserrat_22, text_color: 0xffffff}

--- a/packages/thermostat-ui.yaml
+++ b/packages/thermostat-ui.yaml
@@ -14,7 +14,8 @@
 #   y=421..467 — preset row 2  (ECO BOOST COMF)
 #
 # Navbar contract (nav.yaml):
-#   Writes "Preset · XX.X°" to g_nav_tstat_status and calls nav_refresh_status
+#   Writes "Preset · XX.X°" to any nav slot mapped to thermostat_page, then calls
+#   nav_refresh_status
 #   whenever either current temperature or preset mode changes.
 
 globals:
@@ -38,7 +39,10 @@ sensor:
           if (preset.empty()) preset = "--";
           char buf[64];
           snprintf(buf, sizeof(buf), "%s · %.1f°", preset.c_str(), x);
-          id(g_nav_tstat_status) = buf;
+          if (strcmp("${nav_home_page}", "thermostat_page") == 0) id(g_nav_status_0) = buf;
+          if (strcmp("${nav_page_1}", "thermostat_page") == 0) id(g_nav_status_1) = buf;
+          if (strcmp("${nav_page_2}", "thermostat_page") == 0) id(g_nav_status_2) = buf;
+          if (strcmp("${nav_page_3}", "thermostat_page") == 0) id(g_nav_status_3) = buf;
       - script.execute: nav_refresh_status
 
   - platform: homeassistant
@@ -114,7 +118,10 @@ text_sensor:
       - lambda: |-
           char buf[64];
           snprintf(buf, sizeof(buf), "%s · %.1f°", x.c_str(), id(clim_current_temp).state);
-          id(g_nav_tstat_status) = buf;
+          if (strcmp("${nav_home_page}", "thermostat_page") == 0) id(g_nav_status_0) = buf;
+          if (strcmp("${nav_page_1}", "thermostat_page") == 0) id(g_nav_status_1) = buf;
+          if (strcmp("${nav_page_2}", "thermostat_page") == 0) id(g_nav_status_2) = buf;
+          if (strcmp("${nav_page_3}", "thermostat_page") == 0) id(g_nav_status_3) = buf;
       - script.execute: nav_refresh_status
 
 lvgl:


### PR DESCRIPTION
## Summary

   - **nav.yaml** — Replace animated connecting dots with static text. Add a persistent `navbar` obj to `top_layer` with left
   (`<`) and right (`>`) arrow buttons and a centered lbl_nav_status label. Refactor all page switching into new
   `nav_show_page` + `nav_refresh_status` scripts so both swipe and arrow taps share identical behaviour. Add
   `g_nav_alarm_status` / `g_nav_tstat_status` globals for UI packages to write into. Remove `connecting_anim` script entirely.
   - **alarm-keypad-ui.yaml** — Remove `lbl_status` (alarm state now lives in the navbar). Replace the hidden `code_display`
   overlay with a permanent bar at y=65 (below the 60 px navbar). Shift all keypad rows down to start at y=115. `alarm_state`
   sensor now writes a formatted state string to `g_nav_alarm_status` and calls `nav_refresh_status`.
   - **thermostat-ui.yaml** — Shift all content down 57 px for navbar clearance; compress button heights to keep everything
   within 480 px. `clim_current_temp` and `clim_preset_mode` sensors write a combined 'Preset · XX.X°' string to
   `g_nav_tstat_status` and call `nav_refresh_status`. 