### PR TITLE
fix: correct MDI shield codepoints and centre status labels

### DIFF
--- a/packages/alarm-keypad-ui.yaml
+++ b/packages/alarm-keypad-ui.yaml
@@ -205,9 +205,9 @@ font:
     size: 40
     glyphs:
       - "\U000F033E"  # mdi:lock          → ARM AWAY
-      - "\U000F0FF1"  # mdi:shield       → ARM HOME
+      - "\U000F0498"  # mdi:shield        → ARM HOME
       - "\U000F0594"  # mdi:weather-night → ARM NIGHT
-      - "\U000F0FF2"  # mdi:shield-off    → DISARM
+      - "\U000F099E"  # mdi:shield-off    → DISARM
 
 lvgl:
   pages:
@@ -390,7 +390,7 @@ lvgl:
                               then:
                                 - lvgl.label.update:
                                     id: lbl_disarm_btn
-                                    text: "\U000F0FF2"
+                                    text: "\U000F099E"
                                     text_font: mdi_icons
                         widgets:
                           - label: {text: "CLR", align: CENTER, text_font: montserrat_22, text_color: 0xffffff}
@@ -448,7 +448,7 @@ lvgl:
                           - script.execute: code_overlay_refresh
                           - lvgl.label.update:
                               id: lbl_disarm_btn
-                              text: "\U000F0FF2"
+                              text: "\U000F099E"
                               text_font: mdi_icons
                         widgets:
                           - label: {text: "OK", align: CENTER, text_font: montserrat_22, text_color: 0xffffff}
@@ -513,7 +513,7 @@ lvgl:
                                       entity_id: ${alarm_entity_id}
                         widgets:
                           - label:
-                              text: "\U000F0FF1"
+                              text: "\U000F0498"
                               align: CENTER
                               text_font: mdi_icons
                               text_color: 0xffffff
@@ -569,12 +569,16 @@ lvgl:
                   widgets:
                     - label:
                         id: lbl_disarm_btn
-                        text: "\U000F0FF2"
+                        text: "\U000F099E"
                         align: CENTER
                         text_font: mdi_icons
                         text_color: 0xffffff
 
               # ── Status bar — shows current alarm state  y=415–470 ────
+              # No inner FLEX layout: a FLEX container overrides `align:` on
+              # children, and cross-axis centring of a content-sized label
+              # silently landed the text flush-left. Plain `align: CENTER` on
+              # the single child works reliably.
               - obj:
                   x: 10
                   y: 415
@@ -585,14 +589,9 @@ lvgl:
                   radius: 8
                   border_width: 1
                   border_color: 0x0f3460
-                  pad_all: 10
+                  pad_all: 0
                   scrollbar_mode: "off"
                   scrollable: false
-                  layout:
-                    type: FLEX
-                    flex_flow: COLUMN
-                    flex_align_main: CENTER
-                    flex_align_cross: CENTER
                   widgets:
                     - label:
                         id: lbl_alarm_status

--- a/packages/nav.yaml
+++ b/packages/nav.yaml
@@ -211,11 +211,15 @@ lvgl:
                   - lambda: id(nav_idx) = (id(nav_idx) + ${nav_page_count} - 1) % ${nav_page_count};
                   - script.execute: nav_show_page
 
-            # Status label — filled by nav_refresh_status
+            # Status label — filled by nav_refresh_status.
+            # Intentionally no `height:` override: LVGL labels render text
+            # top-aligned inside their bounding box, so a label pinned to the
+            # full navbar height pushes the text to the top. Letting the label
+            # auto-size lets the row flex's `flex_align_cross: CENTER` do the
+            # vertical centring correctly.
             - label:
                 id: lbl_nav_status
                 flex_grow: 1
-                height: ${nav_bar_height}
                 text: ""
                 align: CENTER
                 text_align: CENTER


### PR DESCRIPTION
## Summary

Three visible defects on the alarm page, all from the same YAML files:

- **Shield icons rendered as credit-card glyphs.** The font glyph list used `\U000F0FF1` (actually `mdi:credit-card-off`) and `\U000F0FF2` (actually `mdi:credit-card-plus`). Correct codepoints are `\U000F0498` (`mdi:shield`) and `\U000F099E` (`mdi:shield-off`). Updated in `font: glyphs:` *and* every `text:` reference — ARM HOME label, disarm button default, and the two `lvgl.label.update` calls inside the CLR and OK button handlers.
- **Bottom status bar "ARMED HOME" was left-aligned.** The status bar `obj` wrapped a single content-sized label in a FLEX column layout, which silently overrode the child's `align: CENTER`. Dropped the inner `layout:` so the plain center alignment works.
- **Top navbar title sat top-aligned within the bar.** `lbl_nav_status` pinned `height: ${nav_bar_height}`; LVGL labels render text top-left inside a fixed bounding box, so the text clung to the top. Removed the height override so the row flex's `flex_align_cross: CENTER` handles vertical centring.

## Root cause — icon bug

Cross-checked against upstream MDI `meta.json` (7447 icons):

| Codepoint | Comment in old YAML | Actual icon |
|-----------|---------------------|-------------|
| `F0FF1`   | `mdi:shield`        | `credit-card-off`  |
| `F0FF2`   | `mdi:shield-off`    | `credit-card-plus` |

That matches the tiny card-with-plus-corner you saw on-screen in every armed/arming/triggered state (they all reuse `lbl_disarm_btn`).

## Test plan

- [x] `esphome config esp32-hass-panel.yaml` — exit 0
- [x] `esphome compile esp32-hass-panel.yaml` (ESP32-S3 / esp-idf, 2026.4.0) — exit 0, firmware 0x14c5c0 bytes
- [ ] Flash to device and visually confirm: arm home shows shield, disarm shows shield-off, arming pulse shows shield-off, top/bottom status labels centre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)