### PR TITLE
fix: show HVAC mode Auto when HA reports "auto"

### DIFF
--- a/packages/thermostat-ui.yaml
+++ b/packages/thermostat-ui.yaml
@@ -51,14 +51,16 @@ text_sensor:
     id: clim_hvac_mode
     entity_id: ${thermostat_entity_id}
     on_value:
+      # Accept both "auto" and "heat_cool" for index 3 — different HA climate
+      # integrations expose the dual-setpoint mode under either name.
       - lvgl.dropdown.update:
           id: dd_hvac_mode
           selected_index: !lambda |-
-            if (x == "off")       return 0;
-            if (x == "heat")      return 1;
-            if (x == "cool")      return 2;
-            if (x == "heat_cool") return 3;
-            if (x == "fan_only")  return 4;
+            if (x == "off")                        return 0;
+            if (x == "heat")                       return 1;
+            if (x == "cool")                       return 2;
+            if (x == "auto" || x == "heat_cool")   return 3;
+            if (x == "fan_only")                   return 4;
             return 0;
 
   - platform: homeassistant
@@ -236,8 +238,12 @@ lvgl:
                     - "Fan Only"
                   selected_index: 0
                   on_value:
+                    # Write "auto" rather than "heat_cool": this is the mode
+                    # name most HA climate integrations (Ecobee, Nest, generic
+                    # thermostat) accept; devices that canonically report
+                    # "heat_cool" still accept "auto" via the climate domain.
                     - lambda: |-
-                        static const char* modes[] = {"off","heat","cool","heat_cool","fan_only"};
+                        static const char* modes[] = {"off","heat","cool","auto","fan_only"};
                         int idx = x;
                         if (idx >= 0 && idx < 5) {
                           id(set_hvac_mode).execute(std::string(modes[idx]));


### PR DESCRIPTION
## Summary

The HVAC mode dropdown showed **Off** when the thermostat was actually in **Auto**. The on-screen text and the HA state disagreed.

Root cause: the read-side mapping in `packages/thermostat-ui.yaml` only handled `"heat_cool"` for the dual-setpoint slot (index 3). Climate integrations that expose the mode as `"auto"` (Ecobee, Nest, generic thermostat, many Z-Wave / HomeKit bridges) fell through to the trailing `return 0`, so the dropdown landed on index 0 (Off).

The write path had the mirror of the same bug — it sent `"heat_cool"` which some devices reject — so even if the dropdown had been right, picking Auto would not have worked on those devices.

## Changes

- **Read**: accept both `"auto"` and `"heat_cool"` for index 3.
- **Write**: send `"auto"` when the user picks Auto. The HA climate domain accepts `"auto"` for devices that canonically report `"heat_cool"` as well, so this direction is strictly broader.

## Test plan

- [x] `esphome config esp32-hass-panel.yaml` — exit 0
- [x] `esphome compile esp32-hass-panel.yaml` (ESP32-S3 / esp-idf, 2026.4.0) — exit 0
- [ ] Flash and confirm on-device: HA thermostat in Auto / preset Home now shows MODE = Auto and PRESET = Home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)