### PR TITLE
feat(3d): pressure ridge, plate fillets, counterbore, narrower spines

### DIFF
--- a/3d/cradle.scad
+++ b/3d/cradle.scad
@@ -28,7 +28,7 @@ plate_w        = 100;
 plate_h        = 110;    // 10 mm trimmed off the top vs original 120
 plate_t        = 5;
 plate_bottom_z = -60;    // Z of plate's bottom edge (fixed anchor)
-plate_corner_r = 5;      // outer corner radius (X-Z corners)
+plate_corner_r = 2;      // outer corner radius (capped at plate_t/2 = 2.5 by sphere-minkowski)
 
 // ---------- CRADLE ----------
 cradle_outer_w = 93;
@@ -102,19 +102,17 @@ union() {
     // planes with the lip.
     difference() {
         union() {
-            // Wall plate with rounded X-Z corners. Inset cube + thin
-            // Y-axis cylinder under minkowski rounds the four vertical
-            // edges by plate_corner_r without changing the plate's
-            // overall bounding box.
+            // Wall plate with all 12 edges and 8 vertices rounded.
+            // Inset cube + sphere minkowski rounds every edge by
+            // plate_corner_r without changing the plate's bounding box.
             minkowski() {
                 translate([-plate_w/2 + plate_corner_r,
-                           0,
+                           plate_corner_r,
                            plate_bottom_z + plate_corner_r])
                     cube([plate_w - 2*plate_corner_r,
-                          plate_t - 0.001,
+                          plate_t - 2*plate_corner_r,
                           plate_h - 2*plate_corner_r]);
-                rotate([-90, 0, 0])
-                    cylinder(h = 0.001, r = plate_corner_r);
+                sphere(r = plate_corner_r);
             }
 
             // Cradle: hollow shell (open top + open front).

--- a/3d/cradle.scad
+++ b/3d/cradle.scad
@@ -58,12 +58,13 @@ box_hole_d       = 4.2;  // #6-32 clearance
 bottom_slot_w    = 60;
 
 // ---------- CENTER SPINES ----------
-// 15 mm-wide uncut strips of plate material forming a cross through
-// the wire passthrough: one vertical (aligned with the screw
-// centerline), one horizontal. Not separate ribs — they are the
-// portions of the plate the wire hole does NOT cut away. The wire
-// passthrough is split into four quadrants around them.
-spine_w          = 15;
+// Uncut strips of plate material forming a cross through the wire
+// passthrough: one vertical (aligned with the screw centerline), one
+// horizontal. Not separate ribs — they are the portions of the plate
+// the wire hole does NOT cut away. The wire passthrough is split into
+// four quadrants around them.
+spine_w_v        = 10;   // vertical spine width (X), narrower so the screws still anchor
+spine_w_h        = 15;   // horizontal spine height (Z)
 
 $fn = 48;
 
@@ -105,13 +106,13 @@ union() {
         }
 
         // Wire passthrough: split into four quadrants separated by a
-        // cross of 15 mm-wide plate strips (vertical on the screw
-        // centerline, horizontal at the plate vertical center).
-        wire_half_w = (wire_hole_w - spine_w) / 2;
-        wire_half_h = (wire_hole_h - spine_w) / 2;
-        translate([-wire_hole_w/2, -0.1,  spine_w/2])
+        // cross of plate strips (vertical on the screw centerline,
+        // horizontal at the plate vertical center).
+        wire_half_w = (wire_hole_w - spine_w_v) / 2;
+        wire_half_h = (wire_hole_h - spine_w_h) / 2;
+        translate([-wire_hole_w/2, -0.1,  spine_w_h/2])
             cube([wire_half_w, plate_t + 0.2, wire_half_h]);  // upper-left
-        translate([ spine_w/2,    -0.1,  spine_w/2])
+        translate([ spine_w_v/2,  -0.1,  spine_w_h/2])
             cube([wire_half_w, plate_t + 0.2, wire_half_h]);  // upper-right
         // Lower quadrants extend 10 mm further down than upper, so the
         // side strips of the bottom bar shrink from 25 mm to 15 mm while
@@ -119,7 +120,7 @@ union() {
         lower_extra_h = 10;
         translate([-wire_hole_w/2, -0.1, -wire_hole_h/2 - lower_extra_h])
             cube([wire_half_w, plate_t + 0.2, wire_half_h + lower_extra_h]);  // lower-left
-        translate([ spine_w/2,    -0.1, -wire_hole_h/2 - lower_extra_h])
+        translate([ spine_w_v/2,  -0.1, -wire_hole_h/2 - lower_extra_h])
             cube([wire_half_w, plate_t + 0.2, wire_half_h + lower_extra_h]);  // lower-right
 
 // Bottom slot (USB-C + SD card) through the cradle's bottom lip.

--- a/3d/cradle.scad
+++ b/3d/cradle.scad
@@ -79,7 +79,7 @@ spine_w_h        = 10;   // horizontal spine height (Z)
 // Pushes the device against the front retention frame.
 ridge_w          = 10;   // X extent (matches spine width)
 ridge_h          = 30;   // Z extent (chord)
-ridge_r          =  1;   // Y peak (sagitta) above plate's back face
+ridge_r          =  2;   // Y peak (sagitta) above plate's back face
 ridge_z          =  21;  // Z center (shifted 40 mm up; ridge sits between horizontal spine and top screw)
 
 $fn = 48;

--- a/3d/cradle.scad
+++ b/3d/cradle.scad
@@ -49,6 +49,11 @@ wire_hole_h    = 70;
 // ---------- GANG-BOX SCREWS ----------
 box_hole_spacing = 83.3;
 box_hole_d       = 4.2;  // #6-32 clearance
+// Counterbore on the device-facing surface so the screw head sits
+// below Y=plate_t and doesn't impede the device. Sized for #6 pan/oval
+// heads (~7.4 mm OD, ~2.5 mm tall).
+csk_d            = 8;    // counterbore diameter
+csk_h            = 3;    // counterbore depth (Y)
 
 // ---------- BOTTOM SLOT (USB-C + SD card) ----------
 // Wide opening through the cradle's bottom lip so the USB-C port and
@@ -144,11 +149,16 @@ union() {
                   cradle_depth + 0.02,
                   wall_bottom_t + 1.1]);
 
-        // US single-gang box screws (vertical centerline)
+        // US single-gang box screws (vertical centerline). Through-hole
+        // plus counterbore on the device-facing surface so the screw
+        // head sits below Y=plate_t.
         for (sz = [-1, 1])
             translate([0, -0.1, sz * box_hole_spacing / 2])
-                rotate([-90, 0, 0])
+                rotate([-90, 0, 0]) {
                     cylinder(h = plate_t + 0.2, d = box_hole_d);
+                    translate([0, 0, plate_t - csk_h + 0.1])
+                        cylinder(h = csk_h + 0.1, d = csk_d);
+                }
     }
 
     // Retention frame at the front face: 4-sided 5 mm-wide border that

--- a/3d/cradle.scad
+++ b/3d/cradle.scad
@@ -69,7 +69,7 @@ bottom_slot_w    = 60;
 // the wire hole does NOT cut away. The wire passthrough is split into
 // four quadrants around them.
 spine_w_v        = 10;   // vertical spine width (X), narrower so the screws still anchor
-spine_w_h        = 15;   // horizontal spine height (Z)
+spine_w_h        = 10;   // horizontal spine height (Z)
 
 // ---------- PRESSURE RIDGE ----------
 // Smooth-curve wedge on the plate's cradle-side face, centered on the

--- a/3d/cradle.scad
+++ b/3d/cradle.scad
@@ -113,10 +113,14 @@ union() {
             cube([wire_half_w, plate_t + 0.2, wire_half_h]);  // upper-left
         translate([ spine_w/2,    -0.1,  spine_w/2])
             cube([wire_half_w, plate_t + 0.2, wire_half_h]);  // upper-right
-        translate([-wire_hole_w/2, -0.1, -wire_hole_h/2])
-            cube([wire_half_w, plate_t + 0.2, wire_half_h]);  // lower-left
-        translate([ spine_w/2,    -0.1, -wire_hole_h/2])
-            cube([wire_half_w, plate_t + 0.2, wire_half_h]);  // lower-right
+        // Lower quadrants extend 10 mm further down than upper, so the
+        // side strips of the bottom bar shrink from 25 mm to 15 mm while
+        // the central column keeps its full 25 mm to anchor the lower screw.
+        lower_extra_h = 10;
+        translate([-wire_hole_w/2, -0.1, -wire_hole_h/2 - lower_extra_h])
+            cube([wire_half_w, plate_t + 0.2, wire_half_h + lower_extra_h]);  // lower-left
+        translate([ spine_w/2,    -0.1, -wire_hole_h/2 - lower_extra_h])
+            cube([wire_half_w, plate_t + 0.2, wire_half_h + lower_extra_h]);  // lower-right
 
 // Bottom slot (USB-C + SD card) through the cradle's bottom lip.
         // Full Y depth of the cradle; Z extends 1 mm up into the cavity

--- a/3d/cradle.scad
+++ b/3d/cradle.scad
@@ -79,7 +79,7 @@ spine_w_h        = 15;   // horizontal spine height (Z)
 ridge_w          = 10;   // X extent (matches spine width)
 ridge_h          = 30;   // Z extent (chord)
 ridge_r          =  1;   // Y peak (sagitta) above plate's back face
-ridge_z          = -24;  // Z center (between horizontal spine and lower screw)
+ridge_z          = -19;  // Z center (shifted 5 mm up from prior -24)
 
 $fn = 48;
 

--- a/3d/cradle.scad
+++ b/3d/cradle.scad
@@ -28,6 +28,7 @@ plate_w        = 100;
 plate_h        = 110;    // 10 mm trimmed off the top vs original 120
 plate_t        = 5;
 plate_bottom_z = -60;    // Z of plate's bottom edge (fixed anchor)
+plate_corner_r = 5;      // outer corner radius (X-Z corners)
 
 // ---------- CRADLE ----------
 cradle_outer_w = 93;
@@ -101,9 +102,20 @@ union() {
     // planes with the lip.
     difference() {
         union() {
-            // Wall plate
-            translate([-plate_w/2, 0, plate_bottom_z])
-                cube([plate_w, plate_t, plate_h]);
+            // Wall plate with rounded X-Z corners. Inset cube + thin
+            // Y-axis cylinder under minkowski rounds the four vertical
+            // edges by plate_corner_r without changing the plate's
+            // overall bounding box.
+            minkowski() {
+                translate([-plate_w/2 + plate_corner_r,
+                           0,
+                           plate_bottom_z + plate_corner_r])
+                    cube([plate_w - 2*plate_corner_r,
+                          plate_t - 0.001,
+                          plate_h - 2*plate_corner_r]);
+                rotate([-90, 0, 0])
+                    cylinder(h = 0.001, r = plate_corner_r);
+            }
 
             // Cradle: hollow shell (open top + open front).
             difference() {

--- a/3d/cradle.scad
+++ b/3d/cradle.scad
@@ -80,7 +80,7 @@ spine_w_h        = 10;   // horizontal spine height (Z)
 ridge_w          = 10;   // X extent (matches spine width)
 ridge_h          = 30;   // Z extent (chord)
 ridge_r          =  1;   // Y peak (sagitta) above plate's back face
-ridge_z          = -19;  // Z center (shifted 5 mm up from prior -24)
+ridge_z          =  21;  // Z center (shifted 40 mm up; ridge sits between horizontal spine and top screw)
 
 $fn = 48;
 

--- a/3d/cradle.scad
+++ b/3d/cradle.scad
@@ -66,6 +66,16 @@ bottom_slot_w    = 60;
 spine_w_v        = 10;   // vertical spine width (X), narrower so the screws still anchor
 spine_w_h        = 15;   // horizontal spine height (Z)
 
+// ---------- PRESSURE RIDGE ----------
+// Smooth-curve wedge on the plate's cradle-side face, centered on the
+// vertical spine. Cross-section in Y-Z is a half-ellipse: chord on
+// Y=plate_t, peak at the middle. Extends ridge_w along X.
+// Pushes the device against the front retention frame.
+ridge_w          = 10;   // X extent (matches spine width)
+ridge_h          = 30;   // Z extent (chord)
+ridge_r          =  1;   // Y peak (sagitta) above plate's back face
+ridge_z          = -24;  // Z center (between horizontal spine and lower screw)
+
 $fn = 48;
 
 // ---------- DERIVED ----------
@@ -170,4 +180,19 @@ union() {
                cradle_z - cradle_outer_h/2 + wall_bottom_t])
         cube([front_lip_w, front_lip_t,
               cradle_outer_h - wall_bottom_t]);               // right post
+
+    // Pressure ridge: half-ellipse cross-section in Y-Z (chord ridge_h,
+    // sagitta ridge_r), extruded along X. Rotation maps the polygon's
+    // X→model Z and the extrusion axis (polygon Z) → model X.
+    translate([0, plate_t, ridge_z])
+        rotate([0, -90, 0])
+            linear_extrude(height = ridge_w, center = true)
+                polygon([
+                    for (i = [0 : 48])
+                        let (
+                            u = -ridge_h/2 + ridge_h * i/48,
+                            v = ridge_r * sqrt(1 - (2*u/ridge_h) * (2*u/ridge_h))
+                        )
+                        [u, v]
+                ]);
 }

--- a/3d/cradle.stl
+++ b/3d/cradle.stl
@@ -167,1012 +167,60 @@ solid OpenSCAD_Model
       vertex -46.5 5 -55
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal 0 -1 0
     outer loop
-      vertex 7.5 5 -35
-      vertex -7.5 5 -7.5
-      vertex 7.5 5 -7.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.5 5 -7.5
-      vertex 7.5 5 -35
-      vertex -7.5 5 -35
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 7.5 5 7.5
-      vertex -7.5 5 35
-      vertex 7.5 5 35
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.5 5 35
-      vertex 7.5 5 7.5
-      vertex -7.5 5 7.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.274104 5 39.568
-      vertex 7.5 5 35
-      vertex 0 5 39.55
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 44.2 5 38
-      vertex 40 5 7.5
-      vertex 40 5 35
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.5 5 -7.5
-      vertex 7.5 5 7.5
-      vertex 40 5 7.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.5 5 7.5
-      vertex 7.5 5 -7.5
-      vertex -7.5 5 7.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.5 5 -7.5
-      vertex 40 5 7.5
-      vertex 40 5 -7.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 44.2 5 38
-      vertex 40 5 -7.5
-      vertex 40 5 7.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 44.2 5 -50
-      vertex 40 5 -7.5
-      vertex 44.2 5 38
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 30 5 -49
-      vertex 7.5 5 -35
-      vertex 40 5 -35
-    endloop
-  endfacet
-  facet normal -0 1 0
-    outer loop
-      vertex 0.54352 5 -39.6216
-      vertex 7.5 5 -35
-      vertex 0.803635 5 -39.7099
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -0.274104 5 -39.568
-      vertex -7.5 5 -35
-      vertex 0 5 -39.55
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.5 5 -35
-      vertex 0 5 -39.55
-      vertex -7.5 5 -35
-    endloop
-  endfacet
-  facet normal -0 1 0
-    outer loop
-      vertex 0 5 -39.55
-      vertex 7.5 5 -35
-      vertex 0.274104 5 -39.568
-    endloop
-  endfacet
-  facet normal -0 1 0
-    outer loop
-      vertex 0.274104 5 -39.568
-      vertex 7.5 5 -35
-      vertex 0.54352 5 -39.6216
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.5 5 -35
-      vertex 1.05 5 -39.8313
-      vertex 0.803635 5 -39.7099
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.5 5 -35
-      vertex 1.2784 5 -39.984
-      vertex 1.05 5 -39.8313
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.5 5 -35
-      vertex 1.48492 5 -40.1651
-      vertex 1.2784 5 -39.984
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.5 5 -35
-      vertex 1.66604 5 -40.3716
-      vertex 1.48492 5 -40.1651
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.5 5 -35
-      vertex 1.81865 5 -40.6
-      vertex 1.66604 5 -40.3716
-    endloop
-  endfacet
-  facet normal -0 1 0
-    outer loop
-      vertex 2.02844 5 -42.1935
-      vertex 7.5 5 -35
-      vertex 30 5 -49
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.5 5 -35
-      vertex 1.94015 5 -40.8464
-      vertex 1.81865 5 -40.6
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.5 5 -35
-      vertex 2.02844 5 -41.1065
-      vertex 1.94015 5 -40.8464
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.5 5 -35
-      vertex 2.08203 5 -41.3759
-      vertex 2.02844 5 -41.1065
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.5 5 -35
-      vertex 2.1 5 -41.65
-      vertex 2.08203 5 -41.3759
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.5 5 -35
-      vertex 2.08203 5 -41.9241
-      vertex 2.1 5 -41.65
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.5 5 -35
-      vertex 2.02844 5 -42.1935
-      vertex 2.08203 5 -41.9241
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.02844 5 -42.1935
-      vertex 30 5 -49
-      vertex 1.94015 5 -42.4536
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.94015 5 -42.4536
-      vertex 30 5 -49
-      vertex 1.81865 5 -42.7
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.81865 5 -42.7
-      vertex 30 5 -49
-      vertex 1.66604 5 -42.9284
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.66604 5 -42.9284
-      vertex 30 5 -49
-      vertex 1.48492 5 -43.1349
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.48492 5 -43.1349
-      vertex 30 5 -49
-      vertex 1.2784 5 -43.316
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.2784 5 -43.316
-      vertex 30 5 -49
-      vertex 1.05 5 -43.4687
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.05 5 -43.4687
-      vertex 30 5 -49
-      vertex 0.803635 5 -43.5901
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.274104 5 -43.732
-      vertex 30 5 -49
-      vertex 0 5 -43.75
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.54352 5 -43.6784
-      vertex 30 5 -49
-      vertex 0.274104 5 -43.732
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.803635 5 -43.5901
-      vertex 30 5 -49
-      vertex 0.54352 5 -43.6784
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 40 5 -7.5
-      vertex 44.2 5 -50
-      vertex 40 5 -35
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 44.2 5 -50
-      vertex 30 5 -49
-      vertex 40 5 -35
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 30 5 -49
-      vertex 44.2 5 -50
       vertex 30 5 -50
+      vertex 30 5 -55
+      vertex 44.2 5 -50
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0 -1 0
     outer loop
-      vertex 50 5 50
-      vertex 0 5 43.75
-      vertex -50 5 50
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 50 5 50
-      vertex 0.274104 5 43.732
-      vertex 0 5 43.75
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 50 5 50
-      vertex 0.54352 5 43.6784
-      vertex 0.274104 5 43.732
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 50 5 50
-      vertex 0.803635 5 43.5901
-      vertex 0.54352 5 43.6784
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 50 5 50
-      vertex 1.05 5 43.4687
-      vertex 0.803635 5 43.5901
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 50 5 50
-      vertex 1.2784 5 43.316
-      vertex 1.05 5 43.4687
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 50 5 50
-      vertex 1.48492 5 43.1349
-      vertex 1.2784 5 43.316
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 50 5 50
-      vertex 1.66604 5 42.9284
-      vertex 1.48492 5 43.1349
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 50 5 50
-      vertex 1.81865 5 42.7
-      vertex 1.66604 5 42.9284
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 40 5 35
-      vertex 50 5 50
+      vertex 44.2 5 -50
+      vertex 46.5 5 38
       vertex 44.2 5 38
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0 -1 0
     outer loop
-      vertex 50 5 50
-      vertex 40 5 35
-      vertex 1.81865 5 42.7
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.81865 5 42.7
-      vertex 40 5 35
-      vertex 1.94015 5 42.4536
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 7.5 5 35
-      vertex 1.94015 5 42.4536
-      vertex 40 5 35
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.94015 5 42.4536
-      vertex 7.5 5 35
-      vertex 2.02844 5 42.1935
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.02844 5 42.1935
-      vertex 7.5 5 35
-      vertex 2.08203 5 41.9241
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.08203 5 41.9241
-      vertex 7.5 5 35
-      vertex 2.1 5 41.65
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.1 5 41.65
-      vertex 7.5 5 35
-      vertex 2.08203 5 41.3759
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.08203 5 41.3759
-      vertex 7.5 5 35
-      vertex 2.02844 5 41.1065
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.02844 5 41.1065
-      vertex 7.5 5 35
-      vertex 1.94015 5 40.8464
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.94015 5 40.8464
-      vertex 7.5 5 35
-      vertex 1.81865 5 40.6
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.81865 5 40.6
-      vertex 7.5 5 35
-      vertex 1.66604 5 40.3716
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.66604 5 40.3716
-      vertex 7.5 5 35
-      vertex 1.48492 5 40.1651
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.48492 5 40.1651
-      vertex 7.5 5 35
-      vertex 1.2784 5 39.984
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.05 5 39.8313
-      vertex 7.5 5 35
-      vertex 0.803635 5 39.7099
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.2784 5 39.984
-      vertex 7.5 5 35
-      vertex 1.05 5 39.8313
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 44.2 5 38
-      vertex 50 5 50
+      vertex 44.2 5 -50
+      vertex 46.5 5 -55
       vertex 46.5 5 38
     endloop
   endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 50 5 -60
-      vertex 46.5 5 38
-      vertex 50 5 50
-    endloop
-  endfacet
-  facet normal 0 1 0
+  facet normal 0 -1 0
     outer loop
       vertex 46.5 5 -55
-      vertex 30 5 -55.1
+      vertex 44.2 5 -50
       vertex 30 5 -55
     endloop
   endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 30 5 -55.1
-      vertex 50 5 -60
-      vertex -30 5 -55.1
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 46.5 5 -55
-      vertex 50 5 -60
-      vertex 30 5 -55.1
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 46.5 5 38
-      vertex 50 5 -60
-      vertex 46.5 5 -55
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -0.274104 5 43.732
-      vertex -50 5 50
-      vertex 0 5 43.75
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -0.54352 5 43.6784
-      vertex -50 5 50
-      vertex -0.274104 5 43.732
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -0.803635 5 43.5901
-      vertex -50 5 50
-      vertex -0.54352 5 43.6784
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -1.05 5 43.4687
-      vertex -50 5 50
-      vertex -0.803635 5 43.5901
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -1.2784 5 43.316
-      vertex -50 5 50
-      vertex -1.05 5 43.4687
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -1.48492 5 43.1349
-      vertex -50 5 50
-      vertex -1.2784 5 43.316
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -1.66604 5 42.9284
-      vertex -50 5 50
-      vertex -1.48492 5 43.1349
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -1.81865 5 42.7
-      vertex -50 5 50
-      vertex -1.66604 5 42.9284
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 38
-      vertex -1.81865 5 42.7
-      vertex -1.94015 5 42.4536
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 38
-      vertex -1.94015 5 42.4536
-      vertex -2.02844 5 42.1935
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 38
-      vertex -2.02844 5 42.1935
-      vertex -2.08203 5 41.9241
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 38
-      vertex -2.08203 5 41.9241
-      vertex -2.1 5 41.65
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 38
-      vertex -2.1 5 41.65
-      vertex -2.08203 5 41.3759
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 38
-      vertex -2.08203 5 41.3759
-      vertex -2.02844 5 41.1065
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 38
-      vertex -2.02844 5 41.1065
-      vertex -1.94015 5 40.8464
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 38
-      vertex -1.94015 5 40.8464
-      vertex -1.81865 5 40.6
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 38
-      vertex -1.81865 5 40.6
-      vertex -1.66604 5 40.3716
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 38
-      vertex -1.66604 5 40.3716
-      vertex -1.48492 5 40.1651
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 38
-      vertex -1.48492 5 40.1651
-      vertex -1.2784 5 39.984
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 38
-      vertex -1.2784 5 39.984
-      vertex -1.05 5 39.8313
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 38
-      vertex -1.05 5 39.8313
-      vertex -0.803635 5 39.7099
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 38
-      vertex -0.803635 5 39.7099
-      vertex -0.54352 5 39.6216
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.803635 5 39.7099
-      vertex 7.5 5 35
-      vertex 0.54352 5 39.6216
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.54352 5 39.6216
-      vertex 7.5 5 35
-      vertex 0.274104 5 39.568
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 38
-      vertex -0.274104 5 39.568
-      vertex 0 5 39.55
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 38
-      vertex -0.54352 5 39.6216
-      vertex -0.274104 5 39.568
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -1.81865 5 42.7
-      vertex -44.2 5 38
-      vertex -50 5 50
-    endloop
-  endfacet
-  facet normal 0 1 -0
+  facet normal 0 -1 0
     outer loop
       vertex -46.5 5 38
-      vertex -50 5 50
+      vertex -44.2 5 -50
       vertex -44.2 5 38
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0 -1 0
     outer loop
-      vertex -50 5 -60
-      vertex -46.5 5 38
       vertex -46.5 5 -55
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -50 5 -60
-      vertex -30 5 -55.1
-      vertex 50 5 -60
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
+      vertex -44.2 5 -50
       vertex -46.5 5 38
-      vertex -50 5 -60
-      vertex -50 5 50
     endloop
   endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -30 5 -55.1
-      vertex -50 5 -60
-      vertex -46.5 5 -55
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.5 5 35
-      vertex 0 5 39.55
-      vertex 7.5 5 35
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0 5 39.55
-      vertex -7.5 5 35
-      vertex -44.2 5 38
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -40 5 35
-      vertex -44.2 5 38
-      vertex -7.5 5 35
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -40 5 7.5
-      vertex -44.2 5 38
-      vertex -40 5 35
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.5 5 -7.5
-      vertex -7.5 5 7.5
-      vertex 7.5 5 -7.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.5 5 7.5
-      vertex -7.5 5 -7.5
-      vertex -40 5 7.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -40 5 -7.5
-      vertex -40 5 7.5
-      vertex -7.5 5 -7.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -40 5 -7.5
-      vertex -44.2 5 38
-      vertex -40 5 7.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 -50
-      vertex -40 5 -7.5
-      vertex -40 5 -35
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -0.54352 5 -39.6216
-      vertex -7.5 5 -35
-      vertex -0.274104 5 -39.568
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -0.803635 5 -39.7099
-      vertex -7.5 5 -35
-      vertex -0.54352 5 -39.6216
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -1.05 5 -39.8313
-      vertex -7.5 5 -35
-      vertex -0.803635 5 -39.7099
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -1.2784 5 -39.984
-      vertex -7.5 5 -35
-      vertex -1.05 5 -39.8313
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -1.48492 5 -40.1651
-      vertex -7.5 5 -35
-      vertex -1.2784 5 -39.984
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -1.66604 5 -40.3716
-      vertex -7.5 5 -35
-      vertex -1.48492 5 -40.1651
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -1.81865 5 -40.6
-      vertex -7.5 5 -35
-      vertex -1.66604 5 -40.3716
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -1.94015 5 -40.8464
-      vertex -7.5 5 -35
-      vertex -1.81865 5 -40.6
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -2.02844 5 -41.1065
-      vertex -7.5 5 -35
-      vertex -1.94015 5 -40.8464
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -2.08203 5 -41.3759
-      vertex -7.5 5 -35
-      vertex -2.02844 5 -41.1065
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -2.1 5 -41.65
-      vertex -7.5 5 -35
-      vertex -2.08203 5 -41.3759
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -2.08203 5 -41.9241
-      vertex -7.5 5 -35
-      vertex -2.1 5 -41.65
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -2.02844 5 -42.1935
-      vertex -7.5 5 -35
-      vertex -2.08203 5 -41.9241
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.5 5 -35
-      vertex -2.02844 5 -42.1935
-      vertex -30 5 -49
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -30 5 -49
-      vertex -2.02844 5 -42.1935
-      vertex -1.94015 5 -42.4536
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -30 5 -49
-      vertex -1.94015 5 -42.4536
-      vertex -1.81865 5 -42.7
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -30 5 -49
-      vertex -1.81865 5 -42.7
-      vertex -1.66604 5 -42.9284
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -30 5 -49
-      vertex -1.66604 5 -42.9284
-      vertex -1.48492 5 -43.1349
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -30 5 -49
-      vertex -1.48492 5 -43.1349
-      vertex -1.2784 5 -43.316
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -30 5 -49
-      vertex -1.2784 5 -43.316
-      vertex -1.05 5 -43.4687
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -30 5 -49
-      vertex -1.05 5 -43.4687
-      vertex -0.803635 5 -43.5901
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -30 5 -49
-      vertex -0.803635 5 -43.5901
-      vertex -0.54352 5 -43.6784
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -30 5 -49
-      vertex 0 5 -43.75
-      vertex 30 5 -49
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0 5 -43.75
-      vertex -30 5 -49
-      vertex -0.274104 5 -43.732
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -30 5 -49
-      vertex -0.54352 5 -43.6784
-      vertex -0.274104 5 -43.732
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.5 5 -35
-      vertex -30 5 -49
-      vertex -40 5 -35
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -44.2 5 -50
-      vertex -30 5 -49
-      vertex -30 5 -50
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -40 5 -7.5
-      vertex -44.2 5 -50
-      vertex -44.2 5 38
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -30 5 -49
-      vertex -44.2 5 -50
-      vertex -40 5 -35
-    endloop
-  endfacet
-  facet normal 0 1 0
+  facet normal 0 -1 0
     outer loop
       vertex -30 5 -55
-      vertex -30 5 -55.1
+      vertex -44.2 5 -50
       vertex -46.5 5 -55
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -44.2 5 -50
+      vertex -30 5 -55
+      vertex -30 5 -50
     endloop
   endfacet
   facet normal 1 -0 0
@@ -1231,2538 +279,23496 @@ solid OpenSCAD_Model
       vertex 30 5 -50
     endloop
   endfacet
-  facet normal -1 0 0
+  facet normal 0.310491 -0.914782 0.258397
     outer loop
-      vertex -50 0 -60
-      vertex -50 5 50
-      vertex -50 5 -60
+      vertex 48.7247 0.250301 48.6429
+      vertex 48.5077 0.105268 48.3902
+      vertex 48.7507 0.187746 48.3902
     endloop
   endfacet
-  facet normal -1 -0 0
+  facet normal 0.318673 -0.938886 0.130157
     outer loop
-      vertex -50 5 50
-      vertex -50 0 -60
-      vertex -50 0 50
+      vertex 48.7507 0.187746 48.3902
+      vertex 48.5077 0.105268 48.3902
+      vertex 48.7637 0.156198 48.1308
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.0648493 0.989358 -0.130249
     outer loop
-      vertex -50 5 50
-      vertex 50 0 50
-      vertex 50 5 50
+      vertex 48.256 4.94479 -58.3902
+      vertex 48 4.96157 -58.3902
+      vertex 48 4.99572 -58.1308
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.227596 -0.670291 -0.706336
     outer loop
-      vertex 50 0 50
-      vertex -50 5 50
-      vertex -50 0 50
+      vertex -48.3892 0.547558 -59.3187
+      vertex -48.5754 0.610782 -59.3187
+      vertex -48.3413 0.726242 -59.5037
+    endloop
+  endfacet
+  facet normal -0.0631903 -0.963996 0.258298
+    outer loop
+      vertex -48 0.10614 48.6429
+      vertex -48.256 0.0552111 48.3902
+      vertex -48 0.0384302 48.3902
+    endloop
+  endfacet
+  facet normal 0.0631748 0.964 -0.258288
+    outer loop
+      vertex 48.2472 4.87766 -58.6429
+      vertex 48 4.89386 -58.6429
+      vertex 48.256 4.94479 -58.3902
+    endloop
+  endfacet
+  facet normal 0.195085 0.980786 -0
+    outer loop
+      vertex 48.5165 4.92772 -58.1308
+      vertex 48.2605 4.97864 48.1308
+      vertex 48.5165 4.92772 48.1308
+    endloop
+  endfacet
+  facet normal 0.195085 0.980786 0
+    outer loop
+      vertex 48.2605 4.97864 48.1308
+      vertex 48.5165 4.92772 -58.1308
+      vertex 48.2605 4.97864 -58.1308
+    endloop
+  endfacet
+  facet normal 0.793533 -0 0.608528
+    outer loop
+      vertex 49.5037 2 49.3187
+      vertex 49.6629 3 49.1111
+      vertex 49.5037 3 49.3187
+    endloop
+  endfacet
+  facet normal 0.793533 0 0.608528
+    outer loop
+      vertex 49.6629 3 49.1111
+      vertex 49.5037 2 49.3187
+      vertex 49.6629 2 49.1111
+    endloop
+  endfacet
+  facet normal 0.193395 -0.972442 0.130209
+    outer loop
+      vertex 48.5077 0.105268 48.3902
+      vertex 48.256 0.0552111 48.3902
+      vertex 48.5165 0.0722847 48.1308
+    endloop
+  endfacet
+  facet normal 0 0.865959 0.500115
+    outer loop
+      vertex 48 4.79375 48.8846
+      vertex -48 4.66294 49.1111
+      vertex 48 4.66294 49.1111
+    endloop
+  endfacet
+  facet normal 0 0.865959 0.500115
+    outer loop
+      vertex -48 4.66294 49.1111
+      vertex 48 4.79375 48.8846
+      vertex -48 4.79375 48.8846
+    endloop
+  endfacet
+  facet normal 0.297157 -0.8751 0.381966
+    outer loop
+      vertex 48.7247 0.250301 48.6429
+      vertex 48.4643 0.267375 48.8846
+      vertex 48.4902 0.170672 48.6429
+    endloop
+  endfacet
+  facet normal -0.849746 -0.169115 0.499332
+    outer loop
+      vertex -49.6487 1.78294 49.1111
+      vertex -49.7784 1.76587 48.8846
+      vertex -49.7326 1.53574 48.8846
+    endloop
+  endfacet
+  facet normal 0.0419945 -0.123693 0.991432
+    outer loop
+      vertex 48.0501 1.87915 49.9957
+      vertex 48.0339 1.87365 49.9957
+      vertex 48.101 1.62311 49.9616
+    endloop
+  endfacet
+  facet normal 0.130336 0 -0.99147
+    outer loop
+      vertex 48.1308 2 -59.9957
+      vertex 48.3902 3 -59.9616
+      vertex 48.3902 2 -59.9616
+    endloop
+  endfacet
+  facet normal 0.130336 0 -0.99147
+    outer loop
+      vertex 48.3902 3 -59.9616
+      vertex 48.1308 2 -59.9957
+      vertex 48.1308 3 -59.9957
+    endloop
+  endfacet
+  facet normal 0.188437 -0.947516 0.258274
+    outer loop
+      vertex 48.5077 0.105268 48.3902
+      vertex 48.2472 0.122342 48.6429
+      vertex 48.256 0.0552111 48.3902
+    endloop
+  endfacet
+  facet normal -0.745377 0.653765 -0.130403
+    outer loop
+      vertex -49.387 4.38704 -58.3902
+      vertex -49.5562 4.19413 -58.3902
+      vertex -49.4112 4.41119 -58.1308
+    endloop
+  endfacet
+  facet normal -0.3105 0.914784 -0.25838
+    outer loop
+      vertex -48.7247 4.7497 -58.6429
+      vertex -48.7507 4.81225 -58.3902
+      vertex -48.5077 4.89473 -58.3902
+    endloop
+  endfacet
+  facet normal -0.577082 -0.195813 0.792864
+    outer loop
+      vertex -49.0733 1.71242 49.6629
+      vertex -49.2738 1.6587 49.5037
+      vertex -49.0266 1.57479 49.6629
+    endloop
+  endfacet
+  facet normal 0.0604523 -0.922187 0.381991
+    outer loop
+      vertex 48.2341 0.221601 48.8846
+      vertex 48 0.206255 48.8846
+      vertex 48.2472 0.122342 48.6429
+    endloop
+  endfacet
+  facet normal 0.318704 -0.93887 0.130191
+    outer loop
+      vertex 48.7637 0.156198 48.1308
+      vertex 48.5077 0.105268 48.3902
+      vertex 48.5165 0.0722847 48.1308
+    endloop
+  endfacet
+  facet normal 0.168981 -0.849814 0.499261
+    outer loop
+      vertex 48.4643 0.267375 48.8846
+      vertex 48.2171 0.351288 49.1111
+      vertex 48.2341 0.221601 48.8846
+    endloop
+  endfacet
+  facet normal 0 0.793422 -0.608672
+    outer loop
+      vertex 48 4.50368 -59.3187
+      vertex -48 4.66294 -59.1111
+      vertex 48 4.66294 -59.1111
+    endloop
+  endfacet
+  facet normal 0 0.793422 -0.608672
+    outer loop
+      vertex -48 4.66294 -59.1111
+      vertex 48 4.50368 -59.3187
+      vertex -48 4.50368 -59.3187
+    endloop
+  endfacet
+  facet normal 0.0398685 -0.608134 0.792832
+    outer loop
+      vertex 48 0.88886 49.6629
+      vertex 48 0.681309 49.5037
+      vertex 48.145 0.898366 49.6629
+    endloop
+  endfacet
+  facet normal -0.751827 0.255117 0.608006
+    outer loop
+      vertex -49.3892 3.57543 49.3187
+      vertex -49.6063 3.4304 49.1111
+      vertex -49.4524 3.38918 49.3187
+    endloop
+  endfacet
+  facet normal -0.382882 0.0250965 -0.923456
+    outer loop
+      vertex -48.6429 3 -59.8939
+      vertex -48.877 3.11546 -59.7937
+      vertex -48.6374 3.08391 -59.8939
+    endloop
+  endfacet
+  facet normal -0.188449 0.947514 0.258271
+    outer loop
+      vertex -48.256 4.94479 48.3902
+      vertex -48.5077 4.89473 48.3902
+      vertex -48.2472 4.87766 48.6429
+    endloop
+  endfacet
+  facet normal 0.278247 0.416353 0.86558
+    outer loop
+      vertex 48.5556 3.96228 49.6629
+      vertex 48.4423 3.76607 49.7937
+      vertex 48.5385 3.70178 49.7937
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -5
+      vertex 0 4.99572 -37.65
+      vertex -5 4.99572 -5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -5
+      vertex 0.522104 4.99572 -37.6842
+      vertex 0 4.99572 -37.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -5
+      vertex 1.03528 4.99572 -37.7863
+      vertex 0.522104 4.99572 -37.6842
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -5
+      vertex 1.53073 4.99572 -37.9545
+      vertex 1.03528 4.99572 -37.7863
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -5
+      vertex 2 4.99572 -38.1859
+      vertex 1.53073 4.99572 -37.9545
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -5
+      vertex 2.43505 4.99572 -38.4766
+      vertex 2 4.99572 -38.1859
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -5
+      vertex 2.82843 4.99572 -38.8216
+      vertex 2.43505 4.99572 -38.4766
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -5
+      vertex 3.17341 4.99572 -39.215
+      vertex 2.82843 4.99572 -38.8216
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -5
+      vertex 3.4641 4.99572 -39.65
+      vertex 3.17341 4.99572 -39.215
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -5
+      vertex 3.69552 4.99572 -40.1193
+      vertex 3.4641 4.99572 -39.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -5
+      vertex 3.8637 4.99572 -40.6147
+      vertex 3.69552 4.99572 -40.1193
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 5 4.99572 -45
+      vertex 3.8637 4.99572 -40.6147
+      vertex 5 4.99572 -5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.8637 4.99572 -40.6147
+      vertex 5 4.99572 -45
+      vertex 3.96578 4.99572 -41.1279
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.96578 4.99572 -41.1279
+      vertex 5 4.99572 -45
+      vertex 4 4.99572 -41.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -45
+      vertex 3.96578 4.99572 -42.1721
+      vertex 4 4.99572 -41.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -45
+      vertex 3.8637 4.99572 -42.6853
+      vertex 3.96578 4.99572 -42.1721
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -45
+      vertex 3.69552 4.99572 -43.1807
+      vertex 3.8637 4.99572 -42.6853
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -45
+      vertex 3.4641 4.99572 -43.65
+      vertex 3.69552 4.99572 -43.1807
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -45
+      vertex 3.17341 4.99572 -44.085
+      vertex 3.4641 4.99572 -43.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -45
+      vertex 2.82843 4.99572 -44.4784
+      vertex 3.17341 4.99572 -44.085
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -45
+      vertex 2.43505 4.99572 -44.8234
+      vertex 2.82843 4.99572 -44.4784
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.43505 4.99572 -44.8234
+      vertex 5 4.99572 -45
+      vertex 2 4.99572 -45.1141
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 5 4.99572 5
+      vertex -5 4.99572 35
+      vertex 5 4.99572 35
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 35
+      vertex 5 4.99572 5
+      vertex -5 4.99572 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 48 4.99572 48.1308
+      vertex 0 4.99572 45.65
+      vertex -48 4.99572 48.1308
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 48 4.99572 48.1308
+      vertex 0.522104 4.99572 45.6158
+      vertex 0 4.99572 45.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 48 4.99572 48.1308
+      vertex 1.03528 4.99572 45.5137
+      vertex 0.522104 4.99572 45.6158
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 48 4.99572 48.1308
+      vertex 1.53073 4.99572 45.3455
+      vertex 1.03528 4.99572 45.5137
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 48 4.99572 48.1308
+      vertex 2 4.99572 45.1141
+      vertex 1.53073 4.99572 45.3455
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 48 4.99572 48.1308
+      vertex 2.43505 4.99572 44.8234
+      vertex 2 4.99572 45.1141
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 48 4.99572 48.1308
+      vertex 2.82843 4.99572 44.4784
+      vertex 2.43505 4.99572 44.8234
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 48 4.99572 48.1308
+      vertex 3.17341 4.99572 44.085
+      vertex 2.82843 4.99572 44.4784
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 48 4.99572 48.1308
+      vertex 3.4641 4.99572 43.65
+      vertex 3.17341 4.99572 44.085
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 48 4.99572 48.1308
+      vertex 3.69552 4.99572 43.1807
+      vertex 3.4641 4.99572 43.65
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 40 4.99572 35
+      vertex 3.69552 4.99572 43.1807
+      vertex 48 4.99572 48.1308
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.69552 4.99572 43.1807
+      vertex 40 4.99572 35
+      vertex 3.8637 4.99572 42.6853
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.8637 4.99572 42.6853
+      vertex 40 4.99572 35
+      vertex 3.96578 4.99572 42.1721
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.96578 4.99572 42.1721
+      vertex 40 4.99572 35
+      vertex 4 4.99572 41.65
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 5 4.99572 35
+      vertex 4 4.99572 41.65
+      vertex 40 4.99572 35
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4 4.99572 41.65
+      vertex 5 4.99572 35
+      vertex 3.96578 4.99572 41.1279
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.96578 4.99572 41.1279
+      vertex 5 4.99572 35
+      vertex 3.8637 4.99572 40.6147
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.8637 4.99572 40.6147
+      vertex 5 4.99572 35
+      vertex 3.69552 4.99572 40.1193
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.69552 4.99572 40.1193
+      vertex 5 4.99572 35
+      vertex 3.4641 4.99572 39.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.4641 4.99572 39.65
+      vertex 5 4.99572 35
+      vertex 3.17341 4.99572 39.215
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.17341 4.99572 39.215
+      vertex 5 4.99572 35
+      vertex 2.82843 4.99572 38.8216
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.43505 4.99572 38.4766
+      vertex 5 4.99572 35
+      vertex 2 4.99572 38.1859
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2 4.99572 38.1859
+      vertex 5 4.99572 35
+      vertex 1.53073 4.99572 37.9545
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.03528 4.99572 37.7863
+      vertex 5 4.99572 35
+      vertex 0.522104 4.99572 37.6842
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.53073 4.99572 37.9545
+      vertex 5 4.99572 35
+      vertex 1.03528 4.99572 37.7863
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.82843 4.99572 38.8216
+      vertex 5 4.99572 35
+      vertex 2.43505 4.99572 38.4766
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 48 4.99572 48.1308
+      vertex 40 4.99572 5
+      vertex 40 4.99572 35
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -5
+      vertex 5 4.99572 5
+      vertex 40 4.99572 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 5
+      vertex 5 4.99572 -5
+      vertex -5 4.99572 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -5
+      vertex 40 4.99572 5
+      vertex 40 4.99572 -5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 48 4.99572 48.1308
+      vertex 40 4.99572 -5
+      vertex 40 4.99572 5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 48 4.99572 -58.1308
+      vertex 40 4.99572 -5
+      vertex 48 4.99572 48.1308
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 30 4.99572 -49
+      vertex 5 4.99572 -45
+      vertex 40 4.99572 -45
+    endloop
+  endfacet
+  facet normal -0 1 0
+    outer loop
+      vertex 0.522104 4.99572 -45.6158
+      vertex 5 4.99572 -45
+      vertex 30 4.99572 -49
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -45
+      vertex 1.53073 4.99572 -45.3455
+      vertex 2 4.99572 -45.1141
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -45
+      vertex 1.03528 4.99572 -45.5137
+      vertex 1.53073 4.99572 -45.3455
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 4.99572 -45
+      vertex 0.522104 4.99572 -45.6158
+      vertex 1.03528 4.99572 -45.5137
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.522104 4.99572 -45.6158
+      vertex 30 4.99572 -49
+      vertex 0 4.99572 -45.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 40 4.99572 -45
+      vertex 30 4.99572 -55.1
+      vertex 30 4.99572 -49
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 30 4.99572 -55.1
+      vertex 48 4.99572 -58.1308
+      vertex -30 4.99572 -55.1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 40 4.99572 -45
+      vertex 48 4.99572 -58.1308
+      vertex 30 4.99572 -55.1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 40 4.99572 -5
+      vertex 48 4.99572 -58.1308
+      vertex 40 4.99572 -45
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -0.522104 4.99572 45.6158
+      vertex -48 4.99572 48.1308
+      vertex 0 4.99572 45.65
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -1.03528 4.99572 45.5137
+      vertex -48 4.99572 48.1308
+      vertex -0.522104 4.99572 45.6158
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -1.53073 4.99572 45.3455
+      vertex -48 4.99572 48.1308
+      vertex -1.03528 4.99572 45.5137
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2 4.99572 45.1141
+      vertex -48 4.99572 48.1308
+      vertex -1.53073 4.99572 45.3455
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2.43505 4.99572 44.8234
+      vertex -48 4.99572 48.1308
+      vertex -2 4.99572 45.1141
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2.82843 4.99572 44.4784
+      vertex -48 4.99572 48.1308
+      vertex -2.43505 4.99572 44.8234
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -3.17341 4.99572 44.085
+      vertex -48 4.99572 48.1308
+      vertex -2.82843 4.99572 44.4784
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -3.4641 4.99572 43.65
+      vertex -48 4.99572 48.1308
+      vertex -3.17341 4.99572 44.085
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -3.69552 4.99572 43.1807
+      vertex -48 4.99572 48.1308
+      vertex -3.4641 4.99572 43.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -40 4.99572 35
+      vertex -3.69552 4.99572 43.1807
+      vertex -3.8637 4.99572 42.6853
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -40 4.99572 35
+      vertex -3.8637 4.99572 42.6853
+      vertex -3.96578 4.99572 42.1721
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -40 4.99572 35
+      vertex -3.96578 4.99572 42.1721
+      vertex -4 4.99572 41.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 35
+      vertex -4 4.99572 41.65
+      vertex -3.96578 4.99572 41.1279
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 35
+      vertex -3.96578 4.99572 41.1279
+      vertex -3.8637 4.99572 40.6147
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 35
+      vertex -3.8637 4.99572 40.6147
+      vertex -3.69552 4.99572 40.1193
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 35
+      vertex -3.69552 4.99572 40.1193
+      vertex -3.4641 4.99572 39.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 35
+      vertex -3.4641 4.99572 39.65
+      vertex -3.17341 4.99572 39.215
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 35
+      vertex -3.17341 4.99572 39.215
+      vertex -2.82843 4.99572 38.8216
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 35
+      vertex -2.82843 4.99572 38.8216
+      vertex -2.43505 4.99572 38.4766
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 35
+      vertex -2.43505 4.99572 38.4766
+      vertex -2 4.99572 38.1859
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 35
+      vertex -2 4.99572 38.1859
+      vertex -1.53073 4.99572 37.9545
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 35
+      vertex -1.53073 4.99572 37.9545
+      vertex -1.03528 4.99572 37.7863
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.522104 4.99572 37.6842
+      vertex 5 4.99572 35
+      vertex 0 4.99572 37.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 35
+      vertex 0 4.99572 37.65
+      vertex 5 4.99572 35
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 4.99572 37.65
+      vertex -5 4.99572 35
+      vertex -0.522104 4.99572 37.6842
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.522104 4.99572 37.6842
+      vertex -5 4.99572 35
+      vertex -1.03528 4.99572 37.7863
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -4 4.99572 41.65
+      vertex -5 4.99572 35
+      vertex -40 4.99572 35
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.69552 4.99572 43.1807
+      vertex -40 4.99572 35
+      vertex -48 4.99572 48.1308
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -40 4.99572 5
+      vertex -48 4.99572 48.1308
+      vertex -40 4.99572 35
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 -5
+      vertex -5 4.99572 5
+      vertex 5 4.99572 -5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 5
+      vertex -5 4.99572 -5
+      vertex -40 4.99572 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -40 4.99572 -5
+      vertex -40 4.99572 5
+      vertex -5 4.99572 -5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -40 4.99572 -5
+      vertex -48 4.99572 48.1308
+      vertex -40 4.99572 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -48 4.99572 -58.1308
+      vertex -40 4.99572 -5
+      vertex -40 4.99572 -45
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.03528 4.99572 -45.5137
+      vertex -5 4.99572 -45
+      vertex -1.53073 4.99572 -45.3455
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.522104 4.99572 -45.6158
+      vertex -5 4.99572 -45
+      vertex -1.03528 4.99572 -45.5137
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 -45
+      vertex -0.522104 4.99572 -45.6158
+      vertex -30 4.99572 -49
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -30 4.99572 -49
+      vertex -0.522104 4.99572 -45.6158
+      vertex 0 4.99572 -45.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -30 4.99572 -49
+      vertex 0 4.99572 -45.65
+      vertex 30 4.99572 -49
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 -45
+      vertex -30 4.99572 -49
+      vertex -40 4.99572 -45
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -30 4.99572 -55.1
+      vertex -40 4.99572 -45
+      vertex -30 4.99572 -49
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -40 4.99572 -5
+      vertex -48 4.99572 -58.1308
+      vertex -48 4.99572 48.1308
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -30 4.99572 -55.1
+      vertex -48 4.99572 -58.1308
+      vertex -40 4.99572 -45
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -48 4.99572 -58.1308
+      vertex -30 4.99572 -55.1
+      vertex 48 4.99572 -58.1308
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -0.522104 4.99572 -37.6842
+      vertex -5 4.99572 -5
+      vertex 0 4.99572 -37.65
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -1.03528 4.99572 -37.7863
+      vertex -5 4.99572 -5
+      vertex -0.522104 4.99572 -37.6842
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -1.53073 4.99572 -37.9545
+      vertex -5 4.99572 -5
+      vertex -1.03528 4.99572 -37.7863
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2 4.99572 -38.1859
+      vertex -5 4.99572 -5
+      vertex -1.53073 4.99572 -37.9545
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2.43505 4.99572 -38.4766
+      vertex -5 4.99572 -5
+      vertex -2 4.99572 -38.1859
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2.82843 4.99572 -38.8216
+      vertex -5 4.99572 -5
+      vertex -2.43505 4.99572 -38.4766
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -3.17341 4.99572 -39.215
+      vertex -5 4.99572 -5
+      vertex -2.82843 4.99572 -38.8216
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -3.4641 4.99572 -39.65
+      vertex -5 4.99572 -5
+      vertex -3.17341 4.99572 -39.215
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -3.69552 4.99572 -40.1193
+      vertex -5 4.99572 -5
+      vertex -3.4641 4.99572 -39.65
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -3.8637 4.99572 -40.6147
+      vertex -5 4.99572 -5
+      vertex -3.69552 4.99572 -40.1193
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 -45
+      vertex -3.8637 4.99572 -40.6147
+      vertex -3.96578 4.99572 -41.1279
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 4.99572 -45
+      vertex -3.96578 4.99572 -41.1279
+      vertex -4 4.99572 -41.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.8637 4.99572 -40.6147
+      vertex -5 4.99572 -45
+      vertex -5 4.99572 -5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.96578 4.99572 -42.1721
+      vertex -5 4.99572 -45
+      vertex -4 4.99572 -41.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.8637 4.99572 -42.6853
+      vertex -5 4.99572 -45
+      vertex -3.96578 4.99572 -42.1721
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.69552 4.99572 -43.1807
+      vertex -5 4.99572 -45
+      vertex -3.8637 4.99572 -42.6853
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.4641 4.99572 -43.65
+      vertex -5 4.99572 -45
+      vertex -3.69552 4.99572 -43.1807
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.17341 4.99572 -44.085
+      vertex -5 4.99572 -45
+      vertex -3.4641 4.99572 -43.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.82843 4.99572 -44.4784
+      vertex -5 4.99572 -45
+      vertex -3.17341 4.99572 -44.085
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.43505 4.99572 -44.8234
+      vertex -5 4.99572 -45
+      vertex -2.82843 4.99572 -44.4784
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.53073 4.99572 -45.3455
+      vertex -5 4.99572 -45
+      vertex -2 4.99572 -45.1141
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2 4.99572 -45.1141
+      vertex -5 4.99572 -45
+      vertex -2.43505 4.99572 -44.8234
+    endloop
+  endfacet
+  facet normal 0.0654257 0.997857 -0
+    outer loop
+      vertex 48.2605 4.97864 -58.1308
+      vertex 48 4.99572 48.1308
+      vertex 48.2605 4.97864 48.1308
+    endloop
+  endfacet
+  facet normal 0.0654257 0.997857 0
+    outer loop
+      vertex 48 4.99572 48.1308
+      vertex 48.2605 4.97864 -58.1308
+      vertex 48 4.99572 -58.1308
+    endloop
+  endfacet
+  facet normal -0.193423 0.972431 -0.130251
+    outer loop
+      vertex -48.256 4.94479 -58.3902
+      vertex -48.5165 4.92772 -58.1308
+      vertex -48.2605 4.97864 -58.1308
+    endloop
+  endfacet
+  facet normal 0.636888 0.726412 -0.258261
+    outer loop
+      vertex 49.3392 4.33916 -58.6429
+      vertex 49.1529 4.5025 -58.6429
+      vertex 49.1941 4.55622 -58.3902
+    endloop
+  endfacet
+  facet normal 0.914834 0.31043 -0.258286
+    outer loop
+      vertex 49.8293 3.49017 -58.6429
+      vertex 49.7497 3.72475 -58.6429
+      vertex 49.8947 3.50769 -58.3902
+    endloop
+  endfacet
+  facet normal 0.188449 -0.94751 0.258286
+    outer loop
+      vertex 48.4902 0.170672 48.6429
+      vertex 48.2472 0.122342 48.6429
+      vertex 48.5077 0.105268 48.3902
+    endloop
+  endfacet
+  facet normal 0.310628 -0.914771 0.258273
+    outer loop
+      vertex 48.7247 0.250301 48.6429
+      vertex 48.4902 0.170672 48.6429
+      vertex 48.5077 0.105268 48.3902
+    endloop
+  endfacet
+  facet normal -0.831531 0.555478 0
+    outer loop
+      vertex -49.7283 3.99786 -58.1308
+      vertex -49.5833 4.21492 48.1308
+      vertex -49.5833 4.21492 -58.1308
+    endloop
+  endfacet
+  facet normal -0.831531 0.555478 0
+    outer loop
+      vertex -49.5833 4.21492 48.1308
+      vertex -49.7283 3.99786 -58.1308
+      vertex -49.7283 3.99786 48.1308
+    endloop
+  endfacet
+  facet normal 0.0648529 -0.989359 0.130239
+    outer loop
+      vertex 48 0.0384302 48.3902
+      vertex 48 0.00428295 48.1308
+      vertex 48.256 0.0552111 48.3902
+    endloop
+  endfacet
+  facet normal 0 -0.258781 -0.965936
+    outer loop
+      vertex -48 1.35712 -59.8939
+      vertex 48 1.60982 -59.9616
+      vertex 48 1.35712 -59.8939
+    endloop
+  endfacet
+  facet normal -0 -0.258781 -0.965936
+    outer loop
+      vertex 48 1.60982 -59.9616
+      vertex -48 1.35712 -59.8939
+      vertex -48 1.60982 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0631903 -0.963996 -0.258298
+    outer loop
+      vertex 48.256 0.0552111 -58.3902
+      vertex 48 0.0384302 -58.3902
+      vertex 48 0.10614 -58.6429
+    endloop
+  endfacet
+  facet normal 0.964026 -0.0631765 -0.25819
+    outer loop
+      vertex 49.9448 1.74396 -58.3902
+      vertex 49.8777 1.7528 -58.6429
+      vertex 49.8939 2 -58.6429
+    endloop
+  endfacet
+  facet normal 0.82882 0.408837 -0.381982
+    outer loop
+      vertex 49.6572 3.68644 -58.8846
+      vertex 49.5534 3.89687 -58.8846
+      vertex 49.6401 3.94693 -58.6429
+    endloop
+  endfacet
+  facet normal -0.99147 0 0.130336
+    outer loop
+      vertex -49.9957 2 48.1308
+      vertex -49.9616 3 48.3902
+      vertex -49.9957 3 48.1308
+    endloop
+  endfacet
+  facet normal -0.99147 0 0.130336
+    outer loop
+      vertex -49.9616 3 48.3902
+      vertex -49.9957 2 48.1308
+      vertex -49.9616 2 48.3902
+    endloop
+  endfacet
+  facet normal -0.65928 0.751898 0
+    outer loop
+      vertex -49.2149 4.58331 -58.1308
+      vertex -49.4112 4.41119 48.1308
+      vertex -49.2149 4.58331 48.1308
+    endloop
+  endfacet
+  facet normal -0.65928 0.751898 0
+    outer loop
+      vertex -49.4112 4.41119 48.1308
+      vertex -49.2149 4.58331 -58.1308
+      vertex -49.4112 4.41119 -58.1308
+    endloop
+  endfacet
+  facet normal -0.00855315 0.130346 0.991432
+    outer loop
+      vertex -48 3.39018 49.9616
+      vertex -48.0509 3.38684 49.9616
+      vertex -48 3.13081 49.9957
+    endloop
+  endfacet
+  facet normal -0.0566694 0.864577 -0.499295
+    outer loop
+      vertex -48.2171 4.64871 -59.1111
+      vertex -48.2341 4.7784 -58.8846
+      vertex -48 4.66294 -59.1111
+    endloop
+  endfacet
+  facet normal -0.321463 0.946922 0
+    outer loop
+      vertex -48.5165 4.92772 -58.1308
+      vertex -48.7637 4.8438 48.1308
+      vertex -48.5165 4.92772 48.1308
+    endloop
+  endfacet
+  facet normal -0.321463 0.946922 0
+    outer loop
+      vertex -48.7637 4.8438 48.1308
+      vertex -48.5165 4.92772 -58.1308
+      vertex -48.7637 4.8438 -58.1308
+    endloop
+  endfacet
+  facet normal 0.0648686 0.989359 0.13023
+    outer loop
+      vertex 48.2605 4.97864 48.1308
+      vertex 48 4.99572 48.1308
+      vertex 48.256 4.94479 48.3902
+    endloop
+  endfacet
+  facet normal 0.466716 -0.532262 -0.70631
+    outer loop
+      vertex 49.0633 0.936738 -59.3187
+      vertex 48.8028 0.953812 -59.5037
+      vertex 48.9325 1.06754 -59.5037
+    endloop
+  endfacet
+  facet normal 0.193395 -0.972442 -0.130209
+    outer loop
+      vertex 48.5165 0.0722847 -58.1308
+      vertex 48.256 0.0552111 -58.3902
+      vertex 48.5077 0.105268 -58.3902
+    endloop
+  endfacet
+  facet normal 0.0648686 0.989359 -0.13023
+    outer loop
+      vertex 48.256 4.94479 -58.3902
+      vertex 48 4.99572 -58.1308
+      vertex 48.2605 4.97864 -58.1308
+    endloop
+  endfacet
+  facet normal 0.318726 0.93886 -0.130215
+    outer loop
+      vertex 48.7637 4.8438 -58.1308
+      vertex 48.5077 4.89473 -58.3902
+      vertex 48.5165 4.92772 -58.1308
+    endloop
+  endfacet
+  facet normal -0.0604523 -0.922187 0.381991
+    outer loop
+      vertex -48.2341 0.221601 48.8846
+      vertex -48.2472 0.122342 48.6429
+      vertex -48 0.206255 48.8846
+    endloop
+  endfacet
+  facet normal 0 -0.991447 -0.130513
+    outer loop
+      vertex -48 0.0384302 -58.3902
+      vertex 48 0.00428295 -58.1308
+      vertex -48 0.00428295 -58.1308
+    endloop
+  endfacet
+  facet normal 0 -0.991447 -0.130513
+    outer loop
+      vertex 48 0.00428295 -58.1308
+      vertex -48 0.0384302 -58.3902
+      vertex 48 0.0384302 -58.3902
+    endloop
+  endfacet
+  facet normal -0.123368 -0.363305 0.923466
+    outer loop
+      vertex -48.1664 1.37903 49.8939
+      vertex -48.246 1.40606 49.8939
+      vertex -48.2289 1.14556 49.7937
+    endloop
+  endfacet
+  facet normal 0.82881 0.408847 0.381993
+    outer loop
+      vertex 49.7497 3.72475 48.6429
+      vertex 49.6401 3.94693 48.6429
+      vertex 49.6572 3.68644 48.8846
+    endloop
+  endfacet
+  facet normal 0.474078 -0.160954 0.865647
+    outer loop
+      vertex 48.8544 1.77106 49.7937
+      vertex 48.8172 1.66149 49.7937
+      vertex 49.0266 1.57479 49.6629
+    endloop
+  endfacet
+  facet normal 0.506732 -0.338481 0.792876
+    outer loop
+      vertex 49.142 1.34065 49.5037
+      vertex 48.8815 1.32358 49.6629
+      vertex 49.0462 1.19723 49.5037
+    endloop
+  endfacet
+  facet normal 0.803139 0.536806 -0.258469
+    outer loop
+      vertex 49.6401 3.94693 -58.6429
+      vertex 49.5562 4.19413 -58.3902
+      vertex 49.6988 3.98078 -58.3902
+    endloop
+  endfacet
+  facet normal 0.896812 -0.442412 0
+    outer loop
+      vertex 49.7283 1.00214 48.1308
+      vertex 49.8438 1.23627 -58.1308
+      vertex 49.8438 1.23627 48.1308
+    endloop
+  endfacet
+  facet normal 0.896812 -0.442412 0
+    outer loop
+      vertex 49.8438 1.23627 -58.1308
+      vertex 49.7283 1.00214 48.1308
+      vertex 49.7283 1.00214 -58.1308
+    endloop
+  endfacet
+  facet normal 0.474141 -0.160884 -0.865625
+    outer loop
+      vertex 49.0266 1.57479 -59.6629
+      vertex 48.8544 1.77106 -59.7937
+      vertex 49.0733 1.71242 -59.6629
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 0.00428295 -5
+      vertex 0 0.00428295 -39.55
+      vertex 5 0.00428295 -5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 0.00428295 -5
+      vertex -0.274104 0.00428295 -39.568
+      vertex 0 0.00428295 -39.55
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 0.00428295 -5
+      vertex -0.54352 0.00428295 -39.6216
+      vertex -0.274104 0.00428295 -39.568
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 0.00428295 -5
+      vertex -0.803635 0.00428295 -39.7099
+      vertex -0.54352 0.00428295 -39.6216
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 0.00428295 -5
+      vertex -1.05 0.00428295 -39.8313
+      vertex -0.803635 0.00428295 -39.7099
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 0.00428295 -5
+      vertex -1.2784 0.00428295 -39.984
+      vertex -1.05 0.00428295 -39.8313
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 0.00428295 -5
+      vertex -1.48492 0.00428295 -40.1651
+      vertex -1.2784 0.00428295 -39.984
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 0.00428295 -5
+      vertex -1.66604 0.00428295 -40.3716
+      vertex -1.48492 0.00428295 -40.1651
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 0.00428295 -5
+      vertex -1.81865 0.00428295 -40.6
+      vertex -1.66604 0.00428295 -40.3716
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 0.00428295 -45
+      vertex -1.81865 0.00428295 -40.6
+      vertex -5 0.00428295 -5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.81865 0.00428295 -40.6
+      vertex -5 0.00428295 -45
+      vertex -1.94015 0.00428295 -40.8464
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.94015 0.00428295 -40.8464
+      vertex -5 0.00428295 -45
+      vertex -2.02844 0.00428295 -41.1065
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.02844 0.00428295 -41.1065
+      vertex -5 0.00428295 -45
+      vertex -2.08203 0.00428295 -41.3759
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.08203 0.00428295 -41.3759
+      vertex -5 0.00428295 -45
+      vertex -2.1 0.00428295 -41.65
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -0.274104 0.00428295 -43.732
+      vertex -5 0.00428295 -45
+      vertex 0 0.00428295 -43.75
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -0.54352 0.00428295 -43.6784
+      vertex -5 0.00428295 -45
+      vertex -0.274104 0.00428295 -43.732
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -0.803635 0.00428295 -43.5901
+      vertex -5 0.00428295 -45
+      vertex -0.54352 0.00428295 -43.6784
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -1.05 0.00428295 -43.4687
+      vertex -5 0.00428295 -45
+      vertex -0.803635 0.00428295 -43.5901
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -1.2784 0.00428295 -43.316
+      vertex -5 0.00428295 -45
+      vertex -1.05 0.00428295 -43.4687
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -1.48492 0.00428295 -43.1349
+      vertex -5 0.00428295 -45
+      vertex -1.2784 0.00428295 -43.316
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -1.66604 0.00428295 -42.9284
+      vertex -5 0.00428295 -45
+      vertex -1.48492 0.00428295 -43.1349
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -1.81865 0.00428295 -42.7
+      vertex -5 0.00428295 -45
+      vertex -1.66604 0.00428295 -42.9284
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -1.94015 0.00428295 -42.4536
+      vertex -5 0.00428295 -45
+      vertex -1.81865 0.00428295 -42.7
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -2.02844 0.00428295 -42.1935
+      vertex -5 0.00428295 -45
+      vertex -1.94015 0.00428295 -42.4536
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -2.08203 0.00428295 -41.9241
+      vertex -5 0.00428295 -45
+      vertex -2.02844 0.00428295 -42.1935
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -2.1 0.00428295 -41.65
+      vertex -5 0.00428295 -45
+      vertex -2.08203 0.00428295 -41.9241
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 0.00428295 5
+      vertex 5 0.00428295 35
+      vertex -5 0.00428295 35
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 5 0.00428295 35
+      vertex -5 0.00428295 5
+      vertex 5 0.00428295 5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -48 0.00428295 48.1308
+      vertex 0 0.00428295 43.75
+      vertex 48 0.00428295 48.1308
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -48 0.00428295 48.1308
+      vertex -0.274104 0.00428295 43.732
+      vertex 0 0.00428295 43.75
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -48 0.00428295 48.1308
+      vertex -0.54352 0.00428295 43.6784
+      vertex -0.274104 0.00428295 43.732
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -48 0.00428295 48.1308
+      vertex -0.803635 0.00428295 43.5901
+      vertex -0.54352 0.00428295 43.6784
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -48 0.00428295 48.1308
+      vertex -1.05 0.00428295 43.4687
+      vertex -0.803635 0.00428295 43.5901
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -48 0.00428295 48.1308
+      vertex -1.2784 0.00428295 43.316
+      vertex -1.05 0.00428295 43.4687
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -48 0.00428295 48.1308
+      vertex -1.48492 0.00428295 43.1349
+      vertex -1.2784 0.00428295 43.316
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -48 0.00428295 48.1308
+      vertex -1.66604 0.00428295 42.9284
+      vertex -1.48492 0.00428295 43.1349
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -48 0.00428295 48.1308
+      vertex -1.81865 0.00428295 42.7
+      vertex -1.66604 0.00428295 42.9284
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -40 0.00428295 35
+      vertex -1.81865 0.00428295 42.7
+      vertex -48 0.00428295 48.1308
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.81865 0.00428295 42.7
+      vertex -40 0.00428295 35
+      vertex -1.94015 0.00428295 42.4536
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.94015 0.00428295 42.4536
+      vertex -40 0.00428295 35
+      vertex -2.02844 0.00428295 42.1935
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 0.00428295 35
+      vertex -2.02844 0.00428295 42.1935
+      vertex -40 0.00428295 35
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.02844 0.00428295 42.1935
+      vertex -5 0.00428295 35
+      vertex -2.08203 0.00428295 41.9241
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.08203 0.00428295 41.9241
+      vertex -5 0.00428295 35
+      vertex -2.1 0.00428295 41.65
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -2.1 0.00428295 41.65
+      vertex -5 0.00428295 35
+      vertex -2.08203 0.00428295 41.3759
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -2.08203 0.00428295 41.3759
+      vertex -5 0.00428295 35
+      vertex -2.02844 0.00428295 41.1065
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -2.02844 0.00428295 41.1065
+      vertex -5 0.00428295 35
+      vertex -1.94015 0.00428295 40.8464
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -1.94015 0.00428295 40.8464
+      vertex -5 0.00428295 35
+      vertex -1.81865 0.00428295 40.6
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -1.81865 0.00428295 40.6
+      vertex -5 0.00428295 35
+      vertex -1.66604 0.00428295 40.3716
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -1.66604 0.00428295 40.3716
+      vertex -5 0.00428295 35
+      vertex -1.48492 0.00428295 40.1651
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -1.48492 0.00428295 40.1651
+      vertex -5 0.00428295 35
+      vertex -1.2784 0.00428295 39.984
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -1.05 0.00428295 39.8313
+      vertex -5 0.00428295 35
+      vertex -0.803635 0.00428295 39.7099
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -0.803635 0.00428295 39.7099
+      vertex -5 0.00428295 35
+      vertex -0.54352 0.00428295 39.6216
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -0.54352 0.00428295 39.6216
+      vertex -5 0.00428295 35
+      vertex -0.274104 0.00428295 39.568
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -1.2784 0.00428295 39.984
+      vertex -5 0.00428295 35
+      vertex -1.05 0.00428295 39.8313
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -48 0.00428295 48.1308
+      vertex -40 0.00428295 5
+      vertex -40 0.00428295 35
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 0.00428295 -5
+      vertex -5 0.00428295 5
+      vertex -40 0.00428295 5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 0.00428295 5
+      vertex -5 0.00428295 -5
+      vertex 5 0.00428295 5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 0.00428295 -5
+      vertex -40 0.00428295 5
+      vertex -40 0.00428295 -5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -48 0.00428295 48.1308
+      vertex -40 0.00428295 -5
+      vertex -40 0.00428295 5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -48 0.00428295 -58.1308
+      vertex -40 0.00428295 -5
+      vertex -48 0.00428295 48.1308
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -48 0.00428295 -58.1308
+      vertex -5 0.00428295 -45
+      vertex -40 0.00428295 -45
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -5 0.00428295 -45
+      vertex -48 0.00428295 -58.1308
+      vertex 5 0.00428295 -45
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 48 0.00428295 -58.1308
+      vertex 5 0.00428295 -45
+      vertex -48 0.00428295 -58.1308
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -40 0.00428295 -5
+      vertex -48 0.00428295 -58.1308
+      vertex -40 0.00428295 -45
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.274104 0.00428295 43.732
+      vertex 48 0.00428295 48.1308
+      vertex 0 0.00428295 43.75
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.54352 0.00428295 43.6784
+      vertex 48 0.00428295 48.1308
+      vertex 0.274104 0.00428295 43.732
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.803635 0.00428295 43.5901
+      vertex 48 0.00428295 48.1308
+      vertex 0.54352 0.00428295 43.6784
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.05 0.00428295 43.4687
+      vertex 48 0.00428295 48.1308
+      vertex 0.803635 0.00428295 43.5901
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.2784 0.00428295 43.316
+      vertex 48 0.00428295 48.1308
+      vertex 1.05 0.00428295 43.4687
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.48492 0.00428295 43.1349
+      vertex 48 0.00428295 48.1308
+      vertex 1.2784 0.00428295 43.316
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.66604 0.00428295 42.9284
+      vertex 48 0.00428295 48.1308
+      vertex 1.48492 0.00428295 43.1349
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.81865 0.00428295 42.7
+      vertex 48 0.00428295 48.1308
+      vertex 1.66604 0.00428295 42.9284
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 40 0.00428295 35
+      vertex 1.81865 0.00428295 42.7
+      vertex 1.94015 0.00428295 42.4536
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 40 0.00428295 35
+      vertex 1.94015 0.00428295 42.4536
+      vertex 2.02844 0.00428295 42.1935
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 35
+      vertex 2.02844 0.00428295 42.1935
+      vertex 2.08203 0.00428295 41.9241
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 35
+      vertex 2.08203 0.00428295 41.9241
+      vertex 2.1 0.00428295 41.65
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 35
+      vertex 2.1 0.00428295 41.65
+      vertex 2.08203 0.00428295 41.3759
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 35
+      vertex 2.08203 0.00428295 41.3759
+      vertex 2.02844 0.00428295 41.1065
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 35
+      vertex 2.02844 0.00428295 41.1065
+      vertex 1.94015 0.00428295 40.8464
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 35
+      vertex 1.94015 0.00428295 40.8464
+      vertex 1.81865 0.00428295 40.6
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 35
+      vertex 1.81865 0.00428295 40.6
+      vertex 1.66604 0.00428295 40.3716
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 35
+      vertex 1.66604 0.00428295 40.3716
+      vertex 1.48492 0.00428295 40.1651
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 35
+      vertex 1.48492 0.00428295 40.1651
+      vertex 1.2784 0.00428295 39.984
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 35
+      vertex 1.2784 0.00428295 39.984
+      vertex 1.05 0.00428295 39.8313
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 35
+      vertex 1.05 0.00428295 39.8313
+      vertex 0.803635 0.00428295 39.7099
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 35
+      vertex 0.803635 0.00428295 39.7099
+      vertex 0.54352 0.00428295 39.6216
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 35
+      vertex 0.54352 0.00428295 39.6216
+      vertex 0.274104 0.00428295 39.568
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -0.274104 0.00428295 39.568
+      vertex -5 0.00428295 35
+      vertex 0 0.00428295 39.55
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 35
+      vertex 0 0.00428295 39.55
+      vertex -5 0.00428295 35
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0.00428295 39.55
+      vertex 5 0.00428295 35
+      vertex 0.274104 0.00428295 39.568
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 2.02844 0.00428295 42.1935
+      vertex 5 0.00428295 35
+      vertex 40 0.00428295 35
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.81865 0.00428295 42.7
+      vertex 40 0.00428295 35
+      vertex 48 0.00428295 48.1308
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 40 0.00428295 5
+      vertex 48 0.00428295 48.1308
+      vertex 40 0.00428295 35
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 -5
+      vertex 5 0.00428295 5
+      vertex -5 0.00428295 -5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 5
+      vertex 5 0.00428295 -5
+      vertex 40 0.00428295 5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 40 0.00428295 -5
+      vertex 40 0.00428295 5
+      vertex 5 0.00428295 -5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 40 0.00428295 -5
+      vertex 48 0.00428295 48.1308
+      vertex 40 0.00428295 5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 48 0.00428295 -58.1308
+      vertex 40 0.00428295 -5
+      vertex 40 0.00428295 -45
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 40 0.00428295 -5
+      vertex 48 0.00428295 -58.1308
+      vertex 48 0.00428295 48.1308
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 -45
+      vertex 48 0.00428295 -58.1308
+      vertex 40 0.00428295 -45
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.274104 0.00428295 -39.568
+      vertex 5 0.00428295 -5
+      vertex 0 0.00428295 -39.55
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.54352 0.00428295 -39.6216
+      vertex 5 0.00428295 -5
+      vertex 0.274104 0.00428295 -39.568
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.803635 0.00428295 -39.7099
+      vertex 5 0.00428295 -5
+      vertex 0.54352 0.00428295 -39.6216
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.05 0.00428295 -39.8313
+      vertex 5 0.00428295 -5
+      vertex 0.803635 0.00428295 -39.7099
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.2784 0.00428295 -39.984
+      vertex 5 0.00428295 -5
+      vertex 1.05 0.00428295 -39.8313
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.48492 0.00428295 -40.1651
+      vertex 5 0.00428295 -5
+      vertex 1.2784 0.00428295 -39.984
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.66604 0.00428295 -40.3716
+      vertex 5 0.00428295 -5
+      vertex 1.48492 0.00428295 -40.1651
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.81865 0.00428295 -40.6
+      vertex 5 0.00428295 -5
+      vertex 1.66604 0.00428295 -40.3716
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 -45
+      vertex 1.81865 0.00428295 -40.6
+      vertex 1.94015 0.00428295 -40.8464
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 -45
+      vertex 1.94015 0.00428295 -40.8464
+      vertex 2.02844 0.00428295 -41.1065
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 -45
+      vertex 2.02844 0.00428295 -41.1065
+      vertex 2.08203 0.00428295 -41.3759
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 -45
+      vertex 2.08203 0.00428295 -41.3759
+      vertex 2.1 0.00428295 -41.65
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 -45
+      vertex 2.1 0.00428295 -41.65
+      vertex 2.08203 0.00428295 -41.9241
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 0.00428295 -45
+      vertex 0 0.00428295 -43.75
+      vertex -5 0.00428295 -45
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0.00428295 -43.75
+      vertex 5 0.00428295 -45
+      vertex 0.274104 0.00428295 -43.732
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.81865 0.00428295 -40.6
+      vertex 5 0.00428295 -45
+      vertex 5 0.00428295 -5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 2.02844 0.00428295 -42.1935
+      vertex 5 0.00428295 -45
+      vertex 2.08203 0.00428295 -41.9241
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.94015 0.00428295 -42.4536
+      vertex 5 0.00428295 -45
+      vertex 2.02844 0.00428295 -42.1935
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.81865 0.00428295 -42.7
+      vertex 5 0.00428295 -45
+      vertex 1.94015 0.00428295 -42.4536
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.66604 0.00428295 -42.9284
+      vertex 5 0.00428295 -45
+      vertex 1.81865 0.00428295 -42.7
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.48492 0.00428295 -43.1349
+      vertex 5 0.00428295 -45
+      vertex 1.66604 0.00428295 -42.9284
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.2784 0.00428295 -43.316
+      vertex 5 0.00428295 -45
+      vertex 1.48492 0.00428295 -43.1349
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.05 0.00428295 -43.4687
+      vertex 5 0.00428295 -45
+      vertex 1.2784 0.00428295 -43.316
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.803635 0.00428295 -43.5901
+      vertex 5 0.00428295 -45
+      vertex 1.05 0.00428295 -43.4687
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.54352 0.00428295 -43.6784
+      vertex 5 0.00428295 -45
+      vertex 0.803635 0.00428295 -43.5901
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.274104 0.00428295 -43.732
+      vertex 5 0.00428295 -45
+      vertex 0.54352 0.00428295 -43.6784
+    endloop
+  endfacet
+  facet normal 0.0654015 -0.997859 0
+    outer loop
+      vertex 48 0.00428295 -58.1308
+      vertex 48.2605 0.0213566 48.1308
+      vertex 48 0.00428295 48.1308
+    endloop
+  endfacet
+  facet normal 0.0654015 -0.997859 0
+    outer loop
+      vertex 48.2605 0.0213566 48.1308
+      vertex 48 0.00428295 -58.1308
+      vertex 48.2605 0.0213566 -58.1308
+    endloop
+  endfacet
+  facet normal 0.188437 -0.947516 -0.258274
+    outer loop
+      vertex 48.256 0.0552111 -58.3902
+      vertex 48.2472 0.122342 -58.6429
+      vertex 48.5077 0.105268 -58.3902
+    endloop
+  endfacet
+  facet normal 0.906365 0.180549 -0.381976
+    outer loop
+      vertex 49.8777 3.2472 -58.6429
+      vertex 49.7326 3.46426 -58.8846
+      vertex 49.8293 3.49017 -58.6429
+    endloop
+  endfacet
+  facet normal -0.997852 -0.0655045 0
+    outer loop
+      vertex -49.9786 1.73951 -58.1308
+      vertex -49.9957 2 48.1308
+      vertex -49.9957 2 -58.1308
+    endloop
+  endfacet
+  facet normal -0.997852 -0.0655045 0
+    outer loop
+      vertex -49.9957 2 48.1308
+      vertex -49.9786 1.73951 -58.1308
+      vertex -49.9786 1.73951 48.1308
+    endloop
+  endfacet
+  facet normal -0.938872 0.318655 0.1303
+    outer loop
+      vertex -49.8438 3.76373 48.1308
+      vertex -49.9277 3.51653 48.1308
+      vertex -49.8947 3.50769 48.3902
+    endloop
+  endfacet
+  facet normal 0 0.923887 -0.382666
+    outer loop
+      vertex 48 4.79375 -58.8846
+      vertex -48 4.89386 -58.6429
+      vertex 48 4.89386 -58.6429
+    endloop
+  endfacet
+  facet normal 0 0.923887 -0.382666
+    outer loop
+      vertex -48 4.89386 -58.6429
+      vertex 48 4.79375 -58.8846
+      vertex -48 4.79375 -58.8846
+    endloop
+  endfacet
+  facet normal 0.213155 -0.318953 -0.92349
+    outer loop
+      vertex 48.4423 1.23393 -59.7937
+      vertex 48.3214 1.44325 -59.8939
+      vertex 48.5385 1.29822 -59.7937
+    endloop
+  endfacet
+  facet normal -0 0.382959 0.923765
+    outer loop
+      vertex -48 3.88458 49.7937
+      vertex 48 3.64288 49.8939
+      vertex 48 3.88458 49.7937
+    endloop
+  endfacet
+  facet normal 0 0.382959 0.923765
+    outer loop
+      vertex 48 3.64288 49.8939
+      vertex -48 3.88458 49.7937
+      vertex -48 3.64288 49.8939
+    endloop
+  endfacet
+  facet normal -0.550929 0.824323 0.130263
+    outer loop
+      vertex -48.9979 4.72834 48.1308
+      vertex -49.2149 4.58331 48.1308
+      vertex -49.1941 4.55622 48.3902
+    endloop
+  endfacet
+  facet normal -0.720485 -0.481202 0.499345
+    outer loop
+      vertex -49.4401 1.16853 49.1111
+      vertex -49.5534 1.10313 48.8846
+      vertex -49.4231 0.908037 48.8846
+    endloop
+  endfacet
+  facet normal 0 0.793422 0.608672
+    outer loop
+      vertex 48 4.66294 49.1111
+      vertex -48 4.50368 49.3187
+      vertex 48 4.50368 49.3187
+    endloop
+  endfacet
+  facet normal 0 0.793422 0.608672
+    outer loop
+      vertex -48 4.50368 49.3187
+      vertex 48 4.66294 49.1111
+      vertex -48 4.66294 49.1111
+    endloop
+  endfacet
+  facet normal -0.0648686 0.989359 -0.13023
+    outer loop
+      vertex -48.256 4.94479 -58.3902
+      vertex -48.2605 4.97864 -58.1308
+      vertex -48 4.99572 -58.1308
+    endloop
+  endfacet
+  facet normal -0.195085 0.980786 0
+    outer loop
+      vertex -48.2605 4.97864 -58.1308
+      vertex -48.5165 4.92772 48.1308
+      vertex -48.2605 4.97864 48.1308
+    endloop
+  endfacet
+  facet normal -0.195085 0.980786 0
+    outer loop
+      vertex -48.5165 4.92772 48.1308
+      vertex -48.2605 4.97864 -58.1308
+      vertex -48.5165 4.92772 -58.1308
+    endloop
+  endfacet
+  facet normal -0.255289 0.751895 -0.607849
+    outer loop
+      vertex -48.3892 4.45244 -59.3187
+      vertex -48.5754 4.38922 -59.3187
+      vertex -48.4304 4.60628 -59.1111
+    endloop
+  endfacet
+  facet normal 0 0.965927 -0.258816
+    outer loop
+      vertex 48 4.89386 -58.6429
+      vertex -48 4.96157 -58.3902
+      vertex 48 4.96157 -58.3902
+    endloop
+  endfacet
+  facet normal 0 0.965927 -0.258816
+    outer loop
+      vertex -48 4.96157 -58.3902
+      vertex 48 4.89386 -58.6429
+      vertex -48 4.89386 -58.6429
+    endloop
+  endfacet
+  facet normal 0.875161 0.296968 -0.381972
+    outer loop
+      vertex 49.8293 3.49017 -58.6429
+      vertex 49.7326 3.46426 -58.8846
+      vertex 49.7497 3.72475 -58.6429
+    endloop
+  endfacet
+  facet normal -0.0748487 0.376296 -0.923471
+    outer loop
+      vertex -48.1664 3.62097 -59.8939
+      vertex -48.2289 3.85444 -59.7937
+      vertex -48.0839 3.63738 -59.8939
+    endloop
+  endfacet
+  facet normal 0.0631869 0.963996 -0.258299
+    outer loop
+      vertex 48.256 4.94479 -58.3902
+      vertex 48 4.89386 -58.6429
+      vertex 48 4.96157 -58.3902
+    endloop
+  endfacet
+  facet normal 0.609286 -0.694935 0.381884
+    outer loop
+      vertex 49.3392 0.660839 48.6429
+      vertex 49.092 0.576926 48.8846
+      vertex 49.1529 0.4975 48.6429
+    endloop
+  endfacet
+  facet normal 0.751829 -0.255136 0.607995
+    outer loop
+      vertex 49.6063 1.5696 49.1111
+      vertex 49.3892 1.42457 49.3187
+      vertex 49.5364 1.36362 49.1111
+    endloop
+  endfacet
+  facet normal 0.0648444 -0.989359 0.130247
+    outer loop
+      vertex 48.256 0.0552111 48.3902
+      vertex 48 0.00428295 48.1308
+      vertex 48.2605 0.0213566 48.1308
+    endloop
+  endfacet
+  facet normal 0.193452 -0.972423 0.130268
+    outer loop
+      vertex 48.5165 0.0722847 48.1308
+      vertex 48.256 0.0552111 48.3902
+      vertex 48.2605 0.0213566 48.1308
+    endloop
+  endfacet
+  facet normal -0.65367 -0.745483 0.130271
+    outer loop
+      vertex -49.1941 0.443782 48.3902
+      vertex -49.4112 0.588815 48.1308
+      vertex -49.2149 0.416691 48.1308
+    endloop
+  endfacet
+  facet normal 0.0631903 -0.963996 0.258298
+    outer loop
+      vertex 48 0.10614 48.6429
+      vertex 48 0.0384302 48.3902
+      vertex 48.256 0.0552111 48.3902
+    endloop
+  endfacet
+  facet normal -0.751829 0.255136 0.607995
+    outer loop
+      vertex -49.5364 3.63638 49.1111
+      vertex -49.6063 3.4304 49.1111
+      vertex -49.3892 3.57543 49.3187
+    endloop
+  endfacet
+  facet normal 0.831531 0.555478 0
+    outer loop
+      vertex 49.7283 3.99786 48.1308
+      vertex 49.5833 4.21492 -58.1308
+      vertex 49.5833 4.21492 48.1308
+    endloop
+  endfacet
+  facet normal 0.831531 0.555478 0
+    outer loop
+      vertex 49.5833 4.21492 -58.1308
+      vertex 49.7283 3.99786 48.1308
+      vertex 49.7283 3.99786 -58.1308
+    endloop
+  endfacet
+  facet normal 0.408667 -0.828943 0.381896
+    outer loop
+      vertex 48.8969 0.446571 48.8846
+      vertex 48.6864 0.342795 48.8846
+      vertex 48.9469 0.359869 48.6429
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 50 0 50
-      vertex 50 5 -60
-      vertex 50 5 50
+      vertex 49.9957 2 48.1308
+      vertex 49.9957 3 -58.1308
+      vertex 49.9957 3 48.1308
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 50 5 -60
-      vertex 50 0 50
-      vertex 50 0 -60
+      vertex 49.9957 3 -58.1308
+      vertex 49.9957 2 48.1308
+      vertex 49.9957 2 -58.1308
+    endloop
+  endfacet
+  facet normal 0.653662 0.745491 0.130268
+    outer loop
+      vertex 49.2149 4.58331 48.1308
+      vertex 49.1941 4.55622 48.3902
+      vertex 49.4112 4.41119 48.1308
+    endloop
+  endfacet
+  facet normal 0.491118 -0.0975 0.86562
+    outer loop
+      vertex 49.1016 1.85497 49.6629
+      vertex 48.8544 1.77106 49.7937
+      vertex 49.0733 1.71242 49.6629
+    endloop
+  endfacet
+  facet normal 0.408726 -0.828882 0.381965
+    outer loop
+      vertex 48.9469 0.359869 48.6429
+      vertex 48.6864 0.342795 48.8846
+      vertex 48.7247 0.250301 48.6429
+    endloop
+  endfacet
+  facet normal 0.258645 -0.0172667 -0.965818
+    outer loop
+      vertex 48.6374 1.91609 -59.8939
+      vertex 48.3868 1.94907 -59.9616
+      vertex 48.3902 2 -59.9616
+    endloop
+  endfacet
+  facet normal 0.659288 -0.75189 0
+    outer loop
+      vertex 49.2149 0.416691 -58.1308
+      vertex 49.4112 0.588815 48.1308
+      vertex 49.2149 0.416691 48.1308
+    endloop
+  endfacet
+  facet normal 0.659288 -0.75189 0
+    outer loop
+      vertex 49.4112 0.588815 48.1308
+      vertex 49.2149 0.416691 -58.1308
+      vertex 49.4112 0.588815 -58.1308
+    endloop
+  endfacet
+  facet normal 0.310491 -0.914782 -0.258397
+    outer loop
+      vertex 48.7507 0.187746 -58.3902
+      vertex 48.5077 0.105268 -58.3902
+      vertex 48.7247 0.250301 -58.6429
+    endloop
+  endfacet
+  facet normal 0.0648529 -0.989359 -0.130239
+    outer loop
+      vertex 48.256 0.0552111 -58.3902
+      vertex 48 0.00428295 -58.1308
+      vertex 48 0.0384302 -58.3902
+    endloop
+  endfacet
+  facet normal 0.0604423 -0.922191 -0.381982
+    outer loop
+      vertex 48.2472 0.122342 -58.6429
+      vertex 48 0.10614 -58.6429
+      vertex 48 0.206255 -58.8846
+    endloop
+  endfacet
+  facet normal 0.227596 -0.670291 -0.706336
+    outer loop
+      vertex 48.3892 0.547558 -59.3187
+      vertex 48.3413 0.726242 -59.5037
+      vertex 48.5754 0.610782 -59.3187
+    endloop
+  endfacet
+  facet normal 0.0648444 -0.989359 -0.130247
+    outer loop
+      vertex 48.2605 0.0213566 -58.1308
+      vertex 48 0.00428295 -58.1308
+      vertex 48.256 0.0552111 -58.3902
+    endloop
+  endfacet
+  facet normal -0.491118 -0.0975 -0.86562
+    outer loop
+      vertex -49.0733 1.71242 -59.6629
+      vertex -49.1016 1.85497 -59.6629
+      vertex -48.8544 1.77106 -59.7937
+    endloop
+  endfacet
+  facet normal 0 -0.608618 -0.793463
+    outer loop
+      vertex -48 0.681309 -59.5037
+      vertex 48 0.88886 -59.6629
+      vertex 48 0.681309 -59.5037
+    endloop
+  endfacet
+  facet normal -0 -0.608618 -0.793463
+    outer loop
+      vertex 48 0.88886 -59.6629
+      vertex -48 0.681309 -59.5037
+      vertex -48 0.88886 -59.6629
+    endloop
+  endfacet
+  facet normal -0.694328 -0.137897 -0.706324
+    outer loop
+      vertex -49.2738 1.6587 -59.5037
+      vertex -49.4908 1.80373 -59.3187
+      vertex -49.3074 1.82788 -59.5037
+    endloop
+  endfacet
+  facet normal 0.609357 -0.69481 -0.382
+    outer loop
+      vertex 49.3392 0.660839 -58.6429
+      vertex 49.092 0.576926 -58.8846
+      vertex 49.2684 0.731631 -58.8846
+    endloop
+  endfacet
+  facet normal 0.706344 -0.046425 -0.706344
+    outer loop
+      vertex 49.4908 1.80373 -59.3187
+      vertex 49.3187 2 -59.5037
+      vertex 49.5037 2 -59.3187
+    endloop
+  endfacet
+  facet normal 0.864562 0.0565594 -0.499334
+    outer loop
+      vertex 49.6629 3 -59.1111
+      vertex 49.6487 3.21706 -59.1111
+      vertex 49.7784 3.23413 -58.8846
+    endloop
+  endfacet
+  facet normal 0 0.130351 -0.991468
+    outer loop
+      vertex -48 3.13081 -59.9957
+      vertex 48 3.39018 -59.9616
+      vertex 48 3.13081 -59.9957
+    endloop
+  endfacet
+  facet normal 0 0.130351 -0.991468
+    outer loop
+      vertex 48 3.39018 -59.9616
+      vertex -48 3.13081 -59.9957
+      vertex -48 3.39018 -59.9616
+    endloop
+  endfacet
+  facet normal 0.803322 0.53664 -0.258246
+    outer loop
+      vertex 49.6401 3.94693 -58.6429
+      vertex 49.5025 4.15291 -58.6429
+      vertex 49.5562 4.19413 -58.3902
+    endloop
+  endfacet
+  facet normal 0.745478 0.653675 0.130271
+    outer loop
+      vertex 49.5833 4.21492 48.1308
+      vertex 49.4112 4.41119 48.1308
+      vertex 49.5562 4.19413 48.3902
+    endloop
+  endfacet
+  facet normal 0.609286 0.69493 -0.381894
+    outer loop
+      vertex 49.3392 4.33916 -58.6429
+      vertex 49.092 4.42307 -58.8846
+      vertex 49.1529 4.5025 -58.6429
+    endloop
+  endfacet
+  facet normal 0 0.865959 -0.500115
+    outer loop
+      vertex 48 4.66294 -59.1111
+      vertex -48 4.79375 -58.8846
+      vertex 48 4.79375 -58.8846
+    endloop
+  endfacet
+  facet normal 0 0.865959 -0.500115
+    outer loop
+      vertex -48 4.79375 -58.8846
+      vertex 48 4.66294 -59.1111
+      vertex -48 4.66294 -59.1111
+    endloop
+  endfacet
+  facet normal 0.321463 0.946922 -0
+    outer loop
+      vertex 48.7637 4.8438 -58.1308
+      vertex 48.5165 4.92772 48.1308
+      vertex 48.7637 4.8438 48.1308
+    endloop
+  endfacet
+  facet normal 0.321463 0.946922 0
+    outer loop
+      vertex 48.5165 4.92772 48.1308
+      vertex 48.7637 4.8438 -58.1308
+      vertex 48.5165 4.92772 -58.1308
+    endloop
+  endfacet
+  facet normal 0.481361 0.720416 0.499292
+    outer loop
+      vertex 48.8969 4.55343 48.8846
+      vertex 48.8315 4.44015 49.1111
+      vertex 49.092 4.42307 48.8846
+    endloop
+  endfacet
+  facet normal -0.964002 0.0632527 0.258262
+    outer loop
+      vertex -49.9448 3.25604 48.3902
+      vertex -49.9616 3 48.3902
+      vertex -49.8939 3 48.6429
+    endloop
+  endfacet
+  facet normal -0.864592 -0.0564996 -0.499288
+    outer loop
+      vertex -49.7784 1.76587 -58.8846
+      vertex -49.7937 2 -58.8846
+      vertex -49.6629 2 -59.1111
+    endloop
+  endfacet
+  facet normal -0.491187 0.0978218 -0.865544
+    outer loop
+      vertex -48.877 3.11546 -59.7937
+      vertex -49.1016 3.14503 -59.6629
+      vertex -48.8544 3.22894 -59.7937
+    endloop
+  endfacet
+  facet normal -0.408729 0.828873 0.381982
+    outer loop
+      vertex -48.7247 4.7497 48.6429
+      vertex -48.9469 4.64013 48.6429
+      vertex -48.6864 4.6572 48.8846
+    endloop
+  endfacet
+  facet normal -0.143959 -0.215692 0.965791
+    outer loop
+      vertex -48.1951 1.66209 49.9616
+      vertex -48.3914 1.48997 49.8939
+      vertex -48.3214 1.44325 49.8939
+    endloop
+  endfacet
+  facet normal -0.213009 0.319148 0.923456
+    outer loop
+      vertex -48.3214 3.55675 49.8939
+      vertex -48.5385 3.70178 49.7937
+      vertex -48.3914 3.51003 49.8939
+    endloop
+  endfacet
+  facet normal 0.318726 0.93886 0.130215
+    outer loop
+      vertex 48.5165 4.92772 48.1308
+      vertex 48.5077 4.89473 48.3902
+      vertex 48.7637 4.8438 48.1308
+    endloop
+  endfacet
+  facet normal -0.227602 0.670286 0.706339
+    outer loop
+      vertex -48.3413 4.27376 49.5037
+      vertex -48.5754 4.38922 49.3187
+      vertex -48.5046 4.21831 49.5037
+    endloop
+  endfacet
+  facet normal 0.382838 -0.0251998 0.923472
+    outer loop
+      vertex 48.8846 2 49.7937
+      vertex 48.6429 2 49.8939
+      vertex 48.877 1.88454 49.7937
+    endloop
+  endfacet
+  facet normal 0.143959 0.215692 0.965791
+    outer loop
+      vertex 48.3214 3.55675 49.8939
+      vertex 48.1951 3.33791 49.9616
+      vertex 48.3914 3.51003 49.8939
+    endloop
+  endfacet
+  facet normal 0.0519085 0.792352 0.607852
+    outer loop
+      vertex 48 4.66294 49.1111
+      vertex 48 4.50368 49.3187
+      vertex 48.1963 4.49082 49.3187
+    endloop
+  endfacet
+  facet normal -0.213155 0.318953 0.92349
+    outer loop
+      vertex -48.4423 3.76607 49.7937
+      vertex -48.5385 3.70178 49.7937
+      vertex -48.3214 3.55675 49.8939
+    endloop
+  endfacet
+  facet normal -0.0631869 0.963996 -0.258299
+    outer loop
+      vertex -48 4.89386 -58.6429
+      vertex -48.256 4.94479 -58.3902
+      vertex -48 4.96157 -58.3902
+    endloop
+  endfacet
+  facet normal -0.0648493 0.989358 -0.130249
+    outer loop
+      vertex -48 4.96157 -58.3902
+      vertex -48.256 4.94479 -58.3902
+      vertex -48 4.99572 -58.1308
+    endloop
+  endfacet
+  facet normal -0.442182 0.896925 0
+    outer loop
+      vertex -48.7637 4.8438 -58.1308
+      vertex -48.9979 4.72834 48.1308
+      vertex -48.7637 4.8438 48.1308
+    endloop
+  endfacet
+  facet normal -0.442182 0.896925 0
+    outer loop
+      vertex -48.9979 4.72834 48.1308
+      vertex -48.7637 4.8438 -58.1308
+      vertex -48.9979 4.72834 -58.1308
+    endloop
+  endfacet
+  facet normal -0.550908 0.824333 -0.130286
+    outer loop
+      vertex -48.9808 4.69877 -58.3902
+      vertex -49.1941 4.55622 -58.3902
+      vertex -48.9979 4.72834 -58.1308
+    endloop
+  endfacet
+  facet normal -0.193406 0.972437 -0.130234
+    outer loop
+      vertex -48.5077 4.89473 -58.3902
+      vertex -48.5165 4.92772 -58.1308
+      vertex -48.256 4.94479 -58.3902
+    endloop
+  endfacet
+  facet normal -0.383228 0.77713 -0.499204
+    outer loop
+      vertex -48.6364 4.53636 -59.1111
+      vertex -48.8315 4.44015 -59.1111
+      vertex -48.6864 4.6572 -58.8846
+    endloop
+  endfacet
+  facet normal 0.720482 0.481208 -0.499345
+    outer loop
+      vertex 49.4401 3.83147 -59.1111
+      vertex 49.4231 4.09196 -58.8846
+      vertex 49.5534 3.89687 -58.8846
+    endloop
+  endfacet
+  facet normal -0.745478 0.653675 -0.130271
+    outer loop
+      vertex -49.5562 4.19413 -58.3902
+      vertex -49.5833 4.21492 -58.1308
+      vertex -49.4112 4.41119 -58.1308
+    endloop
+  endfacet
+  facet normal 0.609357 -0.69481 0.382
+    outer loop
+      vertex 49.2684 0.731631 48.8846
+      vertex 49.092 0.576926 48.8846
+      vertex 49.3392 0.660839 48.6429
+    endloop
+  endfacet
+  facet normal 0.278603 -0.820443 0.499253
+    outer loop
+      vertex 48.6364 0.463645 49.1111
+      vertex 48.4643 0.267375 48.8846
+      vertex 48.6864 0.342795 48.8846
+    endloop
+  endfacet
+  facet normal 0.180235 -0.906414 0.382006
+    outer loop
+      vertex 48.4643 0.267375 48.8846
+      vertex 48.2341 0.221601 48.8846
+      vertex 48.2472 0.122342 48.6429
+    endloop
+  endfacet
+  facet normal 0.180277 -0.90642 0.381972
+    outer loop
+      vertex 48.4643 0.267375 48.8846
+      vertex 48.2472 0.122342 48.6429
+      vertex 48.4902 0.170672 48.6429
+    endloop
+  endfacet
+  facet normal 0 -0.965927 0.258816
+    outer loop
+      vertex -48 0.0384302 48.3902
+      vertex 48 0.10614 48.6429
+      vertex -48 0.10614 48.6429
+    endloop
+  endfacet
+  facet normal 0 -0.965927 0.258816
+    outer loop
+      vertex 48 0.10614 48.6429
+      vertex -48 0.0384302 48.3902
+      vertex 48 0.0384302 48.3902
+    endloop
+  endfacet
+  facet normal -0.0327521 -0.499719 0.865568
+    outer loop
+      vertex -48 1.11542 49.7937
+      vertex -48.1155 1.12299 49.7937
+      vertex -48 0.88886 49.6629
+    endloop
+  endfacet
+  facet normal -0.938977 -0.318441 -0.130069
+    outer loop
+      vertex -49.8438 1.23627 -58.1308
+      vertex -49.8947 1.49231 -58.3902
+      vertex -49.8123 1.24934 -58.3902
+    endloop
+  endfacet
+  facet normal -0.154924 -0.778797 0.607844
+    outer loop
+      vertex -48.3892 0.547558 49.3187
+      vertex -48.4304 0.393724 49.1111
+      vertex -48.1963 0.509185 49.3187
+    endloop
+  endfacet
+  facet normal 0 0.923887 0.382666
+    outer loop
+      vertex 48 4.89386 48.6429
+      vertex -48 4.79375 48.8846
+      vertex 48 4.79375 48.8846
+    endloop
+  endfacet
+  facet normal 0 0.923887 0.382666
+    outer loop
+      vertex -48 4.79375 48.8846
+      vertex 48 4.89386 48.6429
+      vertex -48 4.89386 48.6429
+    endloop
+  endfacet
+  facet normal 0.706344 0.046425 0.706344
+    outer loop
+      vertex 49.4908 3.19627 49.3187
+      vertex 49.3187 3 49.5037
+      vertex 49.5037 3 49.3187
+    endloop
+  endfacet
+  facet normal 0.99147 -0 0.130336
+    outer loop
+      vertex 49.9616 2 48.3902
+      vertex 49.9957 3 48.1308
+      vertex 49.9616 3 48.3902
+    endloop
+  endfacet
+  facet normal 0.99147 0 0.130336
+    outer loop
+      vertex 49.9957 3 48.1308
+      vertex 49.9616 2 48.3902
+      vertex 49.9957 2 48.1308
+    endloop
+  endfacet
+  facet normal 0.536781 -0.803183 0.258388
+    outer loop
+      vertex 49.1941 0.443782 48.3902
+      vertex 48.9469 0.359869 48.6429
+      vertex 48.9808 0.30123 48.3902
+    endloop
+  endfacet
+  facet normal 0.318673 -0.938886 -0.130157
+    outer loop
+      vertex 48.7637 0.156198 -58.1308
+      vertex 48.5077 0.105268 -58.3902
+      vertex 48.7507 0.187746 -58.3902
+    endloop
+  endfacet
+  facet normal 0.965936 0 -0.258781
+    outer loop
+      vertex 49.9616 2 -58.3902
+      vertex 49.8939 3 -58.6429
+      vertex 49.9616 3 -58.3902
+    endloop
+  endfacet
+  facet normal 0.965936 0 -0.258781
+    outer loop
+      vertex 49.8939 3 -58.6429
+      vertex 49.9616 2 -58.3902
+      vertex 49.8939 2 -58.6429
+    endloop
+  endfacet
+  facet normal 0.997852 -0.0655045 0
+    outer loop
+      vertex 49.9786 1.73951 48.1308
+      vertex 49.9957 2 -58.1308
+      vertex 49.9957 2 48.1308
+    endloop
+  endfacet
+  facet normal 0.997852 -0.0655045 0
+    outer loop
+      vertex 49.9957 2 -58.1308
+      vertex 49.9786 1.73951 48.1308
+      vertex 49.9786 1.73951 -58.1308
+    endloop
+  endfacet
+  facet normal 0.726406 0.636897 0.258255
+    outer loop
+      vertex 49.5562 4.19413 48.3902
+      vertex 49.3392 4.33916 48.6429
+      vertex 49.5025 4.15291 48.6429
+    endloop
+  endfacet
+  facet normal 0.34412 -0.169441 0.92351
+    outer loop
+      vertex 48.8172 1.66149 49.7937
+      vertex 48.5567 1.67856 49.8939
+      vertex 48.7661 1.55771 49.7937
+    endloop
+  endfacet
+  facet normal -0.0505091 0.254322 0.9658
+    outer loop
+      vertex -48.0839 3.63738 49.8939
+      vertex -48.101 3.37689 49.9616
+      vertex -48.0509 3.38684 49.9616
+    endloop
+  endfacet
+  facet normal 0.258781 0 0.965936
+    outer loop
+      vertex 48.3902 3 49.9616
+      vertex 48.6429 2 49.8939
+      vertex 48.6429 3 49.8939
+    endloop
+  endfacet
+  facet normal 0.258781 0 0.965936
+    outer loop
+      vertex 48.6429 2 49.8939
+      vertex 48.3902 3 49.9616
+      vertex 48.3902 2 49.9616
+    endloop
+  endfacet
+  facet normal 0.889201 -0.438657 -0.130007
+    outer loop
+      vertex 49.7283 1.00214 -58.1308
+      vertex 49.6988 1.01922 -58.3902
+      vertex 49.8438 1.23627 -58.1308
+    endloop
+  endfacet
+  facet normal 0.65367 -0.745483 -0.130271
+    outer loop
+      vertex 49.2149 0.416691 -58.1308
+      vertex 49.1941 0.443782 -58.3902
+      vertex 49.4112 0.588815 -58.1308
+    endloop
+  endfacet
+  facet normal -0.651417 -0.571263 -0.499314
+    outer loop
+      vertex -49.2684 0.731631 -58.8846
+      vertex -49.4231 0.908037 -58.8846
+      vertex -49.1759 0.824125 -59.1111
+    endloop
+  endfacet
+  facet normal -0.546657 -0.269601 -0.792768
+    outer loop
+      vertex -49.142 1.34065 -59.5037
+      vertex -49.2183 1.49536 -59.5037
+      vertex -49.0266 1.57479 -59.6629
+    endloop
+  endfacet
+  facet normal 0 -0.965927 -0.258816
+    outer loop
+      vertex -48 0.10614 -58.6429
+      vertex 48 0.0384302 -58.3902
+      vertex -48 0.0384302 -58.3902
+    endloop
+  endfacet
+  facet normal 0 -0.965927 -0.258816
+    outer loop
+      vertex 48 0.0384302 -58.3902
+      vertex -48 0.10614 -58.6429
+      vertex 48 0.10614 -58.6429
+    endloop
+  endfacet
+  facet normal -0.193452 -0.972423 0.130268
+    outer loop
+      vertex -48.256 0.0552111 48.3902
+      vertex -48.5165 0.0722847 48.1308
+      vertex -48.2605 0.0213566 48.1308
+    endloop
+  endfacet
+  facet normal 0.694829 -0.609333 -0.382002
+    outer loop
+      vertex 49.3392 0.660839 -58.6429
+      vertex 49.2684 0.731631 -58.8846
+      vertex 49.4231 0.908037 -58.8846
+    endloop
+  endfacet
+  facet normal 0.32144 -0.94693 0
+    outer loop
+      vertex 48.5165 0.0722847 -58.1308
+      vertex 48.7637 0.156198 48.1308
+      vertex 48.5165 0.0722847 48.1308
+    endloop
+  endfacet
+  facet normal 0.32144 -0.94693 0
+    outer loop
+      vertex 48.7637 0.156198 48.1308
+      vertex 48.5165 0.0722847 -58.1308
+      vertex 48.7637 0.156198 -58.1308
+    endloop
+  endfacet
+  facet normal -0.255307 -0.751901 -0.607835
+    outer loop
+      vertex -48.4304 0.393724 -59.1111
+      vertex -48.5754 0.610782 -59.3187
+      vertex -48.3892 0.547558 -59.3187
+    endloop
+  endfacet
+  facet normal -0.310491 -0.914782 -0.258397
+    outer loop
+      vertex -48.5077 0.105268 -58.3902
+      vertex -48.7507 0.187746 -58.3902
+      vertex -48.7247 0.250301 -58.6429
+    endloop
+  endfacet
+  facet normal -0.792355 0.0518356 -0.607854
+    outer loop
+      vertex -49.4908 3.19627 -59.3187
+      vertex -49.6629 3 -59.1111
+      vertex -49.6487 3.21706 -59.1111
+    endloop
+  endfacet
+  facet normal -0.546628 -0.269624 -0.79278
+    outer loop
+      vertex -48.9623 1.44443 -59.6629
+      vertex -49.142 1.34065 -59.5037
+      vertex -49.0266 1.57479 -59.6629
+    endloop
+  endfacet
+  facet normal -0.278308 -0.416342 -0.865566
+    outer loop
+      vertex -48.5556 1.03772 -59.6629
+      vertex -48.6764 1.11847 -59.6629
+      vertex -48.5385 1.29822 -59.7937
+    endloop
+  endfacet
+  facet normal 0.154949 0.77878 -0.607859
+    outer loop
+      vertex 48.3892 4.45244 -59.3187
+      vertex 48.1963 4.49082 -59.3187
+      vertex 48.4304 4.60628 -59.1111
+    endloop
+  endfacet
+  facet normal 0.458218 0.401723 -0.792878
+    outer loop
+      vertex 49.0462 3.80277 -59.5037
+      vertex 48.8815 3.67642 -59.6629
+      vertex 48.9325 3.93246 -59.5037
+    endloop
+  endfacet
+  facet normal 0.481441 -0.720275 -0.499418
+    outer loop
+      vertex 49.092 0.576926 -58.8846
+      vertex 48.8315 0.559853 -59.1111
+      vertex 49.0123 0.680702 -59.1111
+    endloop
+  endfacet
+  facet normal 0.288558 0.252864 -0.923469
+    outer loop
+      vertex 48.51 3.39136 -59.8939
+      vertex 48.4546 3.45458 -59.8939
+      vertex 48.6255 3.62549 -59.7937
+    endloop
+  endfacet
+  facet normal 0.849746 -0.169115 -0.499332
+    outer loop
+      vertex 49.7326 1.53574 -58.8846
+      vertex 49.6487 1.78294 -59.1111
+      vertex 49.7784 1.76587 -58.8846
+    endloop
+  endfacet
+  facet normal 0 -0.499987 -0.866033
+    outer loop
+      vertex -48 0.88886 -59.6629
+      vertex 48 1.11542 -59.7937
+      vertex 48 0.88886 -59.6629
+    endloop
+  endfacet
+  facet normal -0 -0.499987 -0.866033
+    outer loop
+      vertex 48 1.11542 -59.7937
+      vertex -48 0.88886 -59.6629
+      vertex -48 1.11542 -59.7937
+    endloop
+  endfacet
+  facet normal 0.792455 0.0520848 -0.607702
+    outer loop
+      vertex 49.5037 3 -59.3187
+      vertex 49.4908 3.19627 -59.3187
+      vertex 49.6629 3 -59.1111
+    endloop
+  endfacet
+  facet normal 0.97248 -0.193326 -0.130031
+    outer loop
+      vertex 49.9786 1.73951 -58.1308
+      vertex 49.9277 1.48347 -58.1308
+      vertex 49.9448 1.74396 -58.3902
+    endloop
+  endfacet
+  facet normal 0.97248 0.193326 0.130031
+    outer loop
+      vertex 49.9786 3.26049 48.1308
+      vertex 49.9277 3.51653 48.1308
+      vertex 49.9448 3.25604 48.3902
+    endloop
+  endfacet
+  facet normal 0.964002 0.0632527 -0.258262
+    outer loop
+      vertex 49.9616 3 -58.3902
+      vertex 49.8939 3 -58.6429
+      vertex 49.9448 3.25604 -58.3902
+    endloop
+  endfacet
+  facet normal 0.118873 0.597721 -0.792842
+    outer loop
+      vertex 48.3413 4.27376 -59.5037
+      vertex 48.145 4.10163 -59.6629
+      vertex 48.1721 4.30741 -59.5037
+    endloop
+  endfacet
+  facet normal 0.408729 0.828873 -0.381982
+    outer loop
+      vertex 48.9469 4.64013 -58.6429
+      vertex 48.6864 4.6572 -58.8846
+      vertex 48.7247 4.7497 -58.6429
+    endloop
+  endfacet
+  facet normal 0.193406 0.972437 -0.130234
+    outer loop
+      vertex 48.5077 4.89473 -58.3902
+      vertex 48.256 4.94479 -58.3902
+      vertex 48.5165 4.92772 -58.1308
+    endloop
+  endfacet
+  facet normal 0.193423 0.972431 -0.130251
+    outer loop
+      vertex 48.5165 4.92772 -58.1308
+      vertex 48.256 4.94479 -58.3902
+      vertex 48.2605 4.97864 -58.1308
+    endloop
+  endfacet
+  facet normal 0.653662 0.745491 -0.130268
+    outer loop
+      vertex 49.4112 4.41119 -58.1308
+      vertex 49.1941 4.55622 -58.3902
+      vertex 49.2149 4.58331 -58.1308
+    endloop
+  endfacet
+  facet normal 0.427249 0.86643 -0.258374
+    outer loop
+      vertex 48.9469 4.64013 -58.6429
+      vertex 48.7247 4.7497 -58.6429
+      vertex 48.9808 4.69877 -58.3902
+    endloop
+  endfacet
+  facet normal 0.938872 0.318655 0.1303
+    outer loop
+      vertex 49.9277 3.51653 48.1308
+      vertex 49.8438 3.76373 48.1308
+      vertex 49.8947 3.50769 48.3902
+    endloop
+  endfacet
+  facet normal 0.0169617 0.258743 0.965797
+    outer loop
+      vertex 48 3.64288 49.8939
+      vertex 48 3.39018 49.9616
+      vertex 48.0839 3.63738 49.8939
+    endloop
+  endfacet
+  facet normal 0.318679 0.938883 -0.130164
+    outer loop
+      vertex 48.7507 4.81225 -58.3902
+      vertex 48.5077 4.89473 -58.3902
+      vertex 48.7637 4.8438 -58.1308
+    endloop
+  endfacet
+  facet normal -0.980807 0.194982 0
+    outer loop
+      vertex -49.9786 3.26049 -58.1308
+      vertex -49.9277 3.51653 48.1308
+      vertex -49.9277 3.51653 -58.1308
+    endloop
+  endfacet
+  facet normal -0.980807 0.194982 0
+    outer loop
+      vertex -49.9277 3.51653 48.1308
+      vertex -49.9786 3.26049 -58.1308
+      vertex -49.9786 3.26049 48.1308
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -49.9957 2 -58.1308
+      vertex -49.9957 3 48.1308
+      vertex -49.9957 3 -58.1308
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -49.9957 3 48.1308
+      vertex -49.9957 2 -58.1308
+      vertex -49.9957 2 48.1308
+    endloop
+  endfacet
+  facet normal -0.609347 0.694821 0.381995
+    outer loop
+      vertex -49.092 4.42307 48.8846
+      vertex -49.3392 4.33916 48.6429
+      vertex -49.2684 4.26837 48.8846
+    endloop
+  endfacet
+  facet normal -0.922077 -0.0604274 0.38226
+    outer loop
+      vertex -49.7937 2 48.8846
+      vertex -49.8939 2 48.6429
+      vertex -49.8777 1.7528 48.6429
+    endloop
+  endfacet
+  facet normal -0.382959 0 -0.923765
+    outer loop
+      vertex -48.8846 2 -59.7937
+      vertex -48.6429 3 -59.8939
+      vertex -48.6429 2 -59.8939
+    endloop
+  endfacet
+  facet normal -0.382959 0 -0.923765
+    outer loop
+      vertex -48.6429 3 -59.8939
+      vertex -48.8846 2 -59.7937
+      vertex -48.8846 3 -59.7937
+    endloop
+  endfacet
+  facet normal -0.297195 0.875076 -0.381991
+    outer loop
+      vertex -48.6864 4.6572 -58.8846
+      vertex -48.7247 4.7497 -58.6429
+      vertex -48.4643 4.73263 -58.8846
+    endloop
+  endfacet
+  facet normal -0.318726 0.93886 0.130215
+    outer loop
+      vertex -48.5165 4.92772 48.1308
+      vertex -48.7637 4.8438 48.1308
+      vertex -48.5077 4.89473 48.3902
+    endloop
+  endfacet
+  facet normal -0.706344 -0.046425 0.706344
+    outer loop
+      vertex -49.3187 2 49.5037
+      vertex -49.5037 2 49.3187
+      vertex -49.4908 1.80373 49.3187
+    endloop
+  endfacet
+  facet normal -0.128159 -0.025345 0.99143
+    outer loop
+      vertex -48.1297 1.98293 49.9957
+      vertex -48.3868 1.94907 49.9616
+      vertex -48.3769 1.89901 49.9616
+    endloop
+  endfacet
+  facet normal -0.634888 0.313107 0.706315
+    outer loop
+      vertex -49.3022 3.75184 49.3187
+      vertex -49.3892 3.57543 49.3187
+      vertex -49.142 3.65935 49.5037
+    endloop
+  endfacet
+  facet normal -0.670487 0.227516 0.706175
+    outer loop
+      vertex -49.3892 3.57543 49.3187
+      vertex -49.4524 3.38918 49.3187
+      vertex -49.2738 3.3413 49.5037
+    endloop
+  endfacet
+  facet normal -0.778811 0.154784 0.607862
+    outer loop
+      vertex -49.6063 3.4304 49.1111
+      vertex -49.6487 3.21706 49.1111
+      vertex -49.4908 3.19627 49.3187
+    endloop
+  endfacet
+  facet normal -0.608045 -0.0398292 0.792903
+    outer loop
+      vertex -49.1111 2 49.6629
+      vertex -49.3187 2 49.5037
+      vertex -49.1016 1.85497 49.6629
+    endloop
+  endfacet
+  facet normal 0.258743 0.0169597 0.965797
+    outer loop
+      vertex 48.6374 3.08391 49.8939
+      vertex 48.3902 3 49.9616
+      vertex 48.6429 3 49.8939
+    endloop
+  endfacet
+  facet normal 0 0.991445 0.130524
+    outer loop
+      vertex 48 4.99572 48.1308
+      vertex -48 4.96157 48.3902
+      vertex 48 4.96157 48.3902
+    endloop
+  endfacet
+  facet normal 0 0.991445 0.130524
+    outer loop
+      vertex -48 4.96157 48.3902
+      vertex 48 4.99572 48.1308
+      vertex -48 4.99572 48.1308
+    endloop
+  endfacet
+  facet normal 0.0726213 -0.108573 0.991432
+    outer loop
+      vertex 48.2375 1.69045 49.9616
+      vertex 48.0654 1.88672 49.9957
+      vertex 48.1951 1.66209 49.9616
+    endloop
+  endfacet
+  facet normal -0.170862 0.194981 0.96581
+    outer loop
+      vertex -48.2375 3.30955 49.9616
+      vertex -48.3914 3.51003 49.8939
+      vertex -48.2759 3.2759 49.9616
+    endloop
+  endfacet
+  facet normal -0.376568 0.330147 0.865563
+    outer loop
+      vertex -48.7857 3.78569 49.6629
+      vertex -48.8815 3.67642 49.6629
+      vertex -48.6255 3.62549 49.7937
+    endloop
+  endfacet
+  facet normal 0.546628 0.269624 0.79278
+    outer loop
+      vertex 49.142 3.65935 49.5037
+      vertex 48.9623 3.55557 49.6629
+      vertex 49.0266 3.42521 49.6629
+    endloop
+  endfacet
+  facet normal 0.338735 0.506739 0.792764
+    outer loop
+      vertex 48.6593 4.14202 49.5037
+      vertex 48.5556 3.96228 49.6629
+      vertex 48.6764 3.88153 49.6629
+    endloop
+  endfacet
+  facet normal 0.550929 0.824323 0.130263
+    outer loop
+      vertex 49.2149 4.58331 48.1308
+      vertex 48.9979 4.72834 48.1308
+      vertex 49.1941 4.55622 48.3902
+    endloop
+  endfacet
+  facet normal 0 0.991445 -0.130524
+    outer loop
+      vertex 48 4.96157 -58.3902
+      vertex -48 4.99572 -58.1308
+      vertex 48 4.99572 -58.1308
+    endloop
+  endfacet
+  facet normal 0 0.991445 -0.130524
+    outer loop
+      vertex -48 4.99572 -58.1308
+      vertex 48 4.96157 -58.3902
+      vertex -48 4.96157 -58.3902
+    endloop
+  endfacet
+  facet normal -0.824445 0.550744 -0.130272
+    outer loop
+      vertex -49.5562 4.19413 -58.3902
+      vertex -49.7283 3.99786 -58.1308
+      vertex -49.5833 4.21492 -58.1308
+    endloop
+  endfacet
+  facet normal -0.318679 0.938883 -0.130164
+    outer loop
+      vertex -48.7507 4.81225 -58.3902
+      vertex -48.7637 4.8438 -58.1308
+      vertex -48.5077 4.89473 -58.3902
+    endloop
+  endfacet
+  facet normal -0.318726 0.93886 -0.130215
+    outer loop
+      vertex -48.5077 4.89473 -58.3902
+      vertex -48.7637 4.8438 -58.1308
+      vertex -48.5165 4.92772 -58.1308
+    endloop
+  endfacet
+  facet normal 0.188449 0.947514 -0.258271
+    outer loop
+      vertex 48.5077 4.89473 -58.3902
+      vertex 48.2472 4.87766 -58.6429
+      vertex 48.256 4.94479 -58.3902
+    endloop
+  endfacet
+  facet normal 0.393183 0.588676 -0.706306
+    outer loop
+      vertex 48.8028 4.04619 -59.5037
+      vertex 48.7518 4.30222 -59.3187
+      vertex 48.9154 4.19295 -59.3187
+    endloop
+  endfacet
+  facet normal 0.466722 0.53226 -0.706307
+    outer loop
+      vertex 48.9325 3.93246 -59.5037
+      vertex 48.8028 4.04619 -59.5037
+      vertex 49.0633 4.06326 -59.3187
+    endloop
+  endfacet
+  facet normal 0.313092 -0.634876 0.706333
+    outer loop
+      vertex 48.6593 0.85798 49.5037
+      vertex 48.5046 0.781689 49.5037
+      vertex 48.5754 0.610782 49.3187
+    endloop
+  endfacet
+  facet normal 0.269563 -0.546609 0.792814
+    outer loop
+      vertex 48.6593 0.85798 49.5037
+      vertex 48.4252 0.97344 49.6629
+      vertex 48.5046 0.781689 49.5037
+    endloop
+  endfacet
+  facet normal 0.751886 -0.659293 0
+    outer loop
+      vertex 49.4112 0.588815 48.1308
+      vertex 49.5833 0.785085 -58.1308
+      vertex 49.5833 0.785085 48.1308
+    endloop
+  endfacet
+  facet normal 0.751886 -0.659293 0
+    outer loop
+      vertex 49.5833 0.785085 -58.1308
+      vertex 49.4112 0.588815 48.1308
+      vertex 49.4112 0.588815 -58.1308
+    endloop
+  endfacet
+  facet normal 0.947452 -0.188734 0.25829
+    outer loop
+      vertex 49.8777 1.7528 48.6429
+      vertex 49.8293 1.50983 48.6429
+      vertex 49.8947 1.49231 48.3902
+    endloop
+  endfacet
+  facet normal 0.0463055 -0.706363 0.706334
+    outer loop
+      vertex 48.1721 0.692591 49.5037
+      vertex 48 0.681309 49.5037
+      vertex 48.1963 0.509185 49.3187
+    endloop
+  endfacet
+  facet normal 0.0566756 -0.864574 0.4993
+    outer loop
+      vertex 48 0.337061 49.1111
+      vertex 48 0.206255 48.8846
+      vertex 48.2341 0.221601 48.8846
+    endloop
+  endfacet
+  facet normal 0.0631825 -0.963999 0.258291
+    outer loop
+      vertex 48.2472 0.122342 48.6429
+      vertex 48 0.10614 48.6429
+      vertex 48.256 0.0552111 48.3902
+    endloop
+  endfacet
+  facet normal 0.0604423 -0.922191 0.381982
+    outer loop
+      vertex 48 0.206255 48.8846
+      vertex 48 0.10614 48.6429
+      vertex 48.2472 0.122342 48.6429
+    endloop
+  endfacet
+  facet normal -0.318704 -0.93887 0.130191
+    outer loop
+      vertex -48.5077 0.105268 48.3902
+      vertex -48.7637 0.156198 48.1308
+      vertex -48.5165 0.0722847 48.1308
+    endloop
+  endfacet
+  facet normal -0.609357 -0.69481 -0.382
+    outer loop
+      vertex -49.092 0.576926 -58.8846
+      vertex -49.3392 0.660839 -58.6429
+      vertex -49.2684 0.731631 -58.8846
+    endloop
+  endfacet
+  facet normal -0.726411 -0.636892 0.258255
+    outer loop
+      vertex -49.5025 0.847092 48.6429
+      vertex -49.5562 0.805872 48.3902
+      vertex -49.3392 0.660839 48.6429
+    endloop
+  endfacet
+  facet normal -0.906365 -0.180549 0.381976
+    outer loop
+      vertex -49.7326 1.53574 48.8846
+      vertex -49.8777 1.7528 48.6429
+      vertex -49.8293 1.50983 48.6429
+    endloop
+  endfacet
+  facet normal -0.972391 -0.19359 0.130302
+    outer loop
+      vertex -49.8947 1.49231 48.3902
+      vertex -49.9448 1.74396 48.3902
+      vertex -49.9277 1.48347 48.1308
+    endloop
+  endfacet
+  facet normal 0.16906 -0.84976 0.499326
+    outer loop
+      vertex 48.4304 0.393724 49.1111
+      vertex 48.2171 0.351288 49.1111
+      vertex 48.4643 0.267375 48.8846
+    endloop
+  endfacet
+  facet normal -0.0462902 -0.706372 0.706326
+    outer loop
+      vertex -48 0.681309 49.5037
+      vertex -48.1963 0.509185 49.3187
+      vertex -48 0.496321 49.3187
+    endloop
+  endfacet
+  facet normal 0.313097 -0.634876 0.706331
+    outer loop
+      vertex 48.6593 0.85798 49.5037
+      vertex 48.5754 0.610782 49.3187
+      vertex 48.7518 0.697776 49.3187
+    endloop
+  endfacet
+  facet normal 0.964026 0.0631765 0.25819
+    outer loop
+      vertex 49.9448 3.25604 48.3902
+      vertex 49.8777 3.2472 48.6429
+      vertex 49.8939 3 48.6429
+    endloop
+  endfacet
+  facet normal 0.922077 -0.0604274 0.38226
+    outer loop
+      vertex 49.8939 2 48.6429
+      vertex 49.7937 2 48.8846
+      vertex 49.8777 1.7528 48.6429
+    endloop
+  endfacet
+  facet normal 0.720473 -0.48121 0.499355
+    outer loop
+      vertex 49.4401 1.16853 49.1111
+      vertex 49.3193 0.987667 49.1111
+      vertex 49.4231 0.908037 48.8846
+    endloop
+  endfacet
+  facet normal 0.745479 -0.653676 -0.130264
+    outer loop
+      vertex 49.5833 0.785085 -58.1308
+      vertex 49.4112 0.588815 -58.1308
+      vertex 49.5562 0.805872 -58.3902
+    endloop
+  endfacet
+  facet normal 0.947452 -0.188734 -0.25829
+    outer loop
+      vertex 49.8947 1.49231 -58.3902
+      vertex 49.8293 1.50983 -58.6429
+      vertex 49.8777 1.7528 -58.6429
+    endloop
+  endfacet
+  facet normal 0.946945 -0.321394 0
+    outer loop
+      vertex 49.8438 1.23627 48.1308
+      vertex 49.9277 1.48347 -58.1308
+      vertex 49.9277 1.48347 48.1308
+    endloop
+  endfacet
+  facet normal 0.946945 -0.321394 0
+    outer loop
+      vertex 49.9277 1.48347 -58.1308
+      vertex 49.8438 1.23627 48.1308
+      vertex 49.8438 1.23627 -58.1308
+    endloop
+  endfacet
+  facet normal 0.319 -0.213062 0.923495
+    outer loop
+      vertex 48.5567 1.67856 49.8939
+      vertex 48.51 1.60864 49.8939
+      vertex 48.7018 1.4615 49.7937
+    endloop
+  endfacet
+  facet normal 0.416355 -0.278374 0.865538
+    outer loop
+      vertex 48.9623 1.44443 49.6629
+      vertex 48.7018 1.4615 49.7937
+      vertex 48.8815 1.32358 49.6629
+    endloop
+  endfacet
+  facet normal 0.923765 -0 0.382959
+    outer loop
+      vertex 49.7937 2 48.8846
+      vertex 49.8939 3 48.6429
+      vertex 49.7937 3 48.8846
+    endloop
+  endfacet
+  facet normal 0.923765 0 0.382959
+    outer loop
+      vertex 49.8939 3 48.6429
+      vertex 49.7937 2 48.8846
+      vertex 49.8939 2 48.6429
+    endloop
+  endfacet
+  facet normal 0.0250966 -0.382837 0.923475
+    outer loop
+      vertex 48.0839 1.36262 49.8939
+      vertex 48 1.35712 49.8939
+      vertex 48.1155 1.12299 49.7937
+    endloop
+  endfacet
+  facet normal 0.108632 0.0725231 0.991433
+    outer loop
+      vertex 48.3096 3.23753 49.9616
+      vertex 48.1038 3.07963 49.9957
+      vertex 48.1133 3.0654 49.9957
+    endloop
+  endfacet
+  facet normal 0.253029 0.288394 0.923474
+    outer loop
+      vertex 48.6255 3.62549 49.7937
+      vertex 48.3914 3.51003 49.8939
+      vertex 48.4546 3.45458 49.8939
+    endloop
+  endfacet
+  facet normal 0.82433 -0.550975 -0.130025
+    outer loop
+      vertex 49.7283 1.00214 -58.1308
+      vertex 49.5562 0.805872 -58.3902
+      vertex 49.6988 1.01922 -58.3902
+    endloop
+  endfacet
+  facet normal 0.128159 -0.025345 -0.99143
+    outer loop
+      vertex 48.3769 1.89901 -59.9616
+      vertex 48.1297 1.98293 -59.9957
+      vertex 48.3868 1.94907 -59.9616
+    endloop
+  endfacet
+  facet normal 0.195948 -0.577096 -0.792821
+    outer loop
+      vertex 48.5046 0.781689 -59.5037
+      vertex 48.3413 0.726242 -59.5037
+      vertex 48.4252 0.97344 -59.6629
+    endloop
+  endfacet
+  facet normal 0.310628 -0.914771 -0.258273
+    outer loop
+      vertex 48.5077 0.105268 -58.3902
+      vertex 48.4902 0.170672 -58.6429
+      vertex 48.7247 0.250301 -58.6429
+    endloop
+  endfacet
+  facet normal 0.923765 0 -0.382959
+    outer loop
+      vertex 49.8939 2 -58.6429
+      vertex 49.7937 3 -58.8846
+      vertex 49.8939 3 -58.6429
+    endloop
+  endfacet
+  facet normal 0.923765 0 -0.382959
+    outer loop
+      vertex 49.7937 3 -58.8846
+      vertex 49.8939 2 -58.6429
+      vertex 49.7937 2 -58.8846
+    endloop
+  endfacet
+  facet normal 0.481346 -0.720422 -0.499298
+    outer loop
+      vertex 48.8969 0.446571 -58.8846
+      vertex 48.8315 0.559853 -59.1111
+      vertex 49.092 0.576926 -58.8846
+    endloop
+  endfacet
+  facet normal 0.169626 -0.344093 -0.923486
+    outer loop
+      vertex 48.3385 1.18276 -59.7937
+      vertex 48.3214 1.44325 -59.8939
+      vertex 48.4423 1.23393 -59.7937
+    endloop
+  endfacet
+  facet normal 0.401761 -0.458184 -0.792878
+    outer loop
+      vertex 48.8028 0.953812 -59.5037
+      vertex 48.6764 1.11847 -59.6629
+      vertex 48.9325 1.06754 -59.5037
+    endloop
+  endfacet
+  facet normal 0.221416 -0.449171 -0.865575
+    outer loop
+      vertex 48.4252 0.97344 -59.6629
+      vertex 48.3385 1.18276 -59.7937
+      vertex 48.5556 1.03772 -59.6629
+    endloop
+  endfacet
+  facet normal 0.193452 -0.972423 -0.130268
+    outer loop
+      vertex 48.2605 0.0213566 -58.1308
+      vertex 48.256 0.0552111 -58.3902
+      vertex 48.5165 0.0722847 -58.1308
+    endloop
+  endfacet
+  facet normal 0.195114 -0.98078 0
+    outer loop
+      vertex 48.2605 0.0213566 -58.1308
+      vertex 48.5165 0.0722847 48.1308
+      vertex 48.2605 0.0213566 48.1308
+    endloop
+  endfacet
+  facet normal 0.195114 -0.98078 0
+    outer loop
+      vertex 48.5165 0.0722847 48.1308
+      vertex 48.2605 0.0213566 -58.1308
+      vertex 48.5165 0.0722847 -58.1308
+    endloop
+  endfacet
+  facet normal -0.82433 -0.550975 -0.130025
+    outer loop
+      vertex -49.5562 0.805872 -58.3902
+      vertex -49.7283 1.00214 -58.1308
+      vertex -49.6988 1.01922 -58.3902
+    endloop
+  endfacet
+  facet normal -0.889201 -0.438657 0.130007
+    outer loop
+      vertex -49.6988 1.01922 48.3902
+      vertex -49.8438 1.23627 48.1308
+      vertex -49.7283 1.00214 48.1308
+    endloop
+  endfacet
+  facet normal -0.597744 0.118668 -0.792855
+    outer loop
+      vertex -49.1016 3.14503 -59.6629
+      vertex -49.2738 3.3413 -59.5037
+      vertex -49.0733 3.28758 -59.6629
+    endloop
+  endfacet
+  facet normal 0 -0.70713 -0.707084
+    outer loop
+      vertex -48 0.496321 -59.3187
+      vertex 48 0.681309 -59.5037
+      vertex 48 0.496321 -59.3187
+    endloop
+  endfacet
+  facet normal -0 -0.70713 -0.707084
+    outer loop
+      vertex 48 0.681309 -59.5037
+      vertex -48 0.496321 -59.3187
+      vertex -48 0.681309 -59.5037
+    endloop
+  endfacet
+  facet normal -0.393128 -0.588675 -0.706337
+    outer loop
+      vertex -48.7518 0.697776 -59.3187
+      vertex -48.8028 0.953812 -59.5037
+      vertex -48.6593 0.85798 -59.5037
+    endloop
+  endfacet
+  facet normal 0 -0.793422 -0.608672
+    outer loop
+      vertex -48 0.496321 -59.3187
+      vertex 48 0.337061 -59.1111
+      vertex -48 0.337061 -59.1111
+    endloop
+  endfacet
+  facet normal 0 -0.793422 -0.608672
+    outer loop
+      vertex 48 0.337061 -59.1111
+      vertex -48 0.496321 -59.3187
+      vertex 48 0.496321 -59.3187
+    endloop
+  endfacet
+  facet normal -0.0398685 -0.608134 -0.792832
+    outer loop
+      vertex -48 0.681309 -59.5037
+      vertex -48.145 0.898366 -59.6629
+      vertex -48 0.88886 -59.6629
+    endloop
+  endfacet
+  facet normal 0.0250966 -0.382837 -0.923475
+    outer loop
+      vertex 48.1155 1.12299 -59.7937
+      vertex 48 1.35712 -59.8939
+      vertex 48.0839 1.36262 -59.8939
+    endloop
+  endfacet
+  facet normal -0.227586 0.670302 -0.706329
+    outer loop
+      vertex -48.3413 4.27376 -59.5037
+      vertex -48.5754 4.38922 -59.3187
+      vertex -48.3892 4.45244 -59.3187
+    endloop
+  endfacet
+  facet normal -0.889226 0.438585 -0.130081
+    outer loop
+      vertex -49.8123 3.75066 -58.3902
+      vertex -49.8438 3.76373 -58.1308
+      vertex -49.6988 3.98078 -58.3902
+    endloop
+  endfacet
+  facet normal -0.154921 0.778801 -0.607839
+    outer loop
+      vertex -48.1963 4.49082 -59.3187
+      vertex -48.4304 4.60628 -59.1111
+      vertex -48.2171 4.64871 -59.1111
+    endloop
+  endfacet
+  facet normal 0.706374 -0.0463748 -0.706318
+    outer loop
+      vertex 49.4908 1.80373 -59.3187
+      vertex 49.3074 1.82788 -59.5037
+      vertex 49.3187 2 -59.5037
+    endloop
+  endfacet
+  facet normal 0.491118 0.0975 -0.86562
+    outer loop
+      vertex 49.1016 3.14503 -59.6629
+      vertex 48.8544 3.22894 -59.7937
+      vertex 49.0733 3.28758 -59.6629
+    endloop
+  endfacet
+  facet normal 0.254299 0.0502908 -0.965817
+    outer loop
+      vertex 48.3868 3.05093 -59.9616
+      vertex 48.3769 3.10099 -59.9616
+      vertex 48.6374 3.08391 -59.8939
+    endloop
+  endfacet
+  facet normal 0.989379 0.0649178 -0.130061
+    outer loop
+      vertex 49.9616 3 -58.3902
+      vertex 49.9448 3.25604 -58.3902
+      vertex 49.9957 3 -58.1308
+    endloop
+  endfacet
+  facet normal 0.972391 0.19359 0.130302
+    outer loop
+      vertex 49.9277 3.51653 48.1308
+      vertex 49.8947 3.50769 48.3902
+      vertex 49.9448 3.25604 48.3902
+    endloop
+  endfacet
+  facet normal 0.865975 0 -0.500086
+    outer loop
+      vertex 49.7937 2 -58.8846
+      vertex 49.6629 3 -59.1111
+      vertex 49.7937 3 -58.8846
+    endloop
+  endfacet
+  facet normal 0.865975 0 -0.500086
+    outer loop
+      vertex 49.6629 3 -59.1111
+      vertex 49.7937 2 -58.8846
+      vertex 49.6629 2 -59.1111
+    endloop
+  endfacet
+  facet normal 0.71219 0.35123 0.607801
+    outer loop
+      vertex 49.4401 3.83147 49.1111
+      vertex 49.3022 3.75184 49.3187
+      vertex 49.3892 3.57543 49.3187
+    endloop
+  endfacet
+  facet normal 0.97248 0.193326 -0.130031
+    outer loop
+      vertex 49.9448 3.25604 -58.3902
+      vertex 49.9277 3.51653 -58.1308
+      vertex 49.9786 3.26049 -58.1308
+    endloop
+  endfacet
+  facet normal 0.946945 0.321394 0
+    outer loop
+      vertex 49.9277 3.51653 48.1308
+      vertex 49.8438 3.76373 -58.1308
+      vertex 49.8438 3.76373 48.1308
+    endloop
+  endfacet
+  facet normal 0.946945 0.321394 0
+    outer loop
+      vertex 49.8438 3.76373 -58.1308
+      vertex 49.9277 3.51653 48.1308
+      vertex 49.9277 3.51653 -58.1308
+    endloop
+  endfacet
+  facet normal 0.922077 0.0604274 -0.38226
+    outer loop
+      vertex 49.8939 3 -58.6429
+      vertex 49.7937 3 -58.8846
+      vertex 49.8777 3.2472 -58.6429
+    endloop
+  endfacet
+  facet normal 0.694913 0.609284 -0.381928
+    outer loop
+      vertex 49.4231 4.09196 -58.8846
+      vertex 49.3392 4.33916 -58.6429
+      vertex 49.5025 4.15291 -58.6429
+    endloop
+  endfacet
+  facet normal 0.726406 0.636897 -0.258255
+    outer loop
+      vertex 49.5025 4.15291 -58.6429
+      vertex 49.3392 4.33916 -58.6429
+      vertex 49.5562 4.19413 -58.3902
+    endloop
+  endfacet
+  facet normal 0.634888 0.313107 -0.706315
+    outer loop
+      vertex 49.3892 3.57543 -59.3187
+      vertex 49.142 3.65935 -59.5037
+      vertex 49.3022 3.75184 -59.3187
+    endloop
+  endfacet
+  facet normal 0.82881 0.408847 -0.381993
+    outer loop
+      vertex 49.6572 3.68644 -58.8846
+      vertex 49.6401 3.94693 -58.6429
+      vertex 49.7497 3.72475 -58.6429
+    endloop
+  endfacet
+  facet normal 0.694418 0.138228 -0.70617
+    outer loop
+      vertex 49.4908 3.19627 -59.3187
+      vertex 49.2738 3.3413 -59.5037
+      vertex 49.4524 3.38918 -59.3187
+    endloop
+  endfacet
+  facet normal 0.297195 0.875076 -0.381991
+    outer loop
+      vertex 48.6864 4.6572 -58.8846
+      vertex 48.4643 4.73263 -58.8846
+      vertex 48.7247 4.7497 -58.6429
+    endloop
+  endfacet
+  facet normal 0.637026 0.726341 -0.258121
+    outer loop
+      vertex 49.3392 4.33916 -58.6429
+      vertex 49.1941 4.55622 -58.3902
+      vertex 49.387 4.38704 -58.3902
+    endloop
+  endfacet
+  facet normal 0.653742 0.7454 -0.130385
+    outer loop
+      vertex 49.387 4.38704 -58.3902
+      vertex 49.1941 4.55622 -58.3902
+      vertex 49.4112 4.41119 -58.1308
+    endloop
+  endfacet
+  facet normal 0.65928 0.751898 -0
+    outer loop
+      vertex 49.4112 4.41119 -58.1308
+      vertex 49.2149 4.58331 48.1308
+      vertex 49.4112 4.41119 48.1308
+    endloop
+  endfacet
+  facet normal 0.65928 0.751898 0
+    outer loop
+      vertex 49.2149 4.58331 48.1308
+      vertex 49.4112 4.41119 -58.1308
+      vertex 49.2149 4.58331 -58.1308
+    endloop
+  endfacet
+  facet normal -0.98938 -0.0649484 -0.130031
+    outer loop
+      vertex -49.9786 1.73951 -58.1308
+      vertex -49.9957 2 -58.1308
+      vertex -49.9448 1.74396 -58.3902
+    endloop
+  endfacet
+  facet normal -0.997852 0.0655045 0
+    outer loop
+      vertex -49.9957 3 -58.1308
+      vertex -49.9786 3.26049 48.1308
+      vertex -49.9786 3.26049 -58.1308
+    endloop
+  endfacet
+  facet normal -0.997852 0.0655045 0
+    outer loop
+      vertex -49.9786 3.26049 48.1308
+      vertex -49.9957 3 -58.1308
+      vertex -49.9957 3 48.1308
+    endloop
+  endfacet
+  facet normal -0.964026 0.0631765 0.25819
+    outer loop
+      vertex -49.8777 3.2472 48.6429
+      vertex -49.9448 3.25604 48.3902
+      vertex -49.8939 3 48.6429
+    endloop
+  endfacet
+  facet normal -0.989379 -0.0649178 -0.130061
+    outer loop
+      vertex -49.9448 1.74396 -58.3902
+      vertex -49.9957 2 -58.1308
+      vertex -49.9616 2 -58.3902
+    endloop
+  endfacet
+  facet normal -0.97248 0.193326 0.130031
+    outer loop
+      vertex -49.9277 3.51653 48.1308
+      vertex -49.9786 3.26049 48.1308
+      vertex -49.9448 3.25604 48.3902
+    endloop
+  endfacet
+  facet normal -0.906365 0.180549 0.381976
+    outer loop
+      vertex -49.8293 3.49017 48.6429
+      vertex -49.8777 3.2472 48.6429
+      vertex -49.7326 3.46426 48.8846
+    endloop
+  endfacet
+  facet normal -0.751886 0.659293 0
+    outer loop
+      vertex -49.5833 4.21492 -58.1308
+      vertex -49.4112 4.41119 48.1308
+      vertex -49.4112 4.41119 -58.1308
+    endloop
+  endfacet
+  facet normal -0.751886 0.659293 0
+    outer loop
+      vertex -49.4112 4.41119 48.1308
+      vertex -49.5833 4.21492 -58.1308
+      vertex -49.5833 4.21492 48.1308
+    endloop
+  endfacet
+  facet normal -0.221423 0.449163 -0.865577
+    outer loop
+      vertex -48.4423 3.76607 -59.7937
+      vertex -48.5556 3.96228 -59.6629
+      vertex -48.3385 3.81724 -59.7937
+    endloop
+  endfacet
+  facet normal -0.608528 0 -0.793533
+    outer loop
+      vertex -49.3187 2 -59.5037
+      vertex -49.1111 3 -59.6629
+      vertex -49.1111 2 -59.6629
+    endloop
+  endfacet
+  facet normal -0.608528 0 -0.793533
+    outer loop
+      vertex -49.1111 3 -59.6629
+      vertex -49.3187 2 -59.5037
+      vertex -49.3187 3 -59.5037
+    endloop
+  endfacet
+  facet normal -0.313118 0.634873 -0.706324
+    outer loop
+      vertex -48.6593 4.14202 -59.5037
+      vertex -48.7518 4.30222 -59.3187
+      vertex -48.5754 4.38922 -59.3187
+    endloop
+  endfacet
+  facet normal -0.726328 -0.637054 -0.25809
+    outer loop
+      vertex -49.387 0.612961 -58.3902
+      vertex -49.5562 0.805872 -58.3902
+      vertex -49.3392 0.660839 -58.6429
+    endloop
+  endfacet
+  facet normal -0.597056 0.523528 -0.607818
+    outer loop
+      vertex -49.0633 4.06326 -59.3187
+      vertex -49.3193 4.01233 -59.1111
+      vertex -49.1759 4.17587 -59.1111
+    endloop
+  endfacet
+  facet normal -0.636888 0.726412 0.258261
+    outer loop
+      vertex -49.1941 4.55622 48.3902
+      vertex -49.3392 4.33916 48.6429
+      vertex -49.1529 4.5025 48.6429
+    endloop
+  endfacet
+  facet normal -0.523561 0.597075 0.607772
+    outer loop
+      vertex -49.0123 4.3193 49.1111
+      vertex -49.0633 4.06326 49.3187
+      vertex -48.9154 4.19295 49.3187
+    endloop
+  endfacet
+  facet normal -0.653662 0.745491 -0.130268
+    outer loop
+      vertex -49.1941 4.55622 -58.3902
+      vertex -49.4112 4.41119 -58.1308
+      vertex -49.2149 4.58331 -58.1308
+    endloop
+  endfacet
+  facet normal -0.555664 0.831407 0
+    outer loop
+      vertex -48.9979 4.72834 -58.1308
+      vertex -49.2149 4.58331 48.1308
+      vertex -48.9979 4.72834 48.1308
+    endloop
+  endfacet
+  facet normal -0.555664 0.831407 0
+    outer loop
+      vertex -49.2149 4.58331 48.1308
+      vertex -48.9979 4.72834 -58.1308
+      vertex -49.2149 4.58331 -58.1308
+    endloop
+  endfacet
+  facet normal -0.653662 0.745491 0.130268
+    outer loop
+      vertex -49.2149 4.58331 48.1308
+      vertex -49.4112 4.41119 48.1308
+      vertex -49.1941 4.55622 48.3902
+    endloop
+  endfacet
+  facet normal -0.803322 0.53664 0.258246
+    outer loop
+      vertex -49.5562 4.19413 48.3902
+      vertex -49.6401 3.94693 48.6429
+      vertex -49.5025 4.15291 48.6429
+    endloop
+  endfacet
+  facet normal -0.169626 0.344093 0.923486
+    outer loop
+      vertex -48.3385 3.81724 49.7937
+      vertex -48.4423 3.76607 49.7937
+      vertex -48.3214 3.55675 49.8939
+    endloop
+  endfacet
+  facet normal -0.506691 0.338773 0.792778
+    outer loop
+      vertex -48.8815 3.67642 49.6629
+      vertex -49.142 3.65935 49.5037
+      vertex -48.9623 3.55557 49.6629
+    endloop
+  endfacet
+  facet normal -0.634888 0.313115 0.706312
+    outer loop
+      vertex -49.142 3.65935 49.5037
+      vertex -49.3892 3.57543 49.3187
+      vertex -49.2183 3.50464 49.5037
+    endloop
+  endfacet
+  facet normal -0.824332 0.550972 0.130025
+    outer loop
+      vertex -49.5562 4.19413 48.3902
+      vertex -49.7283 3.99786 48.1308
+      vertex -49.6988 3.98078 48.3902
+    endloop
+  endfacet
+  facet normal -0.597744 0.118668 0.792855
+    outer loop
+      vertex -49.0733 3.28758 49.6629
+      vertex -49.2738 3.3413 49.5037
+      vertex -49.1016 3.14503 49.6629
+    endloop
+  endfacet
+  facet normal -0.849746 0.169115 0.499332
+    outer loop
+      vertex -49.7326 3.46426 48.8846
+      vertex -49.7784 3.23413 48.8846
+      vertex -49.6487 3.21706 49.1111
+    endloop
+  endfacet
+  facet normal -0.416355 0.278374 0.865538
+    outer loop
+      vertex -48.8815 3.67642 49.6629
+      vertex -48.9623 3.55557 49.6629
+      vertex -48.7018 3.5385 49.7937
+    endloop
+  endfacet
+  facet normal -0.466723 0.532257 0.706309
+    outer loop
+      vertex -48.9154 4.19295 49.3187
+      vertex -49.0633 4.06326 49.3187
+      vertex -48.8028 4.04619 49.5037
+    endloop
+  endfacet
+  facet normal -0.513447 -0.768467 -0.381878
+    outer loop
+      vertex -48.9469 0.359869 -58.6429
+      vertex -49.092 0.576926 -58.8846
+      vertex -48.8969 0.446571 -58.8846
+    endloop
+  endfacet
+  facet normal -0.310628 -0.914771 0.258273
+    outer loop
+      vertex -48.4902 0.170672 48.6429
+      vertex -48.7247 0.250301 48.6429
+      vertex -48.5077 0.105268 48.3902
+    endloop
+  endfacet
+  facet normal -0.144138 0.215495 0.965809
+    outer loop
+      vertex -48.1951 3.33791 49.9616
+      vertex -48.3914 3.51003 49.8939
+      vertex -48.2375 3.30955 49.9616
+    endloop
+  endfacet
+  facet normal -0.258781 0 0.965936
+    outer loop
+      vertex -48.6429 3 49.8939
+      vertex -48.3902 2 49.9616
+      vertex -48.3902 3 49.9616
+    endloop
+  endfacet
+  facet normal -0.258781 0 0.965936
+    outer loop
+      vertex -48.3902 2 49.9616
+      vertex -48.6429 3 49.8939
+      vertex -48.6429 2 49.8939
+    endloop
+  endfacet
+  facet normal 0.416355 0.278374 0.865538
+    outer loop
+      vertex 48.8815 3.67642 49.6629
+      vertex 48.7018 3.5385 49.7937
+      vertex 48.9623 3.55557 49.6629
+    endloop
+  endfacet
+  facet normal 0 0.965927 0.258816
+    outer loop
+      vertex 48 4.96157 48.3902
+      vertex -48 4.89386 48.6429
+      vertex 48 4.89386 48.6429
+    endloop
+  endfacet
+  facet normal 0 0.965927 0.258816
+    outer loop
+      vertex -48 4.89386 48.6429
+      vertex 48 4.96157 48.3902
+      vertex -48 4.96157 48.3902
+    endloop
+  endfacet
+  facet normal -0.0654257 0.997857 0
+    outer loop
+      vertex -48 4.99572 -58.1308
+      vertex -48.2605 4.97864 48.1308
+      vertex -48 4.99572 48.1308
+    endloop
+  endfacet
+  facet normal -0.0654257 0.997857 0
+    outer loop
+      vertex -48.2605 4.97864 48.1308
+      vertex -48 4.99572 -58.1308
+      vertex -48.2605 4.97864 -58.1308
+    endloop
+  endfacet
+  facet normal -0.0648493 0.989358 0.130249
+    outer loop
+      vertex -48 4.99572 48.1308
+      vertex -48.256 4.94479 48.3902
+      vertex -48 4.96157 48.3902
+    endloop
+  endfacet
+  facet normal 0.123311 -0.363304 0.923474
+    outer loop
+      vertex 48.246 1.40606 49.8939
+      vertex 48.2289 1.14556 49.7937
+      vertex 48.3385 1.18276 49.7937
+    endloop
+  endfacet
+  facet normal 0.123368 -0.363305 0.923466
+    outer loop
+      vertex 48.246 1.40606 49.8939
+      vertex 48.1664 1.37903 49.8939
+      vertex 48.2289 1.14556 49.7937
+    endloop
+  endfacet
+  facet normal 0 -0.499987 0.866033
+    outer loop
+      vertex -48 1.11542 49.7937
+      vertex 48 0.88886 49.6629
+      vertex 48 1.11542 49.7937
+    endloop
+  endfacet
+  facet normal 0 -0.499987 0.866033
+    outer loop
+      vertex 48 0.88886 49.6629
+      vertex -48 1.11542 49.7937
+      vertex -48 0.88886 49.6629
+    endloop
+  endfacet
+  facet normal -0.0398685 -0.608134 0.792832
+    outer loop
+      vertex -48 0.88886 49.6629
+      vertex -48.145 0.898366 49.6629
+      vertex -48 0.681309 49.5037
+    endloop
+  endfacet
+  facet normal 0.213155 -0.318953 0.92349
+    outer loop
+      vertex 48.5385 1.29822 49.7937
+      vertex 48.3214 1.44325 49.8939
+      vertex 48.4423 1.23393 49.7937
+    endloop
+  endfacet
+  facet normal -0.608082 0.0399217 0.79287
+    outer loop
+      vertex -49.3074 3.17212 49.5037
+      vertex -49.3187 3 49.5037
+      vertex -49.1016 3.14503 49.6629
+    endloop
+  endfacet
+  facet normal -0.0860326 0.0983012 0.991431
+    outer loop
+      vertex -48.0796 3.10378 49.9957
+      vertex -48.2759 3.2759 49.9616
+      vertex -48.0925 3.09249 49.9957
+    endloop
+  endfacet
+  facet normal -0.130331 0.00870067 0.991432
+    outer loop
+      vertex -48.3868 3.05093 49.9616
+      vertex -48.3902 3 49.9616
+      vertex -48.1308 3 49.9957
+    endloop
+  endfacet
+  facet normal -0 0.130351 0.991468
+    outer loop
+      vertex -48 3.39018 49.9616
+      vertex 48 3.13081 49.9957
+      vertex 48 3.39018 49.9616
+    endloop
+  endfacet
+  facet normal 0 0.130351 0.991468
+    outer loop
+      vertex 48 3.13081 49.9957
+      vertex -48 3.39018 49.9616
+      vertex -48 3.13081 49.9957
+    endloop
+  endfacet
+  facet normal 0.130331 -0.00870067 0.991432
+    outer loop
+      vertex 48.3902 2 49.9616
+      vertex 48.1308 2 49.9957
+      vertex 48.3868 1.94907 49.9616
+    endloop
+  endfacet
+  facet normal 0.138073 0.694261 0.706355
+    outer loop
+      vertex 48.1963 4.49082 49.3187
+      vertex 48.1721 4.30741 49.5037
+      vertex 48.3413 4.27376 49.5037
+    endloop
+  endfacet
+  facet normal 0.35117 0.712123 0.607915
+    outer loop
+      vertex 48.6364 4.53636 49.1111
+      vertex 48.5754 4.38922 49.3187
+      vertex 48.8315 4.44015 49.1111
+    endloop
+  endfacet
+  facet normal 0.0726313 0.108565 0.991432
+    outer loop
+      vertex 48.2375 3.30955 49.9616
+      vertex 48.0654 3.11328 49.9957
+      vertex 48.0796 3.10378 49.9957
+    endloop
+  endfacet
+  facet normal 0.382838 0.0251998 0.923472
+    outer loop
+      vertex 48.877 3.11546 49.7937
+      vertex 48.6429 3 49.8939
+      vertex 48.8846 3 49.7937
+    endloop
+  endfacet
+  facet normal -0.169036 0.849763 -0.499329
+    outer loop
+      vertex -48.4304 4.60628 -59.1111
+      vertex -48.4643 4.73263 -58.8846
+      vertex -48.2171 4.64871 -59.1111
+    endloop
+  endfacet
+  facet normal -0.168966 0.849812 -0.49927
+    outer loop
+      vertex -48.2171 4.64871 -59.1111
+      vertex -48.4643 4.73263 -58.8846
+      vertex -48.2341 4.7784 -58.8846
+    endloop
+  endfacet
+  facet normal -0.297162 0.875102 -0.381957
+    outer loop
+      vertex -48.4643 4.73263 -58.8846
+      vertex -48.7247 4.7497 -58.6429
+      vertex -48.4902 4.82933 -58.6429
+    endloop
+  endfacet
+  facet normal -0.310633 0.914773 -0.25826
+    outer loop
+      vertex -48.4902 4.82933 -58.6429
+      vertex -48.7247 4.7497 -58.6429
+      vertex -48.5077 4.89473 -58.3902
+    endloop
+  endfacet
+  facet normal 0.18022 0.906416 -0.38201
+    outer loop
+      vertex 48.4643 4.73263 -58.8846
+      vertex 48.2341 4.7784 -58.8846
+      vertex 48.2472 4.87766 -58.6429
+    endloop
+  endfacet
+  facet normal 0.0604353 0.922198 -0.381966
+    outer loop
+      vertex 48.2472 4.87766 -58.6429
+      vertex 48 4.79375 -58.8846
+      vertex 48 4.89386 -58.6429
+    endloop
+  endfacet
+  facet normal 0.532437 0.46662 -0.706241
+    outer loop
+      vertex 49.1929 3.91538 -59.3187
+      vertex 49.0462 3.80277 -59.5037
+      vertex 49.0633 4.06326 -59.3187
+    endloop
+  endfacet
+  facet normal 0.254312 0.0505664 -0.965799
+    outer loop
+      vertex 48.6374 3.08391 -59.8939
+      vertex 48.3769 3.10099 -59.9616
+      vertex 48.621 3.16639 -59.8939
+    endloop
+  endfacet
+  facet normal 0.536775 0.803185 -0.258391
+    outer loop
+      vertex 49.1941 4.55622 -58.3902
+      vertex 48.9469 4.64013 -58.6429
+      vertex 48.9808 4.69877 -58.3902
+    endloop
+  endfacet
+  facet normal 0.442182 0.896925 -0
+    outer loop
+      vertex 48.9979 4.72834 -58.1308
+      vertex 48.7637 4.8438 48.1308
+      vertex 48.9979 4.72834 48.1308
+    endloop
+  endfacet
+  facet normal 0.442182 0.896925 0
+    outer loop
+      vertex 48.7637 4.8438 48.1308
+      vertex 48.9979 4.72834 -58.1308
+      vertex 48.7637 4.8438 -58.1308
+    endloop
+  endfacet
+  facet normal 0.694837 0.609327 -0.381997
+    outer loop
+      vertex 49.4231 4.09196 -58.8846
+      vertex 49.2684 4.26837 -58.8846
+      vertex 49.3392 4.33916 -58.6429
+    endloop
+  endfacet
+  facet normal 0.660335 0.441051 -0.607809
+    outer loop
+      vertex 49.4401 3.83147 -59.1111
+      vertex 49.3022 3.75184 -59.3187
+      vertex 49.3193 4.01233 -59.1111
+    endloop
+  endfacet
+  facet normal 0.278308 -0.416342 0.865566
+    outer loop
+      vertex 48.6764 1.11847 49.6629
+      vertex 48.5385 1.29822 49.7937
+      vertex 48.5556 1.03772 49.6629
+    endloop
+  endfacet
+  facet normal 0.221416 -0.449171 0.865575
+    outer loop
+      vertex 48.5556 1.03772 49.6629
+      vertex 48.3385 1.18276 49.7937
+      vertex 48.4252 0.97344 49.6629
+    endloop
+  endfacet
+  facet normal 0.338735 -0.506739 0.792764
+    outer loop
+      vertex 48.6764 1.11847 49.6629
+      vertex 48.5556 1.03772 49.6629
+      vertex 48.6593 0.85798 49.5037
+    endloop
+  endfacet
+  facet normal 0.571285 -0.651399 0.499313
+    outer loop
+      vertex 49.1759 0.824125 49.1111
+      vertex 49.092 0.576926 48.8846
+      vertex 49.2684 0.731631 48.8846
+    endloop
+  endfacet
+  facet normal 0.154924 -0.778797 0.607844
+    outer loop
+      vertex 48.3892 0.547558 49.3187
+      vertex 48.1963 0.509185 49.3187
+      vertex 48.4304 0.393724 49.1111
+    endloop
+  endfacet
+  facet normal 0.351185 -0.712107 0.607925
+    outer loop
+      vertex 48.7518 0.697776 49.3187
+      vertex 48.5754 0.610782 49.3187
+      vertex 48.8315 0.559853 49.1111
+    endloop
+  endfacet
+  facet normal 0.442182 -0.896925 0
+    outer loop
+      vertex 48.7637 0.156198 -58.1308
+      vertex 48.9979 0.271658 48.1308
+      vertex 48.7637 0.156198 48.1308
+    endloop
+  endfacet
+  facet normal 0.442182 -0.896925 0
+    outer loop
+      vertex 48.9979 0.271658 48.1308
+      vertex 48.7637 0.156198 -58.1308
+      vertex 48.9979 0.271658 -58.1308
+    endloop
+  endfacet
+  facet normal 0.82433 -0.550975 0.130025
+    outer loop
+      vertex 49.6988 1.01922 48.3902
+      vertex 49.5562 0.805872 48.3902
+      vertex 49.7283 1.00214 48.1308
+    endloop
+  endfacet
+  facet normal -0.195948 -0.577096 0.792821
+    outer loop
+      vertex -48.4252 0.97344 49.6629
+      vertex -48.5046 0.781689 49.5037
+      vertex -48.3413 0.726242 49.5037
+    endloop
+  endfacet
+  facet normal 0 -0.991447 0.130513
+    outer loop
+      vertex -48 0.00428295 48.1308
+      vertex 48 0.0384302 48.3902
+      vertex -48 0.0384302 48.3902
+    endloop
+  endfacet
+  facet normal 0 -0.991447 0.130513
+    outer loop
+      vertex 48 0.0384302 48.3902
+      vertex -48 0.00428295 48.1308
+      vertex 48 0.00428295 48.1308
+    endloop
+  endfacet
+  facet normal -0.188449 -0.94751 0.258286
+    outer loop
+      vertex -48.4902 0.170672 48.6429
+      vertex -48.5077 0.105268 48.3902
+      vertex -48.2472 0.122342 48.6429
+    endloop
+  endfacet
+  facet normal -0.188437 -0.947516 0.258274
+    outer loop
+      vertex -48.2472 0.122342 48.6429
+      vertex -48.5077 0.105268 48.3902
+      vertex -48.256 0.0552111 48.3902
+    endloop
+  endfacet
+  facet normal -0.0648529 -0.989359 0.130239
+    outer loop
+      vertex -48 0.0384302 48.3902
+      vertex -48.256 0.0552111 48.3902
+      vertex -48 0.00428295 48.1308
+    endloop
+  endfacet
+  facet normal -0.193395 -0.972442 0.130209
+    outer loop
+      vertex -48.5077 0.105268 48.3902
+      vertex -48.5165 0.0722847 48.1308
+      vertex -48.256 0.0552111 48.3902
+    endloop
+  endfacet
+  facet normal -0.82881 -0.408847 0.381993
+    outer loop
+      vertex -49.6572 1.31356 48.8846
+      vertex -49.7497 1.27525 48.6429
+      vertex -49.6401 1.05307 48.6429
+    endloop
+  endfacet
+  facet normal -0.889226 -0.438585 0.130081
+    outer loop
+      vertex -49.8123 1.24934 48.3902
+      vertex -49.8438 1.23627 48.1308
+      vertex -49.6988 1.01922 48.3902
+    endloop
+  endfacet
+  facet normal -0.820542 -0.278454 0.499174
+    outer loop
+      vertex -49.6063 1.5696 49.1111
+      vertex -49.7326 1.53574 48.8846
+      vertex -49.5364 1.36362 49.1111
+    endloop
+  endfacet
+  facet normal -0.989379 -0.0649178 0.130061
+    outer loop
+      vertex -49.9616 2 48.3902
+      vertex -49.9957 2 48.1308
+      vertex -49.9448 1.74396 48.3902
+    endloop
+  endfacet
+  facet normal -0.889201 -0.438657 -0.130007
+    outer loop
+      vertex -49.7283 1.00214 -58.1308
+      vertex -49.8438 1.23627 -58.1308
+      vertex -49.6988 1.01922 -58.3902
+    endloop
+  endfacet
+  facet normal -0.923765 0 0.382959
+    outer loop
+      vertex -49.8939 2 48.6429
+      vertex -49.7937 3 48.8846
+      vertex -49.8939 3 48.6429
+    endloop
+  endfacet
+  facet normal -0.923765 0 0.382959
+    outer loop
+      vertex -49.7937 3 48.8846
+      vertex -49.8939 2 48.6429
+      vertex -49.7937 2 48.8846
+    endloop
+  endfacet
+  facet normal 0.0519244 -0.792351 0.607851
+    outer loop
+      vertex 48.1963 0.509185 49.3187
+      vertex 48 0.337061 49.1111
+      vertex 48.2171 0.351288 49.1111
+    endloop
+  endfacet
+  facet normal 0.269492 -0.546699 0.792776
+    outer loop
+      vertex 48.5556 1.03772 49.6629
+      vertex 48.4252 0.97344 49.6629
+      vertex 48.6593 0.85798 49.5037
+    endloop
+  endfacet
+  facet normal 0.255307 -0.751901 0.607835
+    outer loop
+      vertex 48.5754 0.610782 49.3187
+      vertex 48.3892 0.547558 49.3187
+      vertex 48.4304 0.393724 49.1111
+    endloop
+  endfacet
+  facet normal 0.0566578 -0.864583 0.499286
+    outer loop
+      vertex 48.2171 0.351288 49.1111
+      vertex 48 0.337061 49.1111
+      vertex 48.2341 0.221601 48.8846
+    endloop
+  endfacet
+  facet normal 0.965936 -0 0.258781
+    outer loop
+      vertex 49.8939 2 48.6429
+      vertex 49.9616 3 48.3902
+      vertex 49.8939 3 48.6429
+    endloop
+  endfacet
+  facet normal 0.965936 0 0.258781
+    outer loop
+      vertex 49.9616 3 48.3902
+      vertex 49.8939 2 48.6429
+      vertex 49.9616 2 48.3902
+    endloop
+  endfacet
+  facet normal 0.318679 0.938883 0.130164
+    outer loop
+      vertex 48.7637 4.8438 48.1308
+      vertex 48.5077 4.89473 48.3902
+      vertex 48.7507 4.81225 48.3902
+    endloop
+  endfacet
+  facet normal 0.491187 0.0978218 0.865544
+    outer loop
+      vertex 49.1016 3.14503 49.6629
+      vertex 48.8544 3.22894 49.7937
+      vertex 48.877 3.11546 49.7937
+    endloop
+  endfacet
+  facet normal 0.670487 0.227516 0.706175
+    outer loop
+      vertex 49.3892 3.57543 49.3187
+      vertex 49.2738 3.3413 49.5037
+      vertex 49.4524 3.38918 49.3187
+    endloop
+  endfacet
+  facet normal 0.938977 -0.318441 0.130069
+    outer loop
+      vertex 49.8947 1.49231 48.3902
+      vertex 49.8123 1.24934 48.3902
+      vertex 49.8438 1.23627 48.1308
+    endloop
+  endfacet
+  facet normal 0.824332 0.550972 0.130025
+    outer loop
+      vertex 49.7283 3.99786 48.1308
+      vertex 49.5562 4.19413 48.3902
+      vertex 49.6988 3.98078 48.3902
+    endloop
+  endfacet
+  facet normal 0.980807 -0.194982 0
+    outer loop
+      vertex 49.9277 1.48347 48.1308
+      vertex 49.9786 1.73951 -58.1308
+      vertex 49.9786 1.73951 48.1308
+    endloop
+  endfacet
+  facet normal 0.980807 -0.194982 0
+    outer loop
+      vertex 49.9786 1.73951 -58.1308
+      vertex 49.9277 1.48347 48.1308
+      vertex 49.9277 1.48347 -58.1308
+    endloop
+  endfacet
+  facet normal 0.864592 -0.0564996 0.499288
+    outer loop
+      vertex 49.7937 2 48.8846
+      vertex 49.6629 2 49.1111
+      vertex 49.7784 1.76587 48.8846
+    endloop
+  endfacet
+  facet normal 0.99147 0 -0.130336
+    outer loop
+      vertex 49.9957 2 -58.1308
+      vertex 49.9616 3 -58.3902
+      vertex 49.9957 3 -58.1308
+    endloop
+  endfacet
+  facet normal 0.99147 0 -0.130336
+    outer loop
+      vertex 49.9616 3 -58.3902
+      vertex 49.9957 2 -58.1308
+      vertex 49.9616 2 -58.3902
+    endloop
+  endfacet
+  facet normal 0.964002 -0.0632527 -0.258262
+    outer loop
+      vertex 49.9448 1.74396 -58.3902
+      vertex 49.8939 2 -58.6429
+      vertex 49.9616 2 -58.3902
+    endloop
+  endfacet
+  facet normal 0.97248 -0.193326 0.130031
+    outer loop
+      vertex 49.9448 1.74396 48.3902
+      vertex 49.9277 1.48347 48.1308
+      vertex 49.9786 1.73951 48.1308
+    endloop
+  endfacet
+  facet normal 0.938872 -0.318655 0.1303
+    outer loop
+      vertex 49.8947 1.49231 48.3902
+      vertex 49.8438 1.23627 48.1308
+      vertex 49.9277 1.48347 48.1308
+    endloop
+  endfacet
+  facet normal 0.416373 -0.278275 0.865561
+    outer loop
+      vertex 48.7661 1.55771 49.7937
+      vertex 48.7018 1.4615 49.7937
+      vertex 48.9623 1.44443 49.6629
+    endloop
+  endfacet
+  facet normal 0.363296 0.123342 0.923473
+    outer loop
+      vertex 48.8172 3.33851 49.7937
+      vertex 48.5939 3.24602 49.8939
+      vertex 48.8544 3.22894 49.7937
+    endloop
+  endfacet
+  facet normal 0.499757 -0.0327359 0.865547
+    outer loop
+      vertex 49.1111 2 49.6629
+      vertex 48.877 1.88454 49.7937
+      vertex 49.1016 1.85497 49.6629
+    endloop
+  endfacet
+  facet normal 0.382959 0 0.923765
+    outer loop
+      vertex 48.6429 3 49.8939
+      vertex 48.8846 2 49.7937
+      vertex 48.8846 3 49.7937
+    endloop
+  endfacet
+  facet normal 0.382959 0 0.923765
+    outer loop
+      vertex 48.8846 2 49.7937
+      vertex 48.6429 3 49.8939
+      vertex 48.6429 2 49.8939
+    endloop
+  endfacet
+  facet normal 0.706374 -0.0463748 0.706318
+    outer loop
+      vertex 49.3187 2 49.5037
+      vertex 49.3074 1.82788 49.5037
+      vertex 49.4908 1.80373 49.3187
+    endloop
+  endfacet
+  facet normal 0.254312 0.0505664 0.965799
+    outer loop
+      vertex 48.621 3.16639 49.8939
+      vertex 48.3769 3.10099 49.9616
+      vertex 48.6374 3.08391 49.8939
+    endloop
+  endfacet
+  facet normal 0.117298 0.0573489 0.99144
+    outer loop
+      vertex 48.3605 3.14931 49.9616
+      vertex 48.1133 3.0654 49.9957
+      vertex 48.1208 3.05006 49.9957
+    endloop
+  endfacet
+  facet normal 0.82444 -0.550754 -0.130265
+    outer loop
+      vertex 49.5833 0.785085 -58.1308
+      vertex 49.5562 0.805872 -58.3902
+      vertex 49.7283 1.00214 -58.1308
+    endloop
+  endfacet
+  facet normal 0.875161 -0.296968 -0.381972
+    outer loop
+      vertex 49.7497 1.27525 -58.6429
+      vertex 49.7326 1.53574 -58.8846
+      vertex 49.8293 1.50983 -58.6429
+    endloop
+  endfacet
+  facet normal 0.653741 -0.745403 -0.130374
+    outer loop
+      vertex 49.4112 0.588815 -58.1308
+      vertex 49.1941 0.443782 -58.3902
+      vertex 49.387 0.612961 -58.3902
+    endloop
+  endfacet
+  facet normal 0.408726 -0.828882 -0.381965
+    outer loop
+      vertex 48.7247 0.250301 -58.6429
+      vertex 48.6864 0.342795 -58.8846
+      vertex 48.9469 0.359869 -58.6429
+    endloop
+  endfacet
+  facet normal 0.427243 -0.866434 -0.258371
+    outer loop
+      vertex 48.9808 0.30123 -58.3902
+      vertex 48.7247 0.250301 -58.6429
+      vertex 48.9469 0.359869 -58.6429
+    endloop
+  endfacet
+  facet normal 0.318704 -0.93887 -0.130191
+    outer loop
+      vertex 48.5165 0.0722847 -58.1308
+      vertex 48.5077 0.105268 -58.3902
+      vertex 48.7637 0.156198 -58.1308
+    endloop
+  endfacet
+  facet normal 0.0631825 -0.963999 -0.258291
+    outer loop
+      vertex 48.256 0.0552111 -58.3902
+      vertex 48 0.10614 -58.6429
+      vertex 48.2472 0.122342 -58.6429
+    endloop
+  endfacet
+  facet normal 0.297157 -0.8751 -0.381966
+    outer loop
+      vertex 48.4902 0.170672 -58.6429
+      vertex 48.4643 0.267375 -58.8846
+      vertex 48.7247 0.250301 -58.6429
+    endloop
+  endfacet
+  facet normal 0.938977 -0.318441 -0.130069
+    outer loop
+      vertex 49.8438 1.23627 -58.1308
+      vertex 49.8123 1.24934 -58.3902
+      vertex 49.8947 1.49231 -58.3902
+    endloop
+  endfacet
+  facet normal 0.866378 -0.427316 -0.258437
+    outer loop
+      vertex 49.8123 1.24934 -58.3902
+      vertex 49.6988 1.01922 -58.3902
+      vertex 49.7497 1.27525 -58.6429
+    endloop
+  endfacet
+  facet normal 0.499816 -0.0328997 -0.865507
+    outer loop
+      vertex 49.1111 2 -59.6629
+      vertex 48.877 1.88454 -59.7937
+      vertex 48.8846 2 -59.7937
+    endloop
+  endfacet
+  facet normal 0.803137 -0.53681 -0.258469
+    outer loop
+      vertex 49.6988 1.01922 -58.3902
+      vertex 49.5562 0.805872 -58.3902
+      vertex 49.6401 1.05307 -58.6429
+    endloop
+  endfacet
+  facet normal 0.864592 -0.0564996 -0.499288
+    outer loop
+      vertex 49.7784 1.76587 -58.8846
+      vertex 49.6629 2 -59.1111
+      vertex 49.7937 2 -58.8846
+    endloop
+  endfacet
+  facet normal 0.914834 -0.31043 -0.258286
+    outer loop
+      vertex 49.8947 1.49231 -58.3902
+      vertex 49.7497 1.27525 -58.6429
+      vertex 49.8293 1.50983 -58.6429
+    endloop
+  endfacet
+  facet normal 0.506691 -0.338773 -0.792778
+    outer loop
+      vertex 49.142 1.34065 -59.5037
+      vertex 48.8815 1.32358 -59.6629
+      vertex 48.9623 1.44443 -59.6629
+    endloop
+  endfacet
+  facet normal 0.160993 -0.474178 -0.865584
+    outer loop
+      vertex 48.2876 0.926722 -59.6629
+      vertex 48.2289 1.14556 -59.7937
+      vertex 48.4252 0.97344 -59.6629
+    endloop
+  endfacet
+  facet normal 0.694921 -0.609282 -0.381917
+    outer loop
+      vertex 49.5025 0.847092 -58.6429
+      vertex 49.3392 0.660839 -58.6429
+      vertex 49.4231 0.908037 -58.8846
+    endloop
+  endfacet
+  facet normal 0.40176 -0.458185 -0.792878
+    outer loop
+      vertex 48.9325 1.06754 -59.5037
+      vertex 48.6764 1.11847 -59.6629
+      vertex 48.7857 1.21431 -59.6629
+    endloop
+  endfacet
+  facet normal 0.278473 -0.820433 -0.499343
+    outer loop
+      vertex 48.4643 0.267375 -58.8846
+      vertex 48.4304 0.393724 -59.1111
+      vertex 48.6364 0.463645 -59.1111
+    endloop
+  endfacet
+  facet normal 0.278603 -0.820443 -0.499253
+    outer loop
+      vertex 48.6864 0.342795 -58.8846
+      vertex 48.4643 0.267375 -58.8846
+      vertex 48.6364 0.463645 -59.1111
+    endloop
+  endfacet
+  facet normal -0.803137 -0.53681 -0.258469
+    outer loop
+      vertex -49.5562 0.805872 -58.3902
+      vertex -49.6988 1.01922 -58.3902
+      vertex -49.6401 1.05307 -58.6429
+    endloop
+  endfacet
+  facet normal -0.82444 -0.550754 0.130265
+    outer loop
+      vertex -49.5562 0.805872 48.3902
+      vertex -49.7283 1.00214 48.1308
+      vertex -49.5833 0.785085 48.1308
+    endloop
+  endfacet
+  facet normal -0.745479 -0.653676 0.130264
+    outer loop
+      vertex -49.5562 0.805872 48.3902
+      vertex -49.5833 0.785085 48.1308
+      vertex -49.4112 0.588815 48.1308
+    endloop
+  endfacet
+  facet normal -0.338438 -0.506781 -0.792864
+    outer loop
+      vertex -48.6593 0.85798 -59.5037
+      vertex -48.8028 0.953812 -59.5037
+      vertex -48.6764 1.11847 -59.6629
+    endloop
+  endfacet
+  facet normal -0.58865 -0.3932 -0.706318
+    outer loop
+      vertex -49.0462 1.19723 -59.5037
+      vertex -49.3022 1.24816 -59.3187
+      vertex -49.142 1.34065 -59.5037
+    endloop
+  endfacet
+  facet normal -0.571285 -0.651399 -0.499313
+    outer loop
+      vertex -49.092 0.576926 -58.8846
+      vertex -49.2684 0.731631 -58.8846
+      vertex -49.1759 0.824125 -59.1111
+    endloop
+  endfacet
+  facet normal -0.726411 -0.636892 -0.258255
+    outer loop
+      vertex -49.3392 0.660839 -58.6429
+      vertex -49.5562 0.805872 -58.3902
+      vertex -49.5025 0.847092 -58.6429
+    endloop
+  endfacet
+  facet normal 0.0519247 -0.792351 -0.607851
+    outer loop
+      vertex 48.1963 0.509185 -59.3187
+      vertex 48 0.337061 -59.1111
+      vertex 48 0.496321 -59.3187
+    endloop
+  endfacet
+  facet normal 0.0462902 -0.706372 -0.706326
+    outer loop
+      vertex 48.1963 0.509185 -59.3187
+      vertex 48 0.496321 -59.3187
+      vertex 48 0.681309 -59.5037
+    endloop
+  endfacet
+  facet normal 0.0398685 -0.608134 -0.792832
+    outer loop
+      vertex 48.145 0.898366 -59.6629
+      vertex 48 0.681309 -59.5037
+      vertex 48 0.88886 -59.6629
+    endloop
+  endfacet
+  facet normal 0 -0.382959 -0.923765
+    outer loop
+      vertex -48 1.11542 -59.7937
+      vertex 48 1.35712 -59.8939
+      vertex 48 1.11542 -59.7937
+    endloop
+  endfacet
+  facet normal -0 -0.382959 -0.923765
+    outer loop
+      vertex 48 1.35712 -59.8939
+      vertex -48 1.11542 -59.7937
+      vertex -48 1.35712 -59.8939
+    endloop
+  endfacet
+  facet normal -0.0748893 -0.376272 -0.923478
+    outer loop
+      vertex -48.1155 1.12299 -59.7937
+      vertex -48.2289 1.14556 -59.7937
+      vertex -48.0839 1.36262 -59.8939
+    endloop
+  endfacet
+  facet normal -0.123368 0.363305 -0.923466
+    outer loop
+      vertex -48.1664 3.62097 -59.8939
+      vertex -48.246 3.59394 -59.8939
+      vertex -48.2289 3.85444 -59.7937
+    endloop
+  endfacet
+  facet normal -0.130331 -0.00870067 -0.991432
+    outer loop
+      vertex -48.3868 1.94907 -59.9616
+      vertex -48.3902 2 -59.9616
+      vertex -48.1308 2 -59.9957
+    endloop
+  endfacet
+  facet normal -0.0250966 -0.382837 -0.923475
+    outer loop
+      vertex -48 1.35712 -59.8939
+      vertex -48.1155 1.12299 -59.7937
+      vertex -48.0839 1.36262 -59.8939
+    endloop
+  endfacet
+  facet normal -0.506691 -0.338773 -0.792778
+    outer loop
+      vertex -48.8815 1.32358 -59.6629
+      vertex -49.142 1.34065 -59.5037
+      vertex -48.9623 1.44443 -59.6629
+    endloop
+  endfacet
+  facet normal -0.706344 -0.046425 -0.706344
+    outer loop
+      vertex -49.4908 1.80373 -59.3187
+      vertex -49.5037 2 -59.3187
+      vertex -49.3187 2 -59.5037
+    endloop
+  endfacet
+  facet normal 0 0.707126 -0.707088
+    outer loop
+      vertex -48 4.31869 -59.5037
+      vertex 48 4.50368 -59.3187
+      vertex 48 4.31869 -59.5037
+    endloop
+  endfacet
+  facet normal 0 0.707126 -0.707088
+    outer loop
+      vertex 48 4.50368 -59.3187
+      vertex -48 4.31869 -59.5037
+      vertex -48 4.50368 -59.3187
+    endloop
+  endfacet
+  facet normal -0.258645 0.0172667 -0.965818
+    outer loop
+      vertex -48.3902 3 -59.9616
+      vertex -48.6374 3.08391 -59.8939
+      vertex -48.3868 3.05093 -59.9616
+    endloop
+  endfacet
+  facet normal 0.215801 0.143902 -0.965775
+    outer loop
+      vertex 48.3379 3.19509 -59.9616
+      vertex 48.3096 3.23753 -59.9616
+      vertex 48.51 3.39136 -59.8939
+    endloop
+  endfacet
+  facet normal 0.500086 0 -0.865975
+    outer loop
+      vertex 48.8846 2 -59.7937
+      vertex 49.1111 3 -59.6629
+      vertex 49.1111 2 -59.6629
+    endloop
+  endfacet
+  facet normal 0.500086 0 -0.865975
+    outer loop
+      vertex 49.1111 3 -59.6629
+      vertex 48.8846 2 -59.7937
+      vertex 48.8846 3 -59.7937
+    endloop
+  endfacet
+  facet normal 0.215801 -0.143902 -0.965775
+    outer loop
+      vertex 48.51 1.60864 -59.8939
+      vertex 48.3096 1.76247 -59.9616
+      vertex 48.3379 1.80491 -59.9616
+    endloop
+  endfacet
+  facet normal 0.706374 0.0463748 -0.706318
+    outer loop
+      vertex 49.3187 3 -59.5037
+      vertex 49.3074 3.17212 -59.5037
+      vertex 49.4908 3.19627 -59.3187
+    endloop
+  endfacet
+  facet normal 0.776999 0.383541 -0.499168
+    outer loop
+      vertex 49.5364 3.63638 -59.1111
+      vertex 49.4401 3.83147 -59.1111
+      vertex 49.6572 3.68644 -58.8846
+    endloop
+  endfacet
+  facet normal 0.258645 0.0172667 -0.965818
+    outer loop
+      vertex 48.3902 3 -59.9616
+      vertex 48.3868 3.05093 -59.9616
+      vertex 48.6374 3.08391 -59.8939
+    endloop
+  endfacet
+  facet normal 0.506732 0.338481 -0.792876
+    outer loop
+      vertex 49.142 3.65935 -59.5037
+      vertex 48.8815 3.67642 -59.6629
+      vertex 49.0462 3.80277 -59.5037
+    endloop
+  endfacet
+  facet normal 0.449015 -0.221476 -0.865641
+    outer loop
+      vertex 48.9623 1.44443 -59.6629
+      vertex 48.8172 1.66149 -59.7937
+      vertex 49.0266 1.57479 -59.6629
+    endloop
+  endfacet
+  facet normal 0.3633 -0.12364 -0.923432
+    outer loop
+      vertex 48.8544 1.77106 -59.7937
+      vertex 48.5939 1.75398 -59.8939
+      vertex 48.621 1.83361 -59.8939
+    endloop
+  endfacet
+  facet normal 0.914848 0.310258 -0.258442
+    outer loop
+      vertex 49.8947 3.50769 -58.3902
+      vertex 49.7497 3.72475 -58.6429
+      vertex 49.8123 3.75066 -58.3902
+    endloop
+  endfacet
+  facet normal 0.98938 0.0649484 -0.130031
+    outer loop
+      vertex 49.9957 3 -58.1308
+      vertex 49.9448 3.25604 -58.3902
+      vertex 49.9786 3.26049 -58.1308
+    endloop
+  endfacet
+  facet normal 0.745478 0.653675 -0.130271
+    outer loop
+      vertex 49.5562 4.19413 -58.3902
+      vertex 49.4112 4.41119 -58.1308
+      vertex 49.5833 4.21492 -58.1308
+    endloop
+  endfacet
+  facet normal 0.824445 0.550744 -0.130272
+    outer loop
+      vertex 49.7283 3.99786 -58.1308
+      vertex 49.5562 4.19413 -58.3902
+      vertex 49.5833 4.21492 -58.1308
+    endloop
+  endfacet
+  facet normal 0.938977 0.318441 -0.130069
+    outer loop
+      vertex 49.8947 3.50769 -58.3902
+      vertex 49.8123 3.75066 -58.3902
+      vertex 49.8438 3.76373 -58.1308
+    endloop
+  endfacet
+  facet normal 0.889226 0.438585 -0.130081
+    outer loop
+      vertex 49.8123 3.75066 -58.3902
+      vertex 49.6988 3.98078 -58.3902
+      vertex 49.8438 3.76373 -58.1308
+    endloop
+  endfacet
+  facet normal 0.938872 0.318655 -0.1303
+    outer loop
+      vertex 49.8947 3.50769 -58.3902
+      vertex 49.8438 3.76373 -58.1308
+      vertex 49.9277 3.51653 -58.1308
+    endloop
+  endfacet
+  facet normal 0.866378 0.427316 -0.258437
+    outer loop
+      vertex 49.7497 3.72475 -58.6429
+      vertex 49.6988 3.98078 -58.3902
+      vertex 49.8123 3.75066 -58.3902
+    endloop
+  endfacet
+  facet normal 0.866341 0.42736 -0.25849
+    outer loop
+      vertex 49.7497 3.72475 -58.6429
+      vertex 49.6401 3.94693 -58.6429
+      vertex 49.6988 3.98078 -58.3902
+    endloop
+  endfacet
+  facet normal 0.875143 0.296992 -0.381996
+    outer loop
+      vertex 49.7326 3.46426 -58.8846
+      vertex 49.6572 3.68644 -58.8846
+      vertex 49.7497 3.72475 -58.6429
+    endloop
+  endfacet
+  facet normal 0.71219 0.35123 -0.607801
+    outer loop
+      vertex 49.3892 3.57543 -59.3187
+      vertex 49.3022 3.75184 -59.3187
+      vertex 49.4401 3.83147 -59.1111
+    endloop
+  endfacet
+  facet normal 0.777012 0.383281 -0.499347
+    outer loop
+      vertex 49.6572 3.68644 -58.8846
+      vertex 49.4401 3.83147 -59.1111
+      vertex 49.5534 3.89687 -58.8846
+    endloop
+  endfacet
+  facet normal 0.972391 0.19359 -0.130302
+    outer loop
+      vertex 49.9448 3.25604 -58.3902
+      vertex 49.8947 3.50769 -58.3902
+      vertex 49.9277 3.51653 -58.1308
+    endloop
+  endfacet
+  facet normal 0.964026 0.0631765 -0.25819
+    outer loop
+      vertex 49.8939 3 -58.6429
+      vertex 49.8777 3.2472 -58.6429
+      vertex 49.9448 3.25604 -58.3902
+    endloop
+  endfacet
+  facet normal 0.849746 0.169115 -0.499332
+    outer loop
+      vertex 49.7784 3.23413 -58.8846
+      vertex 49.6487 3.21706 -59.1111
+      vertex 49.7326 3.46426 -58.8846
+    endloop
+  endfacet
+  facet normal 0.90634 0.180378 -0.382115
+    outer loop
+      vertex 49.7784 3.23413 -58.8846
+      vertex 49.7326 3.46426 -58.8846
+      vertex 49.8777 3.2472 -58.6429
+    endloop
+  endfacet
+  facet normal 0.588625 0.3934 -0.706227
+    outer loop
+      vertex 49.3022 3.75184 -59.3187
+      vertex 49.0462 3.80277 -59.5037
+      vertex 49.1929 3.91538 -59.3187
+    endloop
+  endfacet
+  facet normal 0.820543 0.278463 -0.499167
+    outer loop
+      vertex 49.7326 3.46426 -58.8846
+      vertex 49.5364 3.63638 -59.1111
+      vertex 49.6572 3.68644 -58.8846
+    endloop
+  endfacet
+  facet normal 0.824332 0.550972 -0.130025
+    outer loop
+      vertex 49.6988 3.98078 -58.3902
+      vertex 49.5562 4.19413 -58.3902
+      vertex 49.7283 3.99786 -58.1308
+    endloop
+  endfacet
+  facet normal 0.751886 0.659293 0
+    outer loop
+      vertex 49.5833 4.21492 48.1308
+      vertex 49.4112 4.41119 -58.1308
+      vertex 49.4112 4.41119 48.1308
+    endloop
+  endfacet
+  facet normal 0.751886 0.659293 0
+    outer loop
+      vertex 49.4112 4.41119 -58.1308
+      vertex 49.5833 4.21492 48.1308
+      vertex 49.5833 4.21492 -58.1308
+    endloop
+  endfacet
+  facet normal 0.555664 0.831407 -0
+    outer loop
+      vertex 49.2149 4.58331 -58.1308
+      vertex 48.9979 4.72834 48.1308
+      vertex 49.2149 4.58331 48.1308
+    endloop
+  endfacet
+  facet normal 0.555664 0.831407 0
+    outer loop
+      vertex 48.9979 4.72834 48.1308
+      vertex 49.2149 4.58331 -58.1308
+      vertex 48.9979 4.72834 -58.1308
+    endloop
+  endfacet
+  facet normal 0.550929 0.824323 -0.130263
+    outer loop
+      vertex 49.1941 4.55622 -58.3902
+      vertex 48.9979 4.72834 -58.1308
+      vertex 49.2149 4.58331 -58.1308
+    endloop
+  endfacet
+  facet normal -0.98938 0.0649484 0.130031
+    outer loop
+      vertex -49.9786 3.26049 48.1308
+      vertex -49.9957 3 48.1308
+      vertex -49.9448 3.25604 48.3902
+    endloop
+  endfacet
+  facet normal -0.989379 0.0649178 0.130061
+    outer loop
+      vertex -49.9448 3.25604 48.3902
+      vertex -49.9957 3 48.1308
+      vertex -49.9616 3 48.3902
+    endloop
+  endfacet
+  facet normal -0.458211 -0.401726 -0.792881
+    outer loop
+      vertex -48.7857 1.21431 -59.6629
+      vertex -48.9325 1.06754 -59.5037
+      vertex -48.8815 1.32358 -59.6629
+    endloop
+  endfacet
+  facet normal -0.820543 -0.278463 -0.499167
+    outer loop
+      vertex -49.6572 1.31356 -58.8846
+      vertex -49.7326 1.53574 -58.8846
+      vertex -49.5364 1.36362 -59.1111
+    endloop
+  endfacet
+  facet normal -0.938872 0.318655 -0.1303
+    outer loop
+      vertex -49.8947 3.50769 -58.3902
+      vertex -49.9277 3.51653 -58.1308
+      vertex -49.8438 3.76373 -58.1308
+    endloop
+  endfacet
+  facet normal -0.889201 0.438657 0.130007
+    outer loop
+      vertex -49.7283 3.99786 48.1308
+      vertex -49.8438 3.76373 48.1308
+      vertex -49.6988 3.98078 48.3902
+    endloop
+  endfacet
+  facet normal -0.866378 0.427316 0.258437
+    outer loop
+      vertex -49.6988 3.98078 48.3902
+      vertex -49.8123 3.75066 48.3902
+      vertex -49.7497 3.72475 48.6429
+    endloop
+  endfacet
+  facet normal -0.923765 0 -0.382959
+    outer loop
+      vertex -49.7937 2 -58.8846
+      vertex -49.8939 3 -58.6429
+      vertex -49.7937 3 -58.8846
+    endloop
+  endfacet
+  facet normal -0.923765 -0 -0.382959
+    outer loop
+      vertex -49.8939 3 -58.6429
+      vertex -49.7937 2 -58.8846
+      vertex -49.8939 2 -58.6429
+    endloop
+  endfacet
+  facet normal -0.427287 0.866398 -0.25842
+    outer loop
+      vertex -48.7247 4.7497 -58.6429
+      vertex -48.9808 4.69877 -58.3902
+      vertex -48.7507 4.81225 -58.3902
+    endloop
+  endfacet
+  facet normal -0.914848 0.310258 -0.258442
+    outer loop
+      vertex -49.7497 3.72475 -58.6429
+      vertex -49.8947 3.50769 -58.3902
+      vertex -49.8123 3.75066 -58.3902
+    endloop
+  endfacet
+  facet normal -0.376317 0.0749451 -0.923455
+    outer loop
+      vertex -48.6374 3.08391 -59.8939
+      vertex -48.877 3.11546 -59.7937
+      vertex -48.8544 3.22894 -59.7937
+    endloop
+  endfacet
+  facet normal -0.751827 -0.255117 -0.608006
+    outer loop
+      vertex -49.3892 1.42457 -59.3187
+      vertex -49.6063 1.5696 -59.1111
+      vertex -49.4524 1.61082 -59.3187
+    endloop
+  endfacet
+  facet normal -0.792455 -0.0520848 -0.607702
+    outer loop
+      vertex -49.4908 1.80373 -59.3187
+      vertex -49.6629 2 -59.1111
+      vertex -49.5037 2 -59.3187
+    endloop
+  endfacet
+  facet normal -0.97248 -0.193326 -0.130031
+    outer loop
+      vertex -49.9277 1.48347 -58.1308
+      vertex -49.9786 1.73951 -58.1308
+      vertex -49.9448 1.74396 -58.3902
+    endloop
+  endfacet
+  facet normal -0.938872 -0.318655 -0.1303
+    outer loop
+      vertex -49.8438 1.23627 -58.1308
+      vertex -49.9277 1.48347 -58.1308
+      vertex -49.8947 1.49231 -58.3902
+    endloop
+  endfacet
+  facet normal -0.193406 0.972437 0.130234
+    outer loop
+      vertex -48.256 4.94479 48.3902
+      vertex -48.5165 4.92772 48.1308
+      vertex -48.5077 4.89473 48.3902
+    endloop
+  endfacet
+  facet normal -0.278469 0.820432 0.499345
+    outer loop
+      vertex -48.4643 4.73263 48.8846
+      vertex -48.6364 4.53636 49.1111
+      vertex -48.4304 4.60628 49.1111
+    endloop
+  endfacet
+  facet normal -0.550908 0.824333 0.130286
+    outer loop
+      vertex -48.9979 4.72834 48.1308
+      vertex -49.1941 4.55622 48.3902
+      vertex -48.9808 4.69877 48.3902
+    endloop
+  endfacet
+  facet normal -0.35117 0.712123 0.607915
+    outer loop
+      vertex -48.6364 4.53636 49.1111
+      vertex -48.8315 4.44015 49.1111
+      vertex -48.5754 4.38922 49.3187
+    endloop
+  endfacet
+  facet normal -0.0250917 0.382839 0.923474
+    outer loop
+      vertex -48 3.88458 49.7937
+      vertex -48.1155 3.87701 49.7937
+      vertex -48 3.64288 49.8939
+    endloop
+  endfacet
+  facet normal -0 0.499987 0.866033
+    outer loop
+      vertex -48 4.11114 49.6629
+      vertex 48 3.88458 49.7937
+      vertex 48 4.11114 49.6629
+    endloop
+  endfacet
+  facet normal 0 0.499987 0.866033
+    outer loop
+      vertex 48 3.88458 49.7937
+      vertex -48 4.11114 49.6629
+      vertex -48 3.88458 49.7937
+    endloop
+  endfacet
+  facet normal -0.536775 0.803185 0.258391
+    outer loop
+      vertex -48.9808 4.69877 48.3902
+      vertex -49.1941 4.55622 48.3902
+      vertex -48.9469 4.64013 48.6429
+    endloop
+  endfacet
+  facet normal -0.154921 0.778801 0.607839
+    outer loop
+      vertex -48.2171 4.64871 49.1111
+      vertex -48.4304 4.60628 49.1111
+      vertex -48.1963 4.49082 49.3187
+    endloop
+  endfacet
+  facet normal -0.82882 0.408837 0.381982
+    outer loop
+      vertex -49.6401 3.94693 48.6429
+      vertex -49.6572 3.68644 48.8846
+      vertex -49.5534 3.89687 48.8846
+    endloop
+  endfacet
+  facet normal -0.71194 0.351426 0.607981
+    outer loop
+      vertex -49.4401 3.83147 49.1111
+      vertex -49.5364 3.63638 49.1111
+      vertex -49.3892 3.57543 49.3187
+    endloop
+  endfacet
+  facet normal -0.865975 0 0.500086
+    outer loop
+      vertex -49.7937 2 48.8846
+      vertex -49.6629 3 49.1111
+      vertex -49.7937 3 48.8846
+    endloop
+  endfacet
+  facet normal -0.865975 0 0.500086
+    outer loop
+      vertex -49.6629 3 49.1111
+      vertex -49.7937 2 48.8846
+      vertex -49.6629 2 49.1111
+    endloop
+  endfacet
+  facet normal -0.947452 0.188734 0.25829
+    outer loop
+      vertex -49.8293 3.49017 48.6429
+      vertex -49.8947 3.50769 48.3902
+      vertex -49.8777 3.2472 48.6429
+    endloop
+  endfacet
+  facet normal -0.57127 0.651403 0.499325
+    outer loop
+      vertex -49.092 4.42307 48.8846
+      vertex -49.2684 4.26837 48.8846
+      vertex -49.1759 4.17587 49.1111
+    endloop
+  endfacet
+  facet normal -0.90634 0.180378 0.382115
+    outer loop
+      vertex -49.7326 3.46426 48.8846
+      vertex -49.8777 3.2472 48.6429
+      vertex -49.7784 3.23413 48.8846
+    endloop
+  endfacet
+  facet normal -0.608528 0 0.793533
+    outer loop
+      vertex -49.3187 3 49.5037
+      vertex -49.1111 2 49.6629
+      vertex -49.1111 3 49.6629
+    endloop
+  endfacet
+  facet normal -0.608528 0 0.793533
+    outer loop
+      vertex -49.1111 2 49.6629
+      vertex -49.3187 3 49.5037
+      vertex -49.3187 2 49.5037
+    endloop
+  endfacet
+  facet normal -0.382959 0 0.923765
+    outer loop
+      vertex -48.8846 3 49.7937
+      vertex -48.6429 2 49.8939
+      vertex -48.6429 3 49.8939
+    endloop
+  endfacet
+  facet normal -0.382959 0 0.923765
+    outer loop
+      vertex -48.6429 2 49.8939
+      vertex -48.8846 3 49.7937
+      vertex -48.8846 2 49.7937
+    endloop
+  endfacet
+  facet normal -0.597714 0.118709 0.792872
+    outer loop
+      vertex -49.2738 3.3413 49.5037
+      vertex -49.3074 3.17212 49.5037
+      vertex -49.1016 3.14503 49.6629
+    endloop
+  endfacet
+  facet normal -0.768496 0.513376 0.381915
+    outer loop
+      vertex -49.5025 4.15291 48.6429
+      vertex -49.6401 3.94693 48.6429
+      vertex -49.4231 4.09196 48.8846
+    endloop
+  endfacet
+  facet normal -0.458218 0.401723 0.792878
+    outer loop
+      vertex -48.9325 3.93246 49.5037
+      vertex -49.0462 3.80277 49.5037
+      vertex -48.8815 3.67642 49.6629
+    endloop
+  endfacet
+  facet normal -0.546657 0.269601 0.792768
+    outer loop
+      vertex -49.142 3.65935 49.5037
+      vertex -49.2183 3.50464 49.5037
+      vertex -49.0266 3.42521 49.6629
+    endloop
+  endfacet
+  facet normal -0.344087 -0.169717 0.923472
+    outer loop
+      vertex -48.5939 1.75398 49.8939
+      vertex -48.8172 1.66149 49.7937
+      vertex -48.5567 1.67856 49.8939
+    endloop
+  endfacet
+  facet normal -0.221416 -0.449171 0.865575
+    outer loop
+      vertex -48.3385 1.18276 49.7937
+      vertex -48.5556 1.03772 49.6629
+      vertex -48.4252 0.97344 49.6629
+    endloop
+  endfacet
+  facet normal -0.866341 -0.42736 0.25849
+    outer loop
+      vertex -49.6401 1.05307 48.6429
+      vertex -49.7497 1.27525 48.6429
+      vertex -49.6988 1.01922 48.3902
+    endloop
+  endfacet
+  facet normal -0.82882 -0.408837 0.381982
+    outer loop
+      vertex -49.5534 1.10313 48.8846
+      vertex -49.6572 1.31356 48.8846
+      vertex -49.6401 1.05307 48.6429
+    endloop
+  endfacet
+  facet normal -0.318905 -0.213134 0.923512
+    outer loop
+      vertex -48.5567 1.67856 49.8939
+      vertex -48.7661 1.55771 49.7937
+      vertex -48.7018 1.4615 49.7937
+    endloop
+  endfacet
+  facet normal -0.258743 -0.0169597 0.965797
+    outer loop
+      vertex -48.3902 2 49.9616
+      vertex -48.6429 2 49.8939
+      vertex -48.6374 1.91609 49.8939
+    endloop
+  endfacet
+  facet normal -0.258645 0.0172667 0.965818
+    outer loop
+      vertex -48.3868 3.05093 49.9616
+      vertex -48.6374 3.08391 49.8939
+      vertex -48.3902 3 49.9616
+    endloop
+  endfacet
+  facet normal -0.194878 0.17116 0.965778
+    outer loop
+      vertex -48.2759 3.2759 49.9616
+      vertex -48.51 3.39136 49.8939
+      vertex -48.3096 3.23753 49.9616
+    endloop
+  endfacet
+  facet normal -0.499816 0.0328997 0.865507
+    outer loop
+      vertex -48.877 3.11546 49.7937
+      vertex -49.1111 3 49.6629
+      vertex -48.8846 3 49.7937
+    endloop
+  endfacet
+  facet normal -0.500086 0 0.865975
+    outer loop
+      vertex -49.1111 3 49.6629
+      vertex -48.8846 2 49.7937
+      vertex -48.8846 3 49.7937
+    endloop
+  endfacet
+  facet normal -0.500086 0 0.865975
+    outer loop
+      vertex -48.8846 2 49.7937
+      vertex -49.1111 3 49.6629
+      vertex -49.1111 2 49.6629
+    endloop
+  endfacet
+  facet normal 0.408729 0.828873 0.381982
+    outer loop
+      vertex 48.7247 4.7497 48.6429
+      vertex 48.6864 4.6572 48.8846
+      vertex 48.9469 4.64013 48.6429
+    endloop
+  endfacet
+  facet normal 0.3105 0.914784 0.25838
+    outer loop
+      vertex 48.7507 4.81225 48.3902
+      vertex 48.5077 4.89473 48.3902
+      vertex 48.7247 4.7497 48.6429
+    endloop
+  endfacet
+  facet normal 0.169036 0.849763 0.499329
+    outer loop
+      vertex 48.4643 4.73263 48.8846
+      vertex 48.2171 4.64871 49.1111
+      vertex 48.4304 4.60628 49.1111
+    endloop
+  endfacet
+  facet normal 0.0631869 0.963996 0.258299
+    outer loop
+      vertex 48 4.96157 48.3902
+      vertex 48 4.89386 48.6429
+      vertex 48.256 4.94479 48.3902
+    endloop
+  endfacet
+  facet normal 0.609286 0.69493 0.381894
+    outer loop
+      vertex 49.1529 4.5025 48.6429
+      vertex 49.092 4.42307 48.8846
+      vertex 49.3392 4.33916 48.6429
+    endloop
+  endfacet
+  facet normal 0.0462756 0.706368 0.70633
+    outer loop
+      vertex 48 4.50368 49.3187
+      vertex 48 4.31869 49.5037
+      vertex 48.1963 4.49082 49.3187
+    endloop
+  endfacet
+  facet normal 0.215801 -0.143902 0.965775
+    outer loop
+      vertex 48.3379 1.80491 49.9616
+      vertex 48.3096 1.76247 49.9616
+      vertex 48.51 1.60864 49.8939
+    endloop
+  endfacet
+  facet normal 0.0833786 -0.24554 0.965794
+    outer loop
+      vertex 48.246 1.40606 49.8939
+      vertex 48.101 1.62311 49.9616
+      vertex 48.1664 1.37903 49.8939
+    endloop
+  endfacet
+  facet normal -0.288396 -0.252955 0.923494
+    outer loop
+      vertex -48.51 1.60864 49.8939
+      vertex -48.7018 1.4615 49.7937
+      vertex -48.6255 1.37451 49.7937
+    endloop
+  endfacet
+  facet normal -0.160955 -0.474212 0.865573
+    outer loop
+      vertex -48.3385 1.18276 49.7937
+      vertex -48.4252 0.97344 49.6629
+      vertex -48.2289 1.14556 49.7937
+    endloop
+  endfacet
+  facet normal 0 -0.382959 0.923765
+    outer loop
+      vertex -48 1.35712 49.8939
+      vertex 48 1.11542 49.7937
+      vertex 48 1.35712 49.8939
+    endloop
+  endfacet
+  facet normal 0 -0.382959 0.923765
+    outer loop
+      vertex 48 1.11542 49.7937
+      vertex -48 1.35712 49.8939
+      vertex -48 1.11542 49.7937
+    endloop
+  endfacet
+  facet normal -0.0250917 -0.382839 0.923474
+    outer loop
+      vertex -48 1.35712 49.8939
+      vertex -48.1155 1.12299 49.7937
+      vertex -48 1.11542 49.7937
+    endloop
+  endfacet
+  facet normal -0.123311 -0.363304 0.923474
+    outer loop
+      vertex -48.246 1.40606 49.8939
+      vertex -48.3385 1.18276 49.7937
+      vertex -48.2289 1.14556 49.7937
+    endloop
+  endfacet
+  facet normal 0.213009 -0.319148 0.923456
+    outer loop
+      vertex 48.3914 1.48997 49.8939
+      vertex 48.3214 1.44325 49.8939
+      vertex 48.5385 1.29822 49.7937
+    endloop
+  endfacet
+  facet normal 0.0579371 -0.117099 0.991429
+    outer loop
+      vertex 48.0654 1.88672 49.9957
+      vertex 48.0501 1.87915 49.9957
+      vertex 48.1493 1.63952 49.9616
+    endloop
+  endfacet
+  facet normal 0.118861 -0.597742 0.792828
+    outer loop
+      vertex 48.2876 0.926722 49.6629
+      vertex 48.145 0.898366 49.6629
+      vertex 48.3413 0.726242 49.5037
+    endloop
+  endfacet
+  facet normal 0.160955 -0.474212 0.865573
+    outer loop
+      vertex 48.3385 1.18276 49.7937
+      vertex 48.2289 1.14556 49.7937
+      vertex 48.4252 0.97344 49.6629
+    endloop
+  endfacet
+  facet normal -0.254312 0.0505664 0.965799
+    outer loop
+      vertex -48.621 3.16639 49.8939
+      vertex -48.6374 3.08391 49.8939
+      vertex -48.3769 3.10099 49.9616
+    endloop
+  endfacet
+  facet normal -0.0726213 0.108573 0.991432
+    outer loop
+      vertex -48.1951 3.33791 49.9616
+      vertex -48.2375 3.30955 49.9616
+      vertex -48.0654 3.11328 49.9957
+    endloop
+  endfacet
+  facet normal -0.0254463 0.128126 0.991431
+    outer loop
+      vertex -48.0509 3.38684 49.9616
+      vertex -48.101 3.37689 49.9616
+      vertex -48.0171 3.12969 49.9957
+    endloop
+  endfacet
+  facet normal -0.160955 0.474212 0.865573
+    outer loop
+      vertex -48.2289 3.85444 49.7937
+      vertex -48.4252 4.02656 49.6629
+      vertex -48.3385 3.81724 49.7937
+    endloop
+  endfacet
+  facet normal 0.144138 0.215495 0.965809
+    outer loop
+      vertex 48.3914 3.51003 49.8939
+      vertex 48.1951 3.33791 49.9616
+      vertex 48.2375 3.30955 49.9616
+    endloop
+  endfacet
+  facet normal -0 0.258781 0.965936
+    outer loop
+      vertex -48 3.64288 49.8939
+      vertex 48 3.39018 49.9616
+      vertex 48 3.64288 49.8939
+    endloop
+  endfacet
+  facet normal 0 0.258781 0.965936
+    outer loop
+      vertex 48 3.39018 49.9616
+      vertex -48 3.64288 49.8939
+      vertex -48 3.39018 49.9616
+    endloop
+  endfacet
+  facet normal 0.123368 0.363305 0.923466
+    outer loop
+      vertex 48.2289 3.85444 49.7937
+      vertex 48.1664 3.62097 49.8939
+      vertex 48.246 3.59394 49.8939
+    endloop
+  endfacet
+  facet normal 0.170862 0.194981 0.96581
+    outer loop
+      vertex 48.3914 3.51003 49.8939
+      vertex 48.2375 3.30955 49.9616
+      vertex 48.2759 3.2759 49.9616
+    endloop
+  endfacet
+  facet normal 0.319 0.213062 0.923495
+    outer loop
+      vertex 48.7018 3.5385 49.7937
+      vertex 48.51 3.39136 49.8939
+      vertex 48.5567 3.32144 49.8939
+    endloop
+  endfacet
+  facet normal 0.215653 0.144036 0.965788
+    outer loop
+      vertex 48.51 3.39136 49.8939
+      vertex 48.3379 3.19509 49.9616
+      vertex 48.5567 3.32144 49.8939
+    endloop
+  endfacet
+  facet normal 0.245476 0.0835415 0.965796
+    outer loop
+      vertex 48.5939 3.24602 49.8939
+      vertex 48.3769 3.10099 49.9616
+      vertex 48.621 3.16639 49.8939
+    endloop
+  endfacet
+  facet normal -0.0604353 0.922198 -0.381966
+    outer loop
+      vertex -48 4.79375 -58.8846
+      vertex -48.2472 4.87766 -58.6429
+      vertex -48 4.89386 -58.6429
+    endloop
+  endfacet
+  facet normal -0.0566898 0.864566 -0.499311
+    outer loop
+      vertex -48 4.66294 -59.1111
+      vertex -48.2341 4.7784 -58.8846
+      vertex -48 4.79375 -58.8846
+    endloop
+  endfacet
+  facet normal -0.441217 0.660091 -0.607954
+    outer loop
+      vertex -48.7518 4.30222 -59.3187
+      vertex -49.0123 4.3193 -59.1111
+      vertex -48.8315 4.44015 -59.1111
+    endloop
+  endfacet
+  facet normal -0.726325 0.637055 -0.258095
+    outer loop
+      vertex -49.3392 4.33916 -58.6429
+      vertex -49.5562 4.19413 -58.3902
+      vertex -49.387 4.38704 -58.3902
+    endloop
+  endfacet
+  facet normal -0.18845 0.947514 -0.258272
+    outer loop
+      vertex -48.4902 4.82933 -58.6429
+      vertex -48.5077 4.89473 -58.3902
+      vertex -48.2472 4.87766 -58.6429
+    endloop
+  endfacet
+  facet normal -0.180278 0.906424 -0.381963
+    outer loop
+      vertex -48.4643 4.73263 -58.8846
+      vertex -48.4902 4.82933 -58.6429
+      vertex -48.2472 4.87766 -58.6429
+    endloop
+  endfacet
+  facet normal 0.227602 0.670286 -0.706339
+    outer loop
+      vertex 48.5046 4.21831 -59.5037
+      vertex 48.3413 4.27376 -59.5037
+      vertex 48.5754 4.38922 -59.3187
+    endloop
+  endfacet
+  facet normal 0.3105 0.914784 -0.25838
+    outer loop
+      vertex 48.7247 4.7497 -58.6429
+      vertex 48.5077 4.89473 -58.3902
+      vertex 48.7507 4.81225 -58.3902
+    endloop
+  endfacet
+  facet normal 0.481448 0.72028 -0.499404
+    outer loop
+      vertex 49.0123 4.3193 -59.1111
+      vertex 48.8315 4.44015 -59.1111
+      vertex 49.092 4.42307 -58.8846
+    endloop
+  endfacet
+  facet normal 0.571131 0.651447 -0.499425
+    outer loop
+      vertex 49.1759 4.17587 -59.1111
+      vertex 49.0123 4.3193 -59.1111
+      vertex 49.092 4.42307 -58.8846
+    endloop
+  endfacet
+  facet normal 0.51342 0.76847 -0.381907
+    outer loop
+      vertex 49.092 4.42307 -58.8846
+      vertex 48.9469 4.64013 -58.6429
+      vertex 49.1529 4.5025 -58.6429
+    endloop
+  endfacet
+  facet normal 0.536682 0.803288 -0.258266
+    outer loop
+      vertex 49.1529 4.5025 -58.6429
+      vertex 48.9469 4.64013 -58.6429
+      vertex 49.1941 4.55622 -58.3902
+    endloop
+  endfacet
+  facet normal 0.427287 0.866398 -0.25842
+    outer loop
+      vertex 48.9808 4.69877 -58.3902
+      vertex 48.7247 4.7497 -58.6429
+      vertex 48.7507 4.81225 -58.3902
+    endloop
+  endfacet
+  facet normal 0.513462 0.76846 -0.381872
+    outer loop
+      vertex 49.092 4.42307 -58.8846
+      vertex 48.8969 4.55343 -58.8846
+      vertex 48.9469 4.64013 -58.6429
+    endloop
+  endfacet
+  facet normal 0.43855 0.889235 -0.130133
+    outer loop
+      vertex 48.9808 4.69877 -58.3902
+      vertex 48.7507 4.81225 -58.3902
+      vertex 48.7637 4.8438 -58.1308
+    endloop
+  endfacet
+  facet normal 0.278641 0.820446 -0.499226
+    outer loop
+      vertex 48.6364 4.53636 -59.1111
+      vertex 48.4643 4.73263 -58.8846
+      vertex 48.6864 4.6572 -58.8846
+    endloop
+  endfacet
+  facet normal 0.768496 0.513376 -0.381915
+    outer loop
+      vertex 49.6401 3.94693 -58.6429
+      vertex 49.4231 4.09196 -58.8846
+      vertex 49.5025 4.15291 -58.6429
+    endloop
+  endfacet
+  facet normal 0.768518 0.513291 -0.381985
+    outer loop
+      vertex 49.5534 3.89687 -58.8846
+      vertex 49.4231 4.09196 -58.8846
+      vertex 49.6401 3.94693 -58.6429
+    endloop
+  endfacet
+  facet normal 0.651419 0.571252 -0.499325
+    outer loop
+      vertex 49.4231 4.09196 -58.8846
+      vertex 49.1759 4.17587 -59.1111
+      vertex 49.2684 4.26837 -58.8846
+    endloop
+  endfacet
+  facet normal 0.597118 0.523306 -0.607949
+    outer loop
+      vertex 49.1929 3.91538 -59.3187
+      vertex 49.0633 4.06326 -59.3187
+      vertex 49.3193 4.01233 -59.1111
+    endloop
+  endfacet
+  facet normal 0.351167 -0.71213 0.607909
+    outer loop
+      vertex 48.8315 0.559853 49.1111
+      vertex 48.5754 0.610782 49.3187
+      vertex 48.6364 0.463645 49.1111
+    endloop
+  endfacet
+  facet normal 0.441076 -0.660346 0.607779
+    outer loop
+      vertex 48.9154 0.807052 49.3187
+      vertex 48.7518 0.697776 49.3187
+      vertex 49.0123 0.680702 49.1111
+    endloop
+  endfacet
+  facet normal 0.82444 -0.550754 0.130265
+    outer loop
+      vertex 49.7283 1.00214 48.1308
+      vertex 49.5562 0.805872 48.3902
+      vertex 49.5833 0.785085 48.1308
+    endloop
+  endfacet
+  facet normal 0.513447 -0.768467 0.381878
+    outer loop
+      vertex 49.092 0.576926 48.8846
+      vertex 48.8969 0.446571 48.8846
+      vertex 48.9469 0.359869 48.6429
+    endloop
+  endfacet
+  facet normal 0.914848 -0.310258 0.258442
+    outer loop
+      vertex 49.8947 1.49231 48.3902
+      vertex 49.7497 1.27525 48.6429
+      vertex 49.8123 1.24934 48.3902
+    endloop
+  endfacet
+  facet normal 0.706344 -0.046425 0.706344
+    outer loop
+      vertex 49.5037 2 49.3187
+      vertex 49.3187 2 49.5037
+      vertex 49.4908 1.80373 49.3187
+    endloop
+  endfacet
+  facet normal 0.297162 -0.875096 0.381971
+    outer loop
+      vertex 48.6864 0.342795 48.8846
+      vertex 48.4643 0.267375 48.8846
+      vertex 48.7247 0.250301 48.6429
+    endloop
+  endfacet
+  facet normal 0.438563 -0.88923 0.130126
+    outer loop
+      vertex 48.9808 0.30123 48.3902
+      vertex 48.7507 0.187746 48.3902
+      vertex 48.7637 0.156198 48.1308
+    endloop
+  endfacet
+  facet normal 0.550937 -0.824318 -0.130266
+    outer loop
+      vertex 49.2149 0.416691 -58.1308
+      vertex 48.9979 0.271658 -58.1308
+      vertex 49.1941 0.443782 -58.3902
+    endloop
+  endfacet
+  facet normal 0.438413 -0.889281 0.13028
+    outer loop
+      vertex 48.9808 0.30123 48.3902
+      vertex 48.7637 0.156198 48.1308
+      vertex 48.9979 0.271658 48.1308
+    endloop
+  endfacet
+  facet normal 0.513425 -0.768472 0.381896
+    outer loop
+      vertex 49.092 0.576926 48.8846
+      vertex 48.9469 0.359869 48.6429
+      vertex 49.1529 0.4975 48.6429
+    endloop
+  endfacet
+  facet normal 0.65367 -0.745483 0.130271
+    outer loop
+      vertex 49.4112 0.588815 48.1308
+      vertex 49.1941 0.443782 48.3902
+      vertex 49.2149 0.416691 48.1308
+    endloop
+  endfacet
+  facet normal 0.550913 -0.824329 0.130292
+    outer loop
+      vertex 49.1941 0.443782 48.3902
+      vertex 48.9808 0.30123 48.3902
+      vertex 48.9979 0.271658 48.1308
+    endloop
+  endfacet
+  facet normal -0.0648444 -0.989359 0.130247
+    outer loop
+      vertex -48.256 0.0552111 48.3902
+      vertex -48.2605 0.0213566 48.1308
+      vertex -48 0.00428295 48.1308
+    endloop
+  endfacet
+  facet normal -0.670259 -0.227742 0.706319
+    outer loop
+      vertex -49.2738 1.6587 49.5037
+      vertex -49.3892 1.42457 49.3187
+      vertex -49.2183 1.49536 49.5037
+    endloop
+  endfacet
+  facet normal -0.694921 -0.609282 0.381917
+    outer loop
+      vertex -49.4231 0.908037 48.8846
+      vertex -49.5025 0.847092 48.6429
+      vertex -49.3392 0.660839 48.6429
+    endloop
+  endfacet
+  facet normal -0.0631825 -0.963999 0.258291
+    outer loop
+      vertex -48.2472 0.122342 48.6429
+      vertex -48.256 0.0552111 48.3902
+      vertex -48 0.10614 48.6429
+    endloop
+  endfacet
+  facet normal -0.180277 -0.90642 0.381972
+    outer loop
+      vertex -48.4643 0.267375 48.8846
+      vertex -48.4902 0.170672 48.6429
+      vertex -48.2472 0.122342 48.6429
+    endloop
+  endfacet
+  facet normal -0.778651 0.154996 0.608012
+    outer loop
+      vertex -49.4524 3.38918 49.3187
+      vertex -49.6063 3.4304 49.1111
+      vertex -49.4908 3.19627 49.3187
+    endloop
+  endfacet
+  facet normal -0.491187 0.0978218 0.865544
+    outer loop
+      vertex -48.8544 3.22894 49.7937
+      vertex -49.1016 3.14503 49.6629
+      vertex -48.877 3.11546 49.7937
+    endloop
+  endfacet
+  facet normal -0.965936 0 0.258781
+    outer loop
+      vertex -49.9616 2 48.3902
+      vertex -49.8939 3 48.6429
+      vertex -49.9616 3 48.3902
+    endloop
+  endfacet
+  facet normal -0.965936 0 0.258781
+    outer loop
+      vertex -49.8939 3 48.6429
+      vertex -49.9616 2 48.3902
+      vertex -49.8939 2 48.6429
+    endloop
+  endfacet
+  facet normal -0.938872 -0.318655 0.1303
+    outer loop
+      vertex -49.8947 1.49231 48.3902
+      vertex -49.9277 1.48347 48.1308
+      vertex -49.8438 1.23627 48.1308
+    endloop
+  endfacet
+  facet normal -0.793533 0 0.608528
+    outer loop
+      vertex -49.6629 2 49.1111
+      vertex -49.5037 3 49.3187
+      vertex -49.6629 3 49.1111
+    endloop
+  endfacet
+  facet normal -0.793533 0 0.608528
+    outer loop
+      vertex -49.5037 3 49.3187
+      vertex -49.6629 2 49.1111
+      vertex -49.5037 2 49.3187
+    endloop
+  endfacet
+  facet normal -0.864562 -0.0565594 0.499334
+    outer loop
+      vertex -49.6629 2 49.1111
+      vertex -49.7784 1.76587 48.8846
+      vertex -49.6487 1.78294 49.1111
+    endloop
+  endfacet
+  facet normal -0.938977 -0.318441 0.130069
+    outer loop
+      vertex -49.8123 1.24934 48.3902
+      vertex -49.8947 1.49231 48.3902
+      vertex -49.8438 1.23627 48.1308
+    endloop
+  endfacet
+  facet normal -0.914848 -0.310258 0.258442
+    outer loop
+      vertex -49.7497 1.27525 48.6429
+      vertex -49.8947 1.49231 48.3902
+      vertex -49.8123 1.24934 48.3902
+    endloop
+  endfacet
+  facet normal 0.138078 -0.694268 0.706348
+    outer loop
+      vertex 48.3413 0.726242 49.5037
+      vertex 48.1721 0.692591 49.5037
+      vertex 48.1963 0.509185 49.3187
+    endloop
+  endfacet
+  facet normal 0.227592 -0.670295 0.706333
+    outer loop
+      vertex 48.5046 0.781689 49.5037
+      vertex 48.3413 0.726242 49.5037
+      vertex 48.5754 0.610782 49.3187
+    endloop
+  endfacet
+  facet normal 0.278473 -0.820433 0.499343
+    outer loop
+      vertex 48.6364 0.463645 49.1111
+      vertex 48.4304 0.393724 49.1111
+      vertex 48.4643 0.267375 48.8846
+    endloop
+  endfacet
+  facet normal 0.255208 -0.751889 0.607892
+    outer loop
+      vertex 48.5754 0.610782 49.3187
+      vertex 48.4304 0.393724 49.1111
+      vertex 48.6364 0.463645 49.1111
+    endloop
+  endfacet
+  facet normal 0.824445 0.550744 0.130272
+    outer loop
+      vertex 49.5833 4.21492 48.1308
+      vertex 49.5562 4.19413 48.3902
+      vertex 49.7283 3.99786 48.1308
+    endloop
+  endfacet
+  facet normal 0.694913 0.609284 0.381928
+    outer loop
+      vertex 49.5025 4.15291 48.6429
+      vertex 49.3392 4.33916 48.6429
+      vertex 49.4231 4.09196 48.8846
+    endloop
+  endfacet
+  facet normal 0.653742 0.7454 0.130385
+    outer loop
+      vertex 49.4112 4.41119 48.1308
+      vertex 49.1941 4.55622 48.3902
+      vertex 49.387 4.38704 48.3902
+    endloop
+  endfacet
+  facet normal 0.637026 0.726341 0.258121
+    outer loop
+      vertex 49.387 4.38704 48.3902
+      vertex 49.1941 4.55622 48.3902
+      vertex 49.3392 4.33916 48.6429
+    endloop
+  endfacet
+  facet normal 0.427249 0.86643 0.258374
+    outer loop
+      vertex 48.9808 4.69877 48.3902
+      vertex 48.7247 4.7497 48.6429
+      vertex 48.9469 4.64013 48.6429
+    endloop
+  endfacet
+  facet normal 0.820542 0.278454 0.499174
+    outer loop
+      vertex 49.7326 3.46426 48.8846
+      vertex 49.5364 3.63638 49.1111
+      vertex 49.6063 3.4304 49.1111
+    endloop
+  endfacet
+  facet normal 0.694418 0.138228 0.70617
+    outer loop
+      vertex 49.4524 3.38918 49.3187
+      vertex 49.2738 3.3413 49.5037
+      vertex 49.4908 3.19627 49.3187
+    endloop
+  endfacet
+  facet normal 0.288396 0.252955 0.923494
+    outer loop
+      vertex 48.6255 3.62549 49.7937
+      vertex 48.51 3.39136 49.8939
+      vertex 48.7018 3.5385 49.7937
+    endloop
+  endfacet
+  facet normal 0.972391 -0.19359 0.130302
+    outer loop
+      vertex 49.9448 1.74396 48.3902
+      vertex 49.8947 1.49231 48.3902
+      vertex 49.9277 1.48347 48.1308
+    endloop
+  endfacet
+  facet normal 0.865975 -0 0.500086
+    outer loop
+      vertex 49.6629 2 49.1111
+      vertex 49.7937 3 48.8846
+      vertex 49.6629 3 49.1111
+    endloop
+  endfacet
+  facet normal 0.865975 0 0.500086
+    outer loop
+      vertex 49.7937 3 48.8846
+      vertex 49.6629 2 49.1111
+      vertex 49.7937 2 48.8846
+    endloop
+  endfacet
+  facet normal 0.922077 0.0604274 0.38226
+    outer loop
+      vertex 49.8777 3.2472 48.6429
+      vertex 49.7937 3 48.8846
+      vertex 49.8939 3 48.6429
+    endloop
+  endfacet
+  facet normal 0.849887 -0.16891 0.499161
+    outer loop
+      vertex 49.6487 1.78294 49.1111
+      vertex 49.6063 1.5696 49.1111
+      vertex 49.7326 1.53574 48.8846
+    endloop
+  endfacet
+  facet normal 0.71194 -0.351426 0.607981
+    outer loop
+      vertex 49.5364 1.36362 49.1111
+      vertex 49.3892 1.42457 49.3187
+      vertex 49.4401 1.16853 49.1111
+    endloop
+  endfacet
+  facet normal 0.401761 -0.458184 0.792878
+    outer loop
+      vertex 48.9325 1.06754 49.5037
+      vertex 48.6764 1.11847 49.6629
+      vertex 48.8028 0.953812 49.5037
+    endloop
+  endfacet
+  facet normal 0.171006 -0.194906 0.965799
+    outer loop
+      vertex 48.4546 1.54542 49.8939
+      vertex 48.2759 1.7241 49.9616
+      vertex 48.3914 1.48997 49.8939
+    endloop
+  endfacet
+  facet normal 0.499816 0.0328997 0.865507
+    outer loop
+      vertex 49.1111 3 49.6629
+      vertex 48.877 3.11546 49.7937
+      vertex 48.8846 3 49.7937
+    endloop
+  endfacet
+  facet normal 0.376317 -0.0749451 0.923455
+    outer loop
+      vertex 48.877 1.88454 49.7937
+      vertex 48.6374 1.91609 49.8939
+      vertex 48.8544 1.77106 49.7937
+    endloop
+  endfacet
+  facet normal 0.474141 -0.160884 0.865625
+    outer loop
+      vertex 49.0733 1.71242 49.6629
+      vertex 48.8544 1.77106 49.7937
+      vertex 49.0266 1.57479 49.6629
+    endloop
+  endfacet
+  facet normal 0.449015 -0.221476 0.865641
+    outer loop
+      vertex 49.0266 1.57479 49.6629
+      vertex 48.8172 1.66149 49.7937
+      vertex 48.9623 1.44443 49.6629
+    endloop
+  endfacet
+  facet normal 0.3633 -0.12364 0.923432
+    outer loop
+      vertex 48.621 1.83361 49.8939
+      vertex 48.5939 1.75398 49.8939
+      vertex 48.8544 1.77106 49.7937
+    endloop
+  endfacet
+  facet normal 0.232583 -0.114719 0.965787
+    outer loop
+      vertex 48.5939 1.75398 49.8939
+      vertex 48.3379 1.80491 49.9616
+      vertex 48.5567 1.67856 49.8939
+    endloop
+  endfacet
+  facet normal 0.108679 -0.0724696 0.991432
+    outer loop
+      vertex 48.3379 1.80491 49.9616
+      vertex 48.1133 1.9346 49.9957
+      vertex 48.3096 1.76247 49.9616
+    endloop
+  endfacet
+  facet normal 0.215801 0.143902 0.965775
+    outer loop
+      vertex 48.51 3.39136 49.8939
+      vertex 48.3096 3.23753 49.9616
+      vertex 48.3379 3.19509 49.9616
+    endloop
+  endfacet
+  facet normal 0.831525 -0.555487 0
+    outer loop
+      vertex 49.5833 0.785085 48.1308
+      vertex 49.7283 1.00214 -58.1308
+      vertex 49.7283 1.00214 48.1308
+    endloop
+  endfacet
+  facet normal 0.831525 -0.555487 0
+    outer loop
+      vertex 49.7283 1.00214 -58.1308
+      vertex 49.5833 0.785085 48.1308
+      vertex 49.5833 0.785085 -58.1308
+    endloop
+  endfacet
+  facet normal 0.555672 -0.831402 0
+    outer loop
+      vertex 48.9979 0.271658 -58.1308
+      vertex 49.2149 0.416691 48.1308
+      vertex 48.9979 0.271658 48.1308
+    endloop
+  endfacet
+  facet normal 0.555672 -0.831402 0
+    outer loop
+      vertex 49.2149 0.416691 48.1308
+      vertex 48.9979 0.271658 -58.1308
+      vertex 49.2149 0.416691 -58.1308
+    endloop
+  endfacet
+  facet normal 0.660113 -0.441179 -0.607957
+    outer loop
+      vertex 49.3193 0.987667 -59.1111
+      vertex 49.1929 1.08462 -59.3187
+      vertex 49.3022 1.24816 -59.3187
+    endloop
+  endfacet
+  facet normal 0.74538 -0.653764 -0.130393
+    outer loop
+      vertex 49.4112 0.588815 -58.1308
+      vertex 49.387 0.612961 -58.3902
+      vertex 49.5562 0.805872 -58.3902
+    endloop
+  endfacet
+  facet normal 0 -0.865966 -0.500104
+    outer loop
+      vertex -48 0.337061 -59.1111
+      vertex 48 0.206255 -58.8846
+      vertex -48 0.206255 -58.8846
+    endloop
+  endfacet
+  facet normal 0 -0.865966 -0.500104
+    outer loop
+      vertex 48 0.206255 -58.8846
+      vertex -48 0.337061 -59.1111
+      vertex 48 0.337061 -59.1111
+    endloop
+  endfacet
+  facet normal 0.597056 -0.523522 -0.607823
+    outer loop
+      vertex 49.1759 0.824125 -59.1111
+      vertex 49.0633 0.936738 -59.3187
+      vertex 49.3193 0.987667 -59.1111
+    endloop
+  endfacet
+  facet normal 0.889226 -0.438585 -0.130081
+    outer loop
+      vertex 49.8438 1.23627 -58.1308
+      vertex 49.6988 1.01922 -58.3902
+      vertex 49.8123 1.24934 -58.3902
+    endloop
+  endfacet
+  facet normal 0.637025 -0.726344 -0.258115
+    outer loop
+      vertex 49.387 0.612961 -58.3902
+      vertex 49.1941 0.443782 -58.3902
+      vertex 49.3392 0.660839 -58.6429
+    endloop
+  endfacet
+  facet normal 0.726328 -0.637054 -0.25809
+    outer loop
+      vertex 49.387 0.612961 -58.3902
+      vertex 49.3392 0.660839 -58.6429
+      vertex 49.5562 0.805872 -58.3902
+    endloop
+  endfacet
+  facet normal 0.989379 -0.0649178 -0.130061
+    outer loop
+      vertex 49.9957 2 -58.1308
+      vertex 49.9448 1.74396 -58.3902
+      vertex 49.9616 2 -58.3902
+    endloop
+  endfacet
+  facet normal 0.98938 -0.0649484 -0.130031
+    outer loop
+      vertex 49.9786 1.73951 -58.1308
+      vertex 49.9448 1.74396 -58.3902
+      vertex 49.9957 2 -58.1308
+    endloop
+  endfacet
+  facet normal 0.720485 -0.481202 -0.499345
+    outer loop
+      vertex 49.5534 1.10313 -58.8846
+      vertex 49.4231 0.908037 -58.8846
+      vertex 49.4401 1.16853 -59.1111
+    endloop
+  endfacet
+  facet normal 0.523465 -0.597106 -0.607823
+    outer loop
+      vertex 49.1759 0.824125 -59.1111
+      vertex 49.0123 0.680702 -59.1111
+      vertex 49.0633 0.936738 -59.3187
+    endloop
+  endfacet
+  facet normal 0.778651 -0.154996 -0.608012
+    outer loop
+      vertex 49.6063 1.5696 -59.1111
+      vertex 49.4524 1.61082 -59.3187
+      vertex 49.4908 1.80373 -59.3187
+    endloop
+  endfacet
+  facet normal 0.546628 -0.269624 -0.79278
+    outer loop
+      vertex 49.142 1.34065 -59.5037
+      vertex 48.9623 1.44443 -59.6629
+      vertex 49.0266 1.57479 -59.6629
+    endloop
+  endfacet
+  facet normal 0.875143 -0.296992 -0.381996
+    outer loop
+      vertex 49.7497 1.27525 -58.6429
+      vertex 49.6572 1.31356 -58.8846
+      vertex 49.7326 1.53574 -58.8846
+    endloop
+  endfacet
+  facet normal 0.670259 -0.227742 -0.706319
+    outer loop
+      vertex 49.3892 1.42457 -59.3187
+      vertex 49.2183 1.49536 -59.5037
+      vertex 49.2738 1.6587 -59.5037
+    endloop
+  endfacet
+  facet normal 0.499757 -0.0327359 -0.865547
+    outer loop
+      vertex 49.1016 1.85497 -59.6629
+      vertex 48.877 1.88454 -59.7937
+      vertex 49.1111 2 -59.6629
+    endloop
+  endfacet
+  facet normal 0.608082 0.0399217 -0.79287
+    outer loop
+      vertex 49.3187 3 -59.5037
+      vertex 49.1016 3.14503 -59.6629
+      vertex 49.3074 3.17212 -59.5037
+    endloop
+  endfacet
+  facet normal 0.53244 -0.466617 -0.706241
+    outer loop
+      vertex 49.0633 0.936738 -59.3187
+      vertex 49.0462 1.19723 -59.5037
+      vertex 49.1929 1.08462 -59.3187
+    endloop
+  endfacet
+  facet normal 0.338735 -0.506739 -0.792764
+    outer loop
+      vertex 48.6593 0.85798 -59.5037
+      vertex 48.5556 1.03772 -59.6629
+      vertex 48.6764 1.11847 -59.6629
+    endloop
+  endfacet
+  facet normal 0.227592 -0.670295 -0.706333
+    outer loop
+      vertex 48.5754 0.610782 -59.3187
+      vertex 48.3413 0.726242 -59.5037
+      vertex 48.5046 0.781689 -59.5037
+    endloop
+  endfacet
+  facet normal 0.160955 -0.474212 -0.865573
+    outer loop
+      vertex 48.4252 0.97344 -59.6629
+      vertex 48.2289 1.14556 -59.7937
+      vertex 48.3385 1.18276 -59.7937
+    endloop
+  endfacet
+  facet normal 0.408667 -0.828943 -0.381896
+    outer loop
+      vertex 48.9469 0.359869 -58.6429
+      vertex 48.6864 0.342795 -58.8846
+      vertex 48.8969 0.446571 -58.8846
+    endloop
+  endfacet
+  facet normal 0.609286 -0.694935 -0.381884
+    outer loop
+      vertex 49.1529 0.4975 -58.6429
+      vertex 49.092 0.576926 -58.8846
+      vertex 49.3392 0.660839 -58.6429
+    endloop
+  endfacet
+  facet normal 0.195935 -0.577095 -0.792825
+    outer loop
+      vertex 48.3413 0.726242 -59.5037
+      vertex 48.2876 0.926722 -59.6629
+      vertex 48.4252 0.97344 -59.6629
+    endloop
+  endfacet
+  facet normal 0.0327611 -0.499722 -0.865566
+    outer loop
+      vertex 48.145 0.898366 -59.6629
+      vertex 48 0.88886 -59.6629
+      vertex 48.1155 1.12299 -59.7937
+    endloop
+  endfacet
+  facet normal 0.255208 -0.751889 -0.607892
+    outer loop
+      vertex 48.6364 0.463645 -59.1111
+      vertex 48.4304 0.393724 -59.1111
+      vertex 48.5754 0.610782 -59.3187
+    endloop
+  endfacet
+  facet normal 0.255307 -0.751901 -0.607835
+    outer loop
+      vertex 48.4304 0.393724 -59.1111
+      vertex 48.3892 0.547558 -59.3187
+      vertex 48.5754 0.610782 -59.3187
+    endloop
+  endfacet
+  facet normal -0.438563 -0.88923 -0.130126
+    outer loop
+      vertex -48.7637 0.156198 -58.1308
+      vertex -48.9808 0.30123 -58.3902
+      vertex -48.7507 0.187746 -58.3902
+    endloop
+  endfacet
+  facet normal -0.74538 -0.653764 -0.130393
+    outer loop
+      vertex -49.4112 0.588815 -58.1308
+      vertex -49.5562 0.805872 -58.3902
+      vertex -49.387 0.612961 -58.3902
+    endloop
+  endfacet
+  facet normal -0.751886 -0.659293 0
+    outer loop
+      vertex -49.4112 0.588815 -58.1308
+      vertex -49.5833 0.785085 48.1308
+      vertex -49.5833 0.785085 -58.1308
+    endloop
+  endfacet
+  facet normal -0.751886 -0.659293 0
+    outer loop
+      vertex -49.5833 0.785085 48.1308
+      vertex -49.4112 0.588815 -58.1308
+      vertex -49.4112 0.588815 48.1308
+    endloop
+  endfacet
+  facet normal -0.947452 -0.188734 0.25829
+    outer loop
+      vertex -49.8777 1.7528 48.6429
+      vertex -49.8947 1.49231 48.3902
+      vertex -49.8293 1.50983 48.6429
+    endloop
+  endfacet
+  facet normal -0.82433 -0.550975 0.130025
+    outer loop
+      vertex -49.6988 1.01922 48.3902
+      vertex -49.7283 1.00214 48.1308
+      vertex -49.5562 0.805872 48.3902
+    endloop
+  endfacet
+  facet normal -0.0519247 -0.792351 -0.607851
+    outer loop
+      vertex -48 0.337061 -59.1111
+      vertex -48.1963 0.509185 -59.3187
+      vertex -48 0.496321 -59.3187
+    endloop
+  endfacet
+  facet normal -0.118861 -0.597742 -0.792828
+    outer loop
+      vertex -48.145 0.898366 -59.6629
+      vertex -48.3413 0.726242 -59.5037
+      vertex -48.2876 0.926722 -59.6629
+    endloop
+  endfacet
+  facet normal -0.297162 -0.875096 -0.381971
+    outer loop
+      vertex -48.4643 0.267375 -58.8846
+      vertex -48.7247 0.250301 -58.6429
+      vertex -48.6864 0.342795 -58.8846
+    endloop
+  endfacet
+  facet normal -0.278473 -0.820433 -0.499343
+    outer loop
+      vertex -48.4643 0.267375 -58.8846
+      vertex -48.6364 0.463645 -59.1111
+      vertex -48.4304 0.393724 -59.1111
+    endloop
+  endfacet
+  facet normal -0.481441 -0.720275 -0.499418
+    outer loop
+      vertex -48.8315 0.559853 -59.1111
+      vertex -49.092 0.576926 -58.8846
+      vertex -49.0123 0.680702 -59.1111
+    endloop
+  endfacet
+  facet normal -0.57111 -0.651455 -0.499439
+    outer loop
+      vertex -49.092 0.576926 -58.8846
+      vertex -49.1759 0.824125 -59.1111
+      vertex -49.0123 0.680702 -59.1111
+    endloop
+  endfacet
+  facet normal -0.80332 -0.536644 -0.258246
+    outer loop
+      vertex -49.5562 0.805872 -58.3902
+      vertex -49.6401 1.05307 -58.6429
+      vertex -49.5025 0.847092 -58.6429
+    endloop
+  endfacet
+  facet normal -0.82882 -0.408837 -0.381982
+    outer loop
+      vertex -49.6401 1.05307 -58.6429
+      vertex -49.6572 1.31356 -58.8846
+      vertex -49.5534 1.10313 -58.8846
+    endloop
+  endfacet
+  facet normal -0.193395 -0.972442 -0.130209
+    outer loop
+      vertex -48.256 0.0552111 -58.3902
+      vertex -48.5165 0.0722847 -58.1308
+      vertex -48.5077 0.105268 -58.3902
+    endloop
+  endfacet
+  facet normal 0 -0.92388 -0.382682
+    outer loop
+      vertex -48 0.206255 -58.8846
+      vertex 48 0.10614 -58.6429
+      vertex -48 0.10614 -58.6429
+    endloop
+  endfacet
+  facet normal 0 -0.92388 -0.382682
+    outer loop
+      vertex 48 0.10614 -58.6429
+      vertex -48 0.206255 -58.8846
+      vertex 48 0.206255 -58.8846
+    endloop
+  endfacet
+  facet normal -0.536685 -0.803287 -0.25826
+    outer loop
+      vertex -48.9469 0.359869 -58.6429
+      vertex -49.1941 0.443782 -58.3902
+      vertex -49.1529 0.4975 -58.6429
+    endloop
+  endfacet
+  facet normal -0.481346 -0.720422 -0.499298
+    outer loop
+      vertex -48.8969 0.446571 -58.8846
+      vertex -49.092 0.576926 -58.8846
+      vertex -48.8315 0.559853 -59.1111
+    endloop
+  endfacet
+  facet normal 0.0519244 -0.792351 -0.607851
+    outer loop
+      vertex 48.2171 0.351288 -59.1111
+      vertex 48 0.337061 -59.1111
+      vertex 48.1963 0.509185 -59.3187
+    endloop
+  endfacet
+  facet normal 0.180235 -0.906414 -0.382006
+    outer loop
+      vertex 48.2472 0.122342 -58.6429
+      vertex 48.2341 0.221601 -58.8846
+      vertex 48.4643 0.267375 -58.8846
+    endloop
+  endfacet
+  facet normal -0.138078 -0.694268 -0.706348
+    outer loop
+      vertex -48.1963 0.509185 -59.3187
+      vertex -48.3413 0.726242 -59.5037
+      vertex -48.1721 0.692591 -59.5037
+    endloop
+  endfacet
+  facet normal -0.0976671 -0.49116 -0.865577
+    outer loop
+      vertex -48.145 0.898366 -59.6629
+      vertex -48.2876 0.926722 -59.6629
+      vertex -48.2289 1.14556 -59.7937
+    endloop
+  endfacet
+  facet normal -0.128203 0.0252128 -0.991427
+    outer loop
+      vertex -48.1297 3.01707 -59.9957
+      vertex -48.3769 3.10099 -59.9616
+      vertex -48.1264 3.03385 -59.9957
+    endloop
+  endfacet
+  facet normal -0.344087 -0.169717 -0.923472
+    outer loop
+      vertex -48.5567 1.67856 -59.8939
+      vertex -48.8172 1.66149 -59.7937
+      vertex -48.5939 1.75398 -59.8939
+    endloop
+  endfacet
+  facet normal -0.376568 -0.330147 -0.865563
+    outer loop
+      vertex -48.7857 1.21431 -59.6629
+      vertex -48.8815 1.32358 -59.6629
+      vertex -48.6255 1.37451 -59.7937
+    endloop
+  endfacet
+  facet normal -0.393197 -0.588666 -0.706306
+    outer loop
+      vertex -48.7518 0.697776 -59.3187
+      vertex -48.9154 0.807052 -59.3187
+      vertex -48.8028 0.953812 -59.5037
+    endloop
+  endfacet
+  facet normal -0.768522 -0.513285 -0.381985
+    outer loop
+      vertex -49.4231 0.908037 -58.8846
+      vertex -49.6401 1.05307 -58.6429
+      vertex -49.5534 1.10313 -58.8846
+    endloop
+  endfacet
+  facet normal -0.382882 -0.0250965 -0.923456
+    outer loop
+      vertex -48.6374 1.91609 -59.8939
+      vertex -48.877 1.88454 -59.7937
+      vertex -48.6429 2 -59.8939
+    endloop
+  endfacet
+  facet normal -0.499757 -0.0327359 -0.865547
+    outer loop
+      vertex -49.1016 1.85497 -59.6629
+      vertex -49.1111 2 -59.6629
+      vertex -48.877 1.88454 -59.7937
+    endloop
+  endfacet
+  facet normal -0.500086 0 -0.865975
+    outer loop
+      vertex -49.1111 2 -59.6629
+      vertex -48.8846 3 -59.7937
+      vertex -48.8846 2 -59.7937
+    endloop
+  endfacet
+  facet normal -0.500086 0 -0.865975
+    outer loop
+      vertex -48.8846 3 -59.7937
+      vertex -49.1111 2 -59.6629
+      vertex -49.1111 3 -59.6629
+    endloop
+  endfacet
+  facet normal -0.706374 -0.0463748 -0.706318
+    outer loop
+      vertex -49.3074 1.82788 -59.5037
+      vertex -49.4908 1.80373 -59.3187
+      vertex -49.3187 2 -59.5037
+    endloop
+  endfacet
+  facet normal -0.254312 -0.0505664 -0.965799
+    outer loop
+      vertex -48.621 1.83361 -59.8939
+      vertex -48.6374 1.91609 -59.8939
+      vertex -48.3769 1.89901 -59.9616
+    endloop
+  endfacet
+  facet normal -0.458218 -0.401723 -0.792878
+    outer loop
+      vertex -48.9325 1.06754 -59.5037
+      vertex -49.0462 1.19723 -59.5037
+      vertex -48.8815 1.32358 -59.6629
+    endloop
+  endfacet
+  facet normal -0.751829 -0.255136 -0.607995
+    outer loop
+      vertex -49.5364 1.36362 -59.1111
+      vertex -49.6063 1.5696 -59.1111
+      vertex -49.3892 1.42457 -59.3187
+    endloop
+  endfacet
+  facet normal -0.820542 -0.278454 -0.499174
+    outer loop
+      vertex -49.5364 1.36362 -59.1111
+      vertex -49.7326 1.53574 -58.8846
+      vertex -49.6063 1.5696 -59.1111
+    endloop
+  endfacet
+  facet normal -0.0834146 0.245516 -0.965797
+    outer loop
+      vertex -48.1493 3.36048 -59.9616
+      vertex -48.246 3.59394 -59.8939
+      vertex -48.101 3.37689 -59.9616
+    endloop
+  endfacet
+  facet normal 0.232563 0.114808 -0.965781
+    outer loop
+      vertex 48.3605 3.14931 -59.9616
+      vertex 48.3379 3.19509 -59.9616
+      vertex 48.5939 3.24602 -59.8939
+    endloop
+  endfacet
+  facet normal 0.13039 0.00840238 -0.991427
+    outer loop
+      vertex 48.1308 3 -59.9957
+      vertex 48.1297 3.01707 -59.9957
+      vertex 48.3868 3.05093 -59.9616
+    endloop
+  endfacet
+  facet normal 0.597714 -0.118709 -0.792872
+    outer loop
+      vertex 49.2738 1.6587 -59.5037
+      vertex 49.1016 1.85497 -59.6629
+      vertex 49.3074 1.82788 -59.5037
+    endloop
+  endfacet
+  facet normal 0.382959 0 -0.923765
+    outer loop
+      vertex 48.6429 2 -59.8939
+      vertex 48.8846 3 -59.7937
+      vertex 48.8846 2 -59.7937
+    endloop
+  endfacet
+  facet normal 0.382959 0 -0.923765
+    outer loop
+      vertex 48.8846 3 -59.7937
+      vertex 48.6429 2 -59.8939
+      vertex 48.6429 3 -59.8939
+    endloop
+  endfacet
+  facet normal 0.0579371 -0.117099 -0.991429
+    outer loop
+      vertex 48.1493 1.63952 -59.9616
+      vertex 48.0501 1.87915 -59.9957
+      vertex 48.0654 1.88672 -59.9957
+    endloop
+  endfacet
+  facet normal 0.546657 -0.269601 -0.792768
+    outer loop
+      vertex 49.142 1.34065 -59.5037
+      vertex 49.0266 1.57479 -59.6629
+      vertex 49.2183 1.49536 -59.5037
+    endloop
+  endfacet
+  facet normal 0.706344 0.046425 -0.706344
+    outer loop
+      vertex 49.5037 3 -59.3187
+      vertex 49.3187 3 -59.5037
+      vertex 49.4908 3.19627 -59.3187
+    endloop
+  endfacet
+  facet normal 0.597714 0.118709 -0.792872
+    outer loop
+      vertex 49.3074 3.17212 -59.5037
+      vertex 49.1016 3.14503 -59.6629
+      vertex 49.2738 3.3413 -59.5037
+    endloop
+  endfacet
+  facet normal 0.546657 0.269601 -0.792768
+    outer loop
+      vertex 49.2183 3.50464 -59.5037
+      vertex 49.0266 3.42521 -59.6629
+      vertex 49.142 3.65935 -59.5037
+    endloop
+  endfacet
+  facet normal 0.694328 0.137897 -0.706324
+    outer loop
+      vertex 49.3074 3.17212 -59.5037
+      vertex 49.2738 3.3413 -59.5037
+      vertex 49.4908 3.19627 -59.3187
+    endloop
+  endfacet
+  facet normal 0.3633 0.12364 -0.923432
+    outer loop
+      vertex 48.621 3.16639 -59.8939
+      vertex 48.5939 3.24602 -59.8939
+      vertex 48.8544 3.22894 -59.7937
+    endloop
+  endfacet
+  facet normal 0.258743 0.0169597 -0.965797
+    outer loop
+      vertex 48.6429 3 -59.8939
+      vertex 48.3902 3 -59.9616
+      vertex 48.6374 3.08391 -59.8939
+    endloop
+  endfacet
+  facet normal 0.288558 -0.252864 -0.923469
+    outer loop
+      vertex 48.6255 1.37451 -59.7937
+      vertex 48.4546 1.54542 -59.8939
+      vertex 48.51 1.60864 -59.8939
+    endloop
+  endfacet
+  facet normal 0.144138 -0.215495 -0.965809
+    outer loop
+      vertex 48.3914 1.48997 -59.8939
+      vertex 48.1951 1.66209 -59.9616
+      vertex 48.2375 1.69045 -59.9616
+    endloop
+  endfacet
+  facet normal 0.980807 0.194982 0
+    outer loop
+      vertex 49.9786 3.26049 48.1308
+      vertex 49.9277 3.51653 -58.1308
+      vertex 49.9277 3.51653 48.1308
+    endloop
+  endfacet
+  facet normal 0.980807 0.194982 0
+    outer loop
+      vertex 49.9277 3.51653 -58.1308
+      vertex 49.9786 3.26049 48.1308
+      vertex 49.9786 3.26049 -58.1308
+    endloop
+  endfacet
+  facet normal 0.997852 0.0655045 0
+    outer loop
+      vertex 49.9957 3 48.1308
+      vertex 49.9786 3.26049 -58.1308
+      vertex 49.9786 3.26049 48.1308
+    endloop
+  endfacet
+  facet normal 0.997852 0.0655045 0
+    outer loop
+      vertex 49.9786 3.26049 -58.1308
+      vertex 49.9957 3 48.1308
+      vertex 49.9957 3 -58.1308
+    endloop
+  endfacet
+  facet normal 0.989379 0.0649178 0.130061
+    outer loop
+      vertex 49.9957 3 48.1308
+      vertex 49.9448 3.25604 48.3902
+      vertex 49.9616 3 48.3902
+    endloop
+  endfacet
+  facet normal 0.98938 0.0649484 0.130031
+    outer loop
+      vertex 49.9786 3.26049 48.1308
+      vertex 49.9448 3.25604 48.3902
+      vertex 49.9957 3 48.1308
+    endloop
+  endfacet
+  facet normal 0.889201 0.438657 -0.130007
+    outer loop
+      vertex 49.8438 3.76373 -58.1308
+      vertex 49.6988 3.98078 -58.3902
+      vertex 49.7283 3.99786 -58.1308
+    endloop
+  endfacet
+  facet normal 0.938977 0.318441 0.130069
+    outer loop
+      vertex 49.8438 3.76373 48.1308
+      vertex 49.8123 3.75066 48.3902
+      vertex 49.8947 3.50769 48.3902
+    endloop
+  endfacet
+  facet normal 0.947499 0.188634 -0.25819
+    outer loop
+      vertex 49.9448 3.25604 -58.3902
+      vertex 49.8777 3.2472 -58.6429
+      vertex 49.8947 3.50769 -58.3902
+    endloop
+  endfacet
+  facet normal 0.947452 0.188734 -0.25829
+    outer loop
+      vertex 49.8777 3.2472 -58.6429
+      vertex 49.8293 3.49017 -58.6429
+      vertex 49.8947 3.50769 -58.3902
+    endloop
+  endfacet
+  facet normal 0.71194 0.351426 -0.607981
+    outer loop
+      vertex 49.5364 3.63638 -59.1111
+      vertex 49.3892 3.57543 -59.3187
+      vertex 49.4401 3.83147 -59.1111
+    endloop
+  endfacet
+  facet normal 0.820542 0.278454 -0.499174
+    outer loop
+      vertex 49.6063 3.4304 -59.1111
+      vertex 49.5364 3.63638 -59.1111
+      vertex 49.7326 3.46426 -58.8846
+    endloop
+  endfacet
+  facet normal 0.922148 0.0602608 -0.382114
+    outer loop
+      vertex 49.7937 3 -58.8846
+      vertex 49.7784 3.23413 -58.8846
+      vertex 49.8777 3.2472 -58.6429
+    endloop
+  endfacet
+  facet normal 0.864592 0.0564996 -0.499288
+    outer loop
+      vertex 49.7937 3 -58.8846
+      vertex 49.6629 3 -59.1111
+      vertex 49.7784 3.23413 -58.8846
+    endloop
+  endfacet
+  facet normal 0.441217 0.660091 -0.607954
+    outer loop
+      vertex 49.0123 4.3193 -59.1111
+      vertex 48.7518 4.30222 -59.3187
+      vertex 48.8315 4.44015 -59.1111
+    endloop
+  endfacet
+  facet normal 0.660116 0.44118 -0.607953
+    outer loop
+      vertex 49.3022 3.75184 -59.3187
+      vertex 49.1929 3.91538 -59.3187
+      vertex 49.3193 4.01233 -59.1111
+    endloop
+  endfacet
+  facet normal 0.726325 0.637055 -0.258095
+    outer loop
+      vertex 49.5562 4.19413 -58.3902
+      vertex 49.3392 4.33916 -58.6429
+      vertex 49.387 4.38704 -58.3902
+    endloop
+  endfacet
+  facet normal 0.745377 0.653765 -0.130403
+    outer loop
+      vertex 49.5562 4.19413 -58.3902
+      vertex 49.387 4.38704 -58.3902
+      vertex 49.4112 4.41119 -58.1308
+    endloop
+  endfacet
+  facet normal -0.947499 0.188634 0.25819
+    outer loop
+      vertex -49.8947 3.50769 48.3902
+      vertex -49.9448 3.25604 48.3902
+      vertex -49.8777 3.2472 48.6429
+    endloop
+  endfacet
+  facet normal -0.972391 0.19359 0.130302
+    outer loop
+      vertex -49.9277 3.51653 48.1308
+      vertex -49.9448 3.25604 48.3902
+      vertex -49.8947 3.50769 48.3902
+    endloop
+  endfacet
+  facet normal -0.866378 -0.427316 -0.258437
+    outer loop
+      vertex -49.6988 1.01922 -58.3902
+      vertex -49.8123 1.24934 -58.3902
+      vertex -49.7497 1.27525 -58.6429
+    endloop
+  endfacet
+  facet normal -0.896812 -0.442412 0
+    outer loop
+      vertex -49.7283 1.00214 -58.1308
+      vertex -49.8438 1.23627 48.1308
+      vertex -49.8438 1.23627 -58.1308
+    endloop
+  endfacet
+  facet normal -0.896812 -0.442412 0
+    outer loop
+      vertex -49.8438 1.23627 48.1308
+      vertex -49.7283 1.00214 -58.1308
+      vertex -49.7283 1.00214 48.1308
+    endloop
+  endfacet
+  facet normal -0.99147 0 -0.130336
+    outer loop
+      vertex -49.9616 2 -58.3902
+      vertex -49.9957 3 -58.1308
+      vertex -49.9616 3 -58.3902
+    endloop
+  endfacet
+  facet normal -0.99147 -0 -0.130336
+    outer loop
+      vertex -49.9957 3 -58.1308
+      vertex -49.9616 2 -58.3902
+      vertex -49.9957 2 -58.1308
+    endloop
+  endfacet
+  facet normal -0.803139 0.536806 0.258469
+    outer loop
+      vertex -49.5562 4.19413 48.3902
+      vertex -49.6988 3.98078 48.3902
+      vertex -49.6401 3.94693 48.6429
+    endloop
+  endfacet
+  facet normal -0.82881 0.408847 0.381993
+    outer loop
+      vertex -49.6401 3.94693 48.6429
+      vertex -49.7497 3.72475 48.6429
+      vertex -49.6572 3.68644 48.8846
+    endloop
+  endfacet
+  facet normal -0.745377 0.653765 0.130403
+    outer loop
+      vertex -49.4112 4.41119 48.1308
+      vertex -49.5562 4.19413 48.3902
+      vertex -49.387 4.38704 48.3902
+    endloop
+  endfacet
+  facet normal -0.726325 0.637055 0.258095
+    outer loop
+      vertex -49.387 4.38704 48.3902
+      vertex -49.5562 4.19413 48.3902
+      vertex -49.3392 4.33916 48.6429
+    endloop
+  endfacet
+  facet normal -0.989379 0.0649178 -0.130061
+    outer loop
+      vertex -49.9616 3 -58.3902
+      vertex -49.9957 3 -58.1308
+      vertex -49.9448 3.25604 -58.3902
+    endloop
+  endfacet
+  facet normal -0.803139 0.536806 -0.258469
+    outer loop
+      vertex -49.6401 3.94693 -58.6429
+      vertex -49.6988 3.98078 -58.3902
+      vertex -49.5562 4.19413 -58.3902
+    endloop
+  endfacet
+  facet normal -0.651419 0.571252 -0.499325
+    outer loop
+      vertex -49.1759 4.17587 -59.1111
+      vertex -49.4231 4.09196 -58.8846
+      vertex -49.2684 4.26837 -58.8846
+    endloop
+  endfacet
+  facet normal -0.849746 0.169115 -0.499332
+    outer loop
+      vertex -49.6487 3.21706 -59.1111
+      vertex -49.7784 3.23413 -58.8846
+      vertex -49.7326 3.46426 -58.8846
+    endloop
+  endfacet
+  facet normal -0.499816 0.0328997 -0.865507
+    outer loop
+      vertex -48.8846 3 -59.7937
+      vertex -49.1111 3 -59.6629
+      vertex -48.877 3.11546 -59.7937
+    endloop
+  endfacet
+  facet normal -0.382838 0.0251998 -0.923472
+    outer loop
+      vertex -48.6429 3 -59.8939
+      vertex -48.8846 3 -59.7937
+      vertex -48.877 3.11546 -59.7937
+    endloop
+  endfacet
+  facet normal -0.694328 0.137897 -0.706324
+    outer loop
+      vertex -49.3074 3.17212 -59.5037
+      vertex -49.4908 3.19627 -59.3187
+      vertex -49.2738 3.3413 -59.5037
+    endloop
+  endfacet
+  facet normal -0.608045 0.0398292 -0.792903
+    outer loop
+      vertex -49.1111 3 -59.6629
+      vertex -49.3187 3 -59.5037
+      vertex -49.1016 3.14503 -59.6629
+    endloop
+  endfacet
+  facet normal -0.319 0.213062 -0.923495
+    outer loop
+      vertex -48.5567 3.32144 -59.8939
+      vertex -48.7018 3.5385 -59.7937
+      vertex -48.51 3.39136 -59.8939
+    endloop
+  endfacet
+  facet normal -0.330185 0.376539 -0.865561
+    outer loop
+      vertex -48.6255 3.62549 -59.7937
+      vertex -48.6764 3.88153 -59.6629
+      vertex -48.5385 3.70178 -59.7937
+    endloop
+  endfacet
+  facet normal -0.71219 -0.35123 -0.607801
+    outer loop
+      vertex -49.3022 1.24816 -59.3187
+      vertex -49.4401 1.16853 -59.1111
+      vertex -49.3892 1.42457 -59.3187
+    endloop
+  endfacet
+  facet normal -0.720485 -0.481202 -0.499345
+    outer loop
+      vertex -49.4231 0.908037 -58.8846
+      vertex -49.5534 1.10313 -58.8846
+      vertex -49.4401 1.16853 -59.1111
+    endloop
+  endfacet
+  facet normal -0.550913 -0.824329 -0.130292
+    outer loop
+      vertex -48.9979 0.271658 -58.1308
+      vertex -49.1941 0.443782 -58.3902
+      vertex -48.9808 0.30123 -58.3902
+    endloop
+  endfacet
+  facet normal -0.831525 -0.555487 0
+    outer loop
+      vertex -49.5833 0.785085 -58.1308
+      vertex -49.7283 1.00214 48.1308
+      vertex -49.7283 1.00214 -58.1308
+    endloop
+  endfacet
+  facet normal -0.831525 -0.555487 0
+    outer loop
+      vertex -49.7283 1.00214 48.1308
+      vertex -49.5833 0.785085 -58.1308
+      vertex -49.5833 0.785085 48.1308
+    endloop
+  endfacet
+  facet normal -0.946945 -0.321394 0
+    outer loop
+      vertex -49.8438 1.23627 -58.1308
+      vertex -49.9277 1.48347 48.1308
+      vertex -49.9277 1.48347 -58.1308
+    endloop
+  endfacet
+  facet normal -0.946945 -0.321394 0
+    outer loop
+      vertex -49.9277 1.48347 48.1308
+      vertex -49.8438 1.23627 -58.1308
+      vertex -49.8438 1.23627 48.1308
+    endloop
+  endfacet
+  facet normal -0.980807 -0.194982 0
+    outer loop
+      vertex -49.9277 1.48347 -58.1308
+      vertex -49.9786 1.73951 48.1308
+      vertex -49.9786 1.73951 -58.1308
+    endloop
+  endfacet
+  facet normal -0.980807 -0.194982 0
+    outer loop
+      vertex -49.9786 1.73951 48.1308
+      vertex -49.9277 1.48347 -58.1308
+      vertex -49.9277 1.48347 48.1308
+    endloop
+  endfacet
+  facet normal -0.180278 0.906424 0.381963
+    outer loop
+      vertex -48.2472 4.87766 48.6429
+      vertex -48.4902 4.82933 48.6429
+      vertex -48.4643 4.73263 48.8846
+    endloop
+  endfacet
+  facet normal -0.0631869 0.963996 0.258299
+    outer loop
+      vertex -48 4.96157 48.3902
+      vertex -48.256 4.94479 48.3902
+      vertex -48 4.89386 48.6429
+    endloop
+  endfacet
+  facet normal 0.0566694 0.864577 0.499295
+    outer loop
+      vertex 48.2341 4.7784 48.8846
+      vertex 48 4.66294 49.1111
+      vertex 48.2171 4.64871 49.1111
+    endloop
+  endfacet
+  facet normal 0.297162 0.875102 0.381957
+    outer loop
+      vertex 48.4902 4.82933 48.6429
+      vertex 48.4643 4.73263 48.8846
+      vertex 48.7247 4.7497 48.6429
+    endloop
+  endfacet
+  facet normal -0.726406 0.636897 0.258255
+    outer loop
+      vertex -49.3392 4.33916 48.6429
+      vertex -49.5562 4.19413 48.3902
+      vertex -49.5025 4.15291 48.6429
+    endloop
+  endfacet
+  facet normal -0.768518 0.513291 0.381985
+    outer loop
+      vertex -49.4231 4.09196 48.8846
+      vertex -49.6401 3.94693 48.6429
+      vertex -49.5534 3.89687 48.8846
+    endloop
+  endfacet
+  facet normal -0.0327521 0.499719 0.865568
+    outer loop
+      vertex -48 4.11114 49.6629
+      vertex -48.1155 3.87701 49.7937
+      vertex -48 3.88458 49.7937
+    endloop
+  endfacet
+  facet normal -0.0748487 0.376296 0.923471
+    outer loop
+      vertex -48.0839 3.63738 49.8939
+      vertex -48.2289 3.85444 49.7937
+      vertex -48.1664 3.62097 49.8939
+    endloop
+  endfacet
+  facet normal 0.160955 0.474212 0.865573
+    outer loop
+      vertex 48.4252 4.02656 49.6629
+      vertex 48.2289 3.85444 49.7937
+      vertex 48.3385 3.81724 49.7937
+    endloop
+  endfacet
+  facet normal -0 0.707126 0.707088
+    outer loop
+      vertex -48 4.50368 49.3187
+      vertex 48 4.31869 49.5037
+      vertex 48 4.50368 49.3187
+    endloop
+  endfacet
+  facet normal 0 0.707126 0.707088
+    outer loop
+      vertex 48 4.31869 49.5037
+      vertex -48 4.50368 49.3187
+      vertex -48 4.31869 49.5037
+    endloop
+  endfacet
+  facet normal -0.0748893 0.376272 0.923478
+    outer loop
+      vertex -48.1155 3.87701 49.7937
+      vertex -48.2289 3.85444 49.7937
+      vertex -48.0839 3.63738 49.8939
+    endloop
+  endfacet
+  facet normal -0.18022 0.906416 0.38201
+    outer loop
+      vertex -48.2472 4.87766 48.6429
+      vertex -48.4643 4.73263 48.8846
+      vertex -48.2341 4.7784 48.8846
+    endloop
+  endfacet
+  facet normal -0.393183 0.588676 0.706306
+    outer loop
+      vertex -48.7518 4.30222 49.3187
+      vertex -48.9154 4.19295 49.3187
+      vertex -48.8028 4.04619 49.5037
+    endloop
+  endfacet
+  facet normal -0.0519085 0.792352 0.607852
+    outer loop
+      vertex -48 4.66294 49.1111
+      vertex -48.1963 4.49082 49.3187
+      vertex -48 4.50368 49.3187
+    endloop
+  endfacet
+  facet normal -0.914834 0.31043 0.258286
+    outer loop
+      vertex -49.7497 3.72475 48.6429
+      vertex -49.8947 3.50769 48.3902
+      vertex -49.8293 3.49017 48.6429
+    endloop
+  endfacet
+  facet normal -0.875161 0.296968 0.381972
+    outer loop
+      vertex -49.7497 3.72475 48.6429
+      vertex -49.8293 3.49017 48.6429
+      vertex -49.7326 3.46426 48.8846
+    endloop
+  endfacet
+  facet normal -0.777012 0.383281 0.499347
+    outer loop
+      vertex -49.5534 3.89687 48.8846
+      vertex -49.6572 3.68644 48.8846
+      vertex -49.4401 3.83147 49.1111
+    endloop
+  endfacet
+  facet normal -0.820542 0.278454 0.499174
+    outer loop
+      vertex -49.5364 3.63638 49.1111
+      vertex -49.7326 3.46426 48.8846
+      vertex -49.6063 3.4304 49.1111
+    endloop
+  endfacet
+  facet normal -0.608082 -0.0399217 0.79287
+    outer loop
+      vertex -49.1016 1.85497 49.6629
+      vertex -49.3187 2 49.5037
+      vertex -49.3074 1.82788 49.5037
+    endloop
+  endfacet
+  facet normal -0.416373 -0.278275 0.865561
+    outer loop
+      vertex -48.7661 1.55771 49.7937
+      vertex -48.9623 1.44443 49.6629
+      vertex -48.7018 1.4615 49.7937
+    endloop
+  endfacet
+  facet normal -0.694328 -0.137897 0.706324
+    outer loop
+      vertex -49.3074 1.82788 49.5037
+      vertex -49.4908 1.80373 49.3187
+      vertex -49.2738 1.6587 49.5037
+    endloop
+  endfacet
+  facet normal -0.499757 -0.0327359 0.865547
+    outer loop
+      vertex -48.877 1.88454 49.7937
+      vertex -49.1111 2 49.6629
+      vertex -49.1016 1.85497 49.6629
+    endloop
+  endfacet
+  facet normal -0.577082 0.195813 0.792864
+    outer loop
+      vertex -49.0266 3.42521 49.6629
+      vertex -49.2738 3.3413 49.5037
+      vertex -49.0733 3.28758 49.6629
+    endloop
+  endfacet
+  facet normal -0.706374 0.0463748 0.706318
+    outer loop
+      vertex -49.3074 3.17212 49.5037
+      vertex -49.4908 3.19627 49.3187
+      vertex -49.3187 3 49.5037
+    endloop
+  endfacet
+  facet normal -0.491118 0.0975 0.86562
+    outer loop
+      vertex -49.0733 3.28758 49.6629
+      vertex -49.1016 3.14503 49.6629
+      vertex -48.8544 3.22894 49.7937
+    endloop
+  endfacet
+  facet normal -0.382838 0.0251998 0.923472
+    outer loop
+      vertex -48.877 3.11546 49.7937
+      vertex -48.8846 3 49.7937
+      vertex -48.6429 3 49.8939
+    endloop
+  endfacet
+  facet normal -0.506732 0.338481 0.792876
+    outer loop
+      vertex -49.0462 3.80277 49.5037
+      vertex -49.142 3.65935 49.5037
+      vertex -48.8815 3.67642 49.6629
+    endloop
+  endfacet
+  facet normal -0.532304 0.466674 0.706305
+    outer loop
+      vertex -48.9325 3.93246 49.5037
+      vertex -49.0633 4.06326 49.3187
+      vertex -49.0462 3.80277 49.5037
+    endloop
+  endfacet
+  facet normal -0.474078 0.160954 0.865647
+    outer loop
+      vertex -48.8172 3.33851 49.7937
+      vertex -49.0266 3.42521 49.6629
+      vertex -48.8544 3.22894 49.7937
+    endloop
+  endfacet
+  facet normal -0.0420229 0.123687 0.991431
+    outer loop
+      vertex -48.101 3.37689 49.9616
+      vertex -48.1493 3.36048 49.9616
+      vertex -48.0501 3.12085 49.9957
+    endloop
+  endfacet
+  facet normal -0.40176 -0.458185 0.792878
+    outer loop
+      vertex -48.7857 1.21431 49.6629
+      vertex -48.9325 1.06754 49.5037
+      vertex -48.6764 1.11847 49.6629
+    endloop
+  endfacet
+  facet normal -0.330185 -0.376539 0.865561
+    outer loop
+      vertex -48.6255 1.37451 49.7937
+      vertex -48.6764 1.11847 49.6629
+      vertex -48.5385 1.29822 49.7937
+    endloop
+  endfacet
+  facet normal -0.44122 -0.660101 0.60794
+    outer loop
+      vertex -48.7518 0.697776 49.3187
+      vertex -49.0123 0.680702 49.1111
+      vertex -48.8315 0.559853 49.1111
+    endloop
+  endfacet
+  facet normal -0.255208 -0.751889 0.607892
+    outer loop
+      vertex -48.5754 0.610782 49.3187
+      vertex -48.6364 0.463645 49.1111
+      vertex -48.4304 0.393724 49.1111
+    endloop
+  endfacet
+  facet normal -0.117298 -0.0573489 0.99144
+    outer loop
+      vertex -48.1208 1.94994 49.9957
+      vertex -48.3605 1.85069 49.9616
+      vertex -48.1133 1.9346 49.9957
+    endloop
+  endfacet
+  facet normal -0.363296 -0.123342 0.923473
+    outer loop
+      vertex -48.5939 1.75398 49.8939
+      vertex -48.8544 1.77106 49.7937
+      vertex -48.8172 1.66149 49.7937
+    endloop
+  endfacet
+  facet normal -0.382882 -0.0250965 0.923456
+    outer loop
+      vertex -48.6429 2 49.8939
+      vertex -48.877 1.88454 49.7937
+      vertex -48.6374 1.91609 49.8939
+    endloop
+  endfacet
+  facet normal -0.258645 -0.0172667 0.965818
+    outer loop
+      vertex -48.3902 2 49.9616
+      vertex -48.6374 1.91609 49.8939
+      vertex -48.3868 1.94907 49.9616
+    endloop
+  endfacet
+  facet normal -0.215653 0.144036 0.965788
+    outer loop
+      vertex -48.51 3.39136 49.8939
+      vertex -48.5567 3.32144 49.8939
+      vertex -48.3379 3.19509 49.9616
+    endloop
+  endfacet
+  facet normal -0.499816 -0.0328997 0.865507
+    outer loop
+      vertex -48.8846 2 49.7937
+      vertex -49.1111 2 49.6629
+      vertex -48.877 1.88454 49.7937
+    endloop
+  endfacet
+  facet normal -0.382882 0.0250965 0.923456
+    outer loop
+      vertex -48.6374 3.08391 49.8939
+      vertex -48.877 3.11546 49.7937
+      vertex -48.6429 3 49.8939
+    endloop
+  endfacet
+  facet normal -0.376317 0.0749451 0.923455
+    outer loop
+      vertex -48.8544 3.22894 49.7937
+      vertex -48.877 3.11546 49.7937
+      vertex -48.6374 3.08391 49.8939
+    endloop
+  endfacet
+  facet normal 0.310633 0.914773 0.25826
+    outer loop
+      vertex 48.5077 4.89473 48.3902
+      vertex 48.4902 4.82933 48.6429
+      vertex 48.7247 4.7497 48.6429
+    endloop
+  endfacet
+  facet normal 0.51342 0.76847 0.381907
+    outer loop
+      vertex 49.1529 4.5025 48.6429
+      vertex 48.9469 4.64013 48.6429
+      vertex 49.092 4.42307 48.8846
+    endloop
+  endfacet
+  facet normal 0.168966 0.849812 0.49927
+    outer loop
+      vertex 48.2341 4.7784 48.8846
+      vertex 48.2171 4.64871 49.1111
+      vertex 48.4643 4.73263 48.8846
+    endloop
+  endfacet
+  facet normal 0.0604679 0.922184 0.381995
+    outer loop
+      vertex 48.2472 4.87766 48.6429
+      vertex 48 4.79375 48.8846
+      vertex 48.2341 4.7784 48.8846
+    endloop
+  endfacet
+  facet normal 0.0977607 0.491186 0.865551
+    outer loop
+      vertex 48.145 4.10163 49.6629
+      vertex 48.1155 3.87701 49.7937
+      vertex 48.2289 3.85444 49.7937
+    endloop
+  endfacet
+  facet normal 0.458211 0.401726 0.792881
+    outer loop
+      vertex 48.9325 3.93246 49.5037
+      vertex 48.7857 3.78569 49.6629
+      vertex 48.8815 3.67642 49.6629
+    endloop
+  endfacet
+  facet normal 0.532437 0.46662 0.706241
+    outer loop
+      vertex 49.0633 4.06326 49.3187
+      vertex 49.0462 3.80277 49.5037
+      vertex 49.1929 3.91538 49.3187
+    endloop
+  endfacet
+  facet normal 0.351199 0.712086 0.607941
+    outer loop
+      vertex 48.8315 4.44015 49.1111
+      vertex 48.5754 4.38922 49.3187
+      vertex 48.7518 4.30222 49.3187
+    endloop
+  endfacet
+  facet normal 0.0748487 -0.376296 0.923471
+    outer loop
+      vertex 48.1664 1.37903 49.8939
+      vertex 48.0839 1.36262 49.8939
+      vertex 48.2289 1.14556 49.7937
+    endloop
+  endfacet
+  facet normal 0.0505877 -0.254326 0.965795
+    outer loop
+      vertex 48.101 1.62311 49.9616
+      vertex 48.0839 1.36262 49.8939
+      vertex 48.1664 1.37903 49.8939
+    endloop
+  endfacet
+  facet normal 0 -0.258781 0.965936
+    outer loop
+      vertex -48 1.60982 49.9616
+      vertex 48 1.35712 49.8939
+      vertex 48 1.60982 49.9616
+    endloop
+  endfacet
+  facet normal 0 -0.258781 0.965936
+    outer loop
+      vertex 48 1.35712 49.8939
+      vertex -48 1.60982 49.9616
+      vertex -48 1.35712 49.8939
+    endloop
+  endfacet
+  facet normal 0 -0.130351 0.991468
+    outer loop
+      vertex -48 1.86919 49.9957
+      vertex 48 1.60982 49.9616
+      vertex 48 1.86919 49.9957
+    endloop
+  endfacet
+  facet normal 0 -0.130351 0.991468
+    outer loop
+      vertex 48 1.60982 49.9616
+      vertex -48 1.86919 49.9957
+      vertex -48 1.60982 49.9616
+    endloop
+  endfacet
+  facet normal -0.288558 -0.252864 0.923469
+    outer loop
+      vertex -48.51 1.60864 49.8939
+      vertex -48.6255 1.37451 49.7937
+      vertex -48.4546 1.54542 49.8939
+    endloop
+  endfacet
+  facet normal -0.34412 -0.169441 0.92351
+    outer loop
+      vertex -48.5567 1.67856 49.8939
+      vertex -48.8172 1.66149 49.7937
+      vertex -48.7661 1.55771 49.7937
+    endloop
+  endfacet
+  facet normal -0.278308 -0.416342 0.865566
+    outer loop
+      vertex -48.5385 1.29822 49.7937
+      vertex -48.6764 1.11847 49.6629
+      vertex -48.5556 1.03772 49.6629
+    endloop
+  endfacet
+  facet normal 0 -0.608618 0.793463
+    outer loop
+      vertex -48 0.88886 49.6629
+      vertex 48 0.681309 49.5037
+      vertex 48 0.88886 49.6629
+    endloop
+  endfacet
+  facet normal 0 -0.608618 0.793463
+    outer loop
+      vertex 48 0.681309 49.5037
+      vertex -48 0.88886 49.6629
+      vertex -48 0.681309 49.5037
+    endloop
+  endfacet
+  facet normal 0.278247 -0.416353 0.86558
+    outer loop
+      vertex 48.5385 1.29822 49.7937
+      vertex 48.4423 1.23393 49.7937
+      vertex 48.5556 1.03772 49.6629
+    endloop
+  endfacet
+  facet normal 0.376568 -0.330147 0.865563
+    outer loop
+      vertex 48.8815 1.32358 49.6629
+      vertex 48.6255 1.37451 49.7937
+      vertex 48.7857 1.21431 49.6629
+    endloop
+  endfacet
+  facet normal 0.0748893 -0.376272 0.923478
+    outer loop
+      vertex 48.2289 1.14556 49.7937
+      vertex 48.0839 1.36262 49.8939
+      vertex 48.1155 1.12299 49.7937
+    endloop
+  endfacet
+  facet normal 0.195948 -0.577096 0.792821
+    outer loop
+      vertex 48.4252 0.97344 49.6629
+      vertex 48.3413 0.726242 49.5037
+      vertex 48.5046 0.781689 49.5037
+    endloop
+  endfacet
+  facet normal 0.0250917 -0.382839 0.923474
+    outer loop
+      vertex 48 1.35712 49.8939
+      vertex 48 1.11542 49.7937
+      vertex 48.1155 1.12299 49.7937
+    endloop
+  endfacet
+  facet normal 0.0327521 -0.499719 0.865568
+    outer loop
+      vertex 48 1.11542 49.7937
+      vertex 48 0.88886 49.6629
+      vertex 48.1155 1.12299 49.7937
+    endloop
+  endfacet
+  facet normal -0.0327752 0.499727 0.865563
+    outer loop
+      vertex -48 4.11114 49.6629
+      vertex -48.145 4.10163 49.6629
+      vertex -48.1155 3.87701 49.7937
+    endloop
+  endfacet
+  facet normal 0.213155 0.318953 0.92349
+    outer loop
+      vertex 48.4423 3.76607 49.7937
+      vertex 48.3214 3.55675 49.8939
+      vertex 48.5385 3.70178 49.7937
+    endloop
+  endfacet
+  facet normal 0.0398585 0.608125 0.79284
+    outer loop
+      vertex 48.1721 4.30741 49.5037
+      vertex 48 4.31869 49.5037
+      vertex 48.145 4.10163 49.6629
+    endloop
+  endfacet
+  facet normal 0.221423 0.449163 0.865577
+    outer loop
+      vertex 48.5556 3.96228 49.6629
+      vertex 48.3385 3.81724 49.7937
+      vertex 48.4423 3.76607 49.7937
+    endloop
+  endfacet
+  facet normal 0.213009 0.319148 0.923456
+    outer loop
+      vertex 48.5385 3.70178 49.7937
+      vertex 48.3214 3.55675 49.8939
+      vertex 48.3914 3.51003 49.8939
+    endloop
+  endfacet
+  facet normal 0.118873 0.597721 0.792842
+    outer loop
+      vertex 48.1721 4.30741 49.5037
+      vertex 48.145 4.10163 49.6629
+      vertex 48.3413 4.27376 49.5037
+    endloop
+  endfacet
+  facet normal 0.0748487 0.376296 0.923471
+    outer loop
+      vertex 48.2289 3.85444 49.7937
+      vertex 48.0839 3.63738 49.8939
+      vertex 48.1664 3.62097 49.8939
+    endloop
+  endfacet
+  facet normal 0.0981411 0.0861964 0.991433
+    outer loop
+      vertex 48.2759 3.2759 49.9616
+      vertex 48.1038 3.07963 49.9957
+      vertex 48.3096 3.23753 49.9616
+    endloop
+  endfacet
+  facet normal 0.128159 0.025345 0.99143
+    outer loop
+      vertex 48.3769 3.10099 49.9616
+      vertex 48.1297 3.01707 49.9957
+      vertex 48.3868 3.05093 49.9616
+    endloop
+  endfacet
+  facet normal 0.130331 0.00870067 0.991432
+    outer loop
+      vertex 48.3868 3.05093 49.9616
+      vertex 48.1308 3 49.9957
+      vertex 48.3902 3 49.9616
+    endloop
+  endfacet
+  facet normal 0.245596 0.0833562 0.965782
+    outer loop
+      vertex 48.5939 3.24602 49.8939
+      vertex 48.3605 3.14931 49.9616
+      vertex 48.3769 3.10099 49.9616
+    endloop
+  endfacet
+  facet normal 0.344087 0.169717 0.923472
+    outer loop
+      vertex 48.8172 3.33851 49.7937
+      vertex 48.5567 3.32144 49.8939
+      vertex 48.5939 3.24602 49.8939
+    endloop
+  endfacet
+  facet normal -0.18022 0.906416 -0.38201
+    outer loop
+      vertex -48.2341 4.7784 -58.8846
+      vertex -48.4643 4.73263 -58.8846
+      vertex -48.2472 4.87766 -58.6429
+    endloop
+  endfacet
+  facet normal -0.0604679 0.922184 -0.381995
+    outer loop
+      vertex -48.2341 4.7784 -58.8846
+      vertex -48.2472 4.87766 -58.6429
+      vertex -48 4.79375 -58.8846
+    endloop
+  endfacet
+  facet normal 0.0398853 0.608136 -0.79283
+    outer loop
+      vertex 48.145 4.10163 -59.6629
+      vertex 48 4.11114 -59.6629
+      vertex 48 4.31869 -59.5037
+    endloop
+  endfacet
+  facet normal -0.0976467 0.491161 -0.865578
+    outer loop
+      vertex -48.2289 3.85444 -59.7937
+      vertex -48.2876 4.07328 -59.6629
+      vertex -48.145 4.10163 -59.6629
+    endloop
+  endfacet
+  facet normal -0.0519085 0.792352 -0.607852
+    outer loop
+      vertex -48 4.50368 -59.3187
+      vertex -48.1963 4.49082 -59.3187
+      vertex -48 4.66294 -59.1111
+    endloop
+  endfacet
+  facet normal -0.0519361 0.792363 -0.607835
+    outer loop
+      vertex -48.1963 4.49082 -59.3187
+      vertex -48.2171 4.64871 -59.1111
+      vertex -48 4.66294 -59.1111
+    endloop
+  endfacet
+  facet normal 0.0566898 0.864566 -0.499311
+    outer loop
+      vertex 48.2341 4.7784 -58.8846
+      vertex 48 4.66294 -59.1111
+      vertex 48 4.79375 -58.8846
+    endloop
+  endfacet
+  facet normal 0.0398585 0.608125 -0.79284
+    outer loop
+      vertex 48.145 4.10163 -59.6629
+      vertex 48 4.31869 -59.5037
+      vertex 48.1721 4.30741 -59.5037
+    endloop
+  endfacet
+  facet normal 0.313118 0.634873 -0.706324
+    outer loop
+      vertex 48.6593 4.14202 -59.5037
+      vertex 48.5754 4.38922 -59.3187
+      vertex 48.7518 4.30222 -59.3187
+    endloop
+  endfacet
+  facet normal 0.269492 0.546699 -0.792776
+    outer loop
+      vertex 48.5556 3.96228 -59.6629
+      vertex 48.4252 4.02656 -59.6629
+      vertex 48.6593 4.14202 -59.5037
+    endloop
+  endfacet
+  facet normal 0.215653 0.144036 -0.965788
+    outer loop
+      vertex 48.5567 3.32144 -59.8939
+      vertex 48.3379 3.19509 -59.9616
+      vertex 48.51 3.39136 -59.8939
+    endloop
+  endfacet
+  facet normal 0 0.499987 -0.866033
+    outer loop
+      vertex -48 3.88458 -59.7937
+      vertex 48 4.11114 -59.6629
+      vertex 48 3.88458 -59.7937
+    endloop
+  endfacet
+  facet normal 0 0.499987 -0.866033
+    outer loop
+      vertex 48 4.11114 -59.6629
+      vertex -48 3.88458 -59.7937
+      vertex -48 4.11114 -59.6629
+    endloop
+  endfacet
+  facet normal 0.0519085 0.792352 -0.607852
+    outer loop
+      vertex 48.1963 4.49082 -59.3187
+      vertex 48 4.50368 -59.3187
+      vertex 48 4.66294 -59.1111
+    endloop
+  endfacet
+  facet normal 0.180278 0.906424 -0.381963
+    outer loop
+      vertex 48.4643 4.73263 -58.8846
+      vertex 48.2472 4.87766 -58.6429
+      vertex 48.4902 4.82933 -58.6429
+    endloop
+  endfacet
+  facet normal 0.18845 0.947514 -0.258272
+    outer loop
+      vertex 48.4902 4.82933 -58.6429
+      vertex 48.2472 4.87766 -58.6429
+      vertex 48.5077 4.89473 -58.3902
+    endloop
+  endfacet
+  facet normal 0.438414 0.889282 -0.130273
+    outer loop
+      vertex 48.9808 4.69877 -58.3902
+      vertex 48.7637 4.8438 -58.1308
+      vertex 48.9979 4.72834 -58.1308
+    endloop
+  endfacet
+  facet normal 0.550908 0.824333 -0.130286
+    outer loop
+      vertex 49.1941 4.55622 -58.3902
+      vertex 48.9808 4.69877 -58.3902
+      vertex 48.9979 4.72834 -58.1308
+    endloop
+  endfacet
+  facet normal 0.651433 0.571209 -0.499356
+    outer loop
+      vertex 49.3193 4.01233 -59.1111
+      vertex 49.1759 4.17587 -59.1111
+      vertex 49.4231 4.09196 -58.8846
+    endloop
+  endfacet
+  facet normal 0.720469 0.481216 -0.499355
+    outer loop
+      vertex 49.4401 3.83147 -59.1111
+      vertex 49.3193 4.01233 -59.1111
+      vertex 49.4231 4.09196 -58.8846
+    endloop
+  endfacet
+  facet normal 0.408649 0.828955 -0.38189
+    outer loop
+      vertex 48.8969 4.55343 -58.8846
+      vertex 48.6864 4.6572 -58.8846
+      vertex 48.9469 4.64013 -58.6429
+    endloop
+  endfacet
+  facet normal 0.481361 0.720416 -0.499292
+    outer loop
+      vertex 49.092 4.42307 -58.8846
+      vertex 48.8315 4.44015 -59.1111
+      vertex 48.8969 4.55343 -58.8846
+    endloop
+  endfacet
+  facet normal 0.57127 0.651403 -0.499325
+    outer loop
+      vertex 49.1759 4.17587 -59.1111
+      vertex 49.092 4.42307 -58.8846
+      vertex 49.2684 4.26837 -58.8846
+    endloop
+  endfacet
+  facet normal 0.609347 0.694821 -0.381995
+    outer loop
+      vertex 49.2684 4.26837 -58.8846
+      vertex 49.092 4.42307 -58.8846
+      vertex 49.3392 4.33916 -58.6429
+    endloop
+  endfacet
+  facet normal 0.597056 -0.523522 0.607823
+    outer loop
+      vertex 49.3193 0.987667 49.1111
+      vertex 49.0633 0.936738 49.3187
+      vertex 49.1759 0.824125 49.1111
+    endloop
+  endfacet
+  facet normal 0.252976 -0.28849 0.923459
+    outer loop
+      vertex 48.6255 1.37451 49.7937
+      vertex 48.3914 1.48997 49.8939
+      vertex 48.5385 1.29822 49.7937
+    endloop
+  endfacet
+  facet normal 0.889201 -0.438657 0.130007
+    outer loop
+      vertex 49.8438 1.23627 48.1308
+      vertex 49.6988 1.01922 48.3902
+      vertex 49.7283 1.00214 48.1308
+    endloop
+  endfacet
+  facet normal 0.866341 -0.42736 0.25849
+    outer loop
+      vertex 49.7497 1.27525 48.6429
+      vertex 49.6401 1.05307 48.6429
+      vertex 49.6988 1.01922 48.3902
+    endloop
+  endfacet
+  facet normal 0.820543 -0.278463 0.499167
+    outer loop
+      vertex 49.7326 1.53574 48.8846
+      vertex 49.5364 1.36362 49.1111
+      vertex 49.6572 1.31356 48.8846
+    endloop
+  endfacet
+  facet normal 0.889226 -0.438585 0.130081
+    outer loop
+      vertex 49.8123 1.24934 48.3902
+      vertex 49.6988 1.01922 48.3902
+      vertex 49.8438 1.23627 48.1308
+    endloop
+  endfacet
+  facet normal 0.637025 -0.726344 0.258115
+    outer loop
+      vertex 49.3392 0.660839 48.6429
+      vertex 49.1941 0.443782 48.3902
+      vertex 49.387 0.612961 48.3902
+    endloop
+  endfacet
+  facet normal 0.803137 -0.53681 0.258469
+    outer loop
+      vertex 49.6401 1.05307 48.6429
+      vertex 49.5562 0.805872 48.3902
+      vertex 49.6988 1.01922 48.3902
+    endloop
+  endfacet
+  facet normal 0.427243 -0.866434 0.258371
+    outer loop
+      vertex 48.9469 0.359869 48.6429
+      vertex 48.7247 0.250301 48.6429
+      vertex 48.9808 0.30123 48.3902
+    endloop
+  endfacet
+  facet normal 0.427298 -0.866388 0.258435
+    outer loop
+      vertex 48.9808 0.30123 48.3902
+      vertex 48.7247 0.250301 48.6429
+      vertex 48.7507 0.187746 48.3902
+    endloop
+  endfacet
+  facet normal 0.550937 -0.824318 0.130266
+    outer loop
+      vertex 49.1941 0.443782 48.3902
+      vertex 48.9979 0.271658 48.1308
+      vertex 49.2149 0.416691 48.1308
+    endloop
+  endfacet
+  facet normal -0.195114 -0.98078 0
+    outer loop
+      vertex -48.5165 0.0722847 -58.1308
+      vertex -48.2605 0.0213566 48.1308
+      vertex -48.5165 0.0722847 48.1308
+    endloop
+  endfacet
+  facet normal -0.195114 -0.98078 -0
+    outer loop
+      vertex -48.2605 0.0213566 48.1308
+      vertex -48.5165 0.0722847 -58.1308
+      vertex -48.2605 0.0213566 -58.1308
+    endloop
+  endfacet
+  facet normal -0.0654015 -0.997859 0
+    outer loop
+      vertex -48.2605 0.0213566 -58.1308
+      vertex -48 0.00428295 48.1308
+      vertex -48.2605 0.0213566 48.1308
+    endloop
+  endfacet
+  facet normal -0.0654015 -0.997859 -0
+    outer loop
+      vertex -48 0.00428295 48.1308
+      vertex -48.2605 0.0213566 -58.1308
+      vertex -48 0.00428295 -58.1308
+    endloop
+  endfacet
+  facet normal -0.0648444 -0.989359 -0.130247
+    outer loop
+      vertex -48 0.00428295 -58.1308
+      vertex -48.2605 0.0213566 -58.1308
+      vertex -48.256 0.0552111 -58.3902
+    endloop
+  endfacet
+  facet normal -0.550937 -0.824318 0.130266
+    outer loop
+      vertex -49.1941 0.443782 48.3902
+      vertex -49.2149 0.416691 48.1308
+      vertex -48.9979 0.271658 48.1308
+    endloop
+  endfacet
+  facet normal -0.726328 -0.637054 0.25809
+    outer loop
+      vertex -49.3392 0.660839 48.6429
+      vertex -49.5562 0.805872 48.3902
+      vertex -49.387 0.612961 48.3902
+    endloop
+  endfacet
+  facet normal -0.118878 -0.597729 0.792835
+    outer loop
+      vertex -48.145 0.898366 49.6629
+      vertex -48.3413 0.726242 49.5037
+      vertex -48.1721 0.692591 49.5037
+    endloop
+  endfacet
+  facet normal -0.707107 0 0.707107
+    outer loop
+      vertex -49.5037 2 49.3187
+      vertex -49.3187 3 49.5037
+      vertex -49.5037 3 49.3187
+    endloop
+  endfacet
+  facet normal -0.707107 0 0.707107
+    outer loop
+      vertex -49.3187 3 49.5037
+      vertex -49.5037 2 49.3187
+      vertex -49.3187 2 49.5037
+    endloop
+  endfacet
+  facet normal -0.706344 0.046425 0.706344
+    outer loop
+      vertex -49.4908 3.19627 49.3187
+      vertex -49.5037 3 49.3187
+      vertex -49.3187 3 49.5037
+    endloop
+  endfacet
+  facet normal -0.792355 0.0518356 0.607854
+    outer loop
+      vertex -49.6487 3.21706 49.1111
+      vertex -49.6629 3 49.1111
+      vertex -49.4908 3.19627 49.3187
+    endloop
+  endfacet
+  facet normal -0.964002 -0.0632527 0.258262
+    outer loop
+      vertex -49.8939 2 48.6429
+      vertex -49.9616 2 48.3902
+      vertex -49.9448 1.74396 48.3902
+    endloop
+  endfacet
+  facet normal -0.866378 -0.427316 0.258437
+    outer loop
+      vertex -49.7497 1.27525 48.6429
+      vertex -49.8123 1.24934 48.3902
+      vertex -49.6988 1.01922 48.3902
+    endloop
+  endfacet
+  facet normal -0.964026 -0.0631765 0.25819
+    outer loop
+      vertex -49.8939 2 48.6429
+      vertex -49.9448 1.74396 48.3902
+      vertex -49.8777 1.7528 48.6429
+    endloop
+  endfacet
+  facet normal -0.947499 -0.188634 0.25819
+    outer loop
+      vertex -49.8777 1.7528 48.6429
+      vertex -49.9448 1.74396 48.3902
+      vertex -49.8947 1.49231 48.3902
+    endloop
+  endfacet
+  facet normal -0.864592 -0.0564996 0.499288
+    outer loop
+      vertex -49.6629 2 49.1111
+      vertex -49.7937 2 48.8846
+      vertex -49.7784 1.76587 48.8846
+    endloop
+  endfacet
+  facet normal -0.792355 -0.0518356 0.607854
+    outer loop
+      vertex -49.4908 1.80373 49.3187
+      vertex -49.6629 2 49.1111
+      vertex -49.6487 1.78294 49.1111
+    endloop
+  endfacet
+  facet normal 0.195935 -0.577095 0.792825
+    outer loop
+      vertex 48.4252 0.97344 49.6629
+      vertex 48.2876 0.926722 49.6629
+      vertex 48.3413 0.726242 49.5037
+    endloop
+  endfacet
+  facet normal 0.154939 -0.778785 0.607855
+    outer loop
+      vertex 48.4304 0.393724 49.1111
+      vertex 48.1963 0.509185 49.3187
+      vertex 48.2171 0.351288 49.1111
+    endloop
+  endfacet
+  facet normal 0.889226 0.438585 0.130081
+    outer loop
+      vertex 49.8438 3.76373 48.1308
+      vertex 49.6988 3.98078 48.3902
+      vertex 49.8123 3.75066 48.3902
+    endloop
+  endfacet
+  facet normal 0.866378 0.427316 0.258437
+    outer loop
+      vertex 49.8123 3.75066 48.3902
+      vertex 49.6988 3.98078 48.3902
+      vertex 49.7497 3.72475 48.6429
+    endloop
+  endfacet
+  facet normal 0.550908 0.824333 0.130286
+    outer loop
+      vertex 48.9979 4.72834 48.1308
+      vertex 48.9808 4.69877 48.3902
+      vertex 49.1941 4.55622 48.3902
+    endloop
+  endfacet
+  facet normal 0.438414 0.889282 0.130273
+    outer loop
+      vertex 48.9979 4.72834 48.1308
+      vertex 48.7637 4.8438 48.1308
+      vertex 48.9808 4.69877 48.3902
+    endloop
+  endfacet
+  facet normal 0.726325 0.637055 0.258095
+    outer loop
+      vertex 49.387 4.38704 48.3902
+      vertex 49.3392 4.33916 48.6429
+      vertex 49.5562 4.19413 48.3902
+    endloop
+  endfacet
+  facet normal 0.745377 0.653765 0.130403
+    outer loop
+      vertex 49.4112 4.41119 48.1308
+      vertex 49.387 4.38704 48.3902
+      vertex 49.5562 4.19413 48.3902
+    endloop
+  endfacet
+  facet normal 0.660335 0.441051 0.607809
+    outer loop
+      vertex 49.3193 4.01233 49.1111
+      vertex 49.3022 3.75184 49.3187
+      vertex 49.4401 3.83147 49.1111
+    endloop
+  endfacet
+  facet normal 0.864562 0.0565594 0.499334
+    outer loop
+      vertex 49.7784 3.23413 48.8846
+      vertex 49.6487 3.21706 49.1111
+      vertex 49.6629 3 49.1111
+    endloop
+  endfacet
+  facet normal 0.634888 0.313115 0.706312
+    outer loop
+      vertex 49.3892 3.57543 49.3187
+      vertex 49.142 3.65935 49.5037
+      vertex 49.2183 3.50464 49.5037
+    endloop
+  endfacet
+  facet normal 0.577116 0.196094 0.79277
+    outer loop
+      vertex 49.2183 3.50464 49.5037
+      vertex 49.0266 3.42521 49.6629
+      vertex 49.2738 3.3413 49.5037
+    endloop
+  endfacet
+  facet normal 0.318905 0.213134 0.923512
+    outer loop
+      vertex 48.7018 3.5385 49.7937
+      vertex 48.5567 3.32144 49.8939
+      vertex 48.7661 3.44229 49.7937
+    endloop
+  endfacet
+  facet normal 0.34412 0.169441 0.92351
+    outer loop
+      vertex 48.7661 3.44229 49.7937
+      vertex 48.5567 3.32144 49.8939
+      vertex 48.8172 3.33851 49.7937
+    endloop
+  endfacet
+  facet normal 0.474078 0.160954 0.865647
+    outer loop
+      vertex 49.0266 3.42521 49.6629
+      vertex 48.8172 3.33851 49.7937
+      vertex 48.8544 3.22894 49.7937
+    endloop
+  endfacet
+  facet normal 0.382882 0.0250965 0.923456
+    outer loop
+      vertex 48.877 3.11546 49.7937
+      vertex 48.6374 3.08391 49.8939
+      vertex 48.6429 3 49.8939
+    endloop
+  endfacet
+  facet normal 0.499757 0.0327359 0.865547
+    outer loop
+      vertex 49.1016 3.14503 49.6629
+      vertex 48.877 3.11546 49.7937
+      vertex 49.1111 3 49.6629
+    endloop
+  endfacet
+  facet normal 0.608045 0.0398292 0.792903
+    outer loop
+      vertex 49.3187 3 49.5037
+      vertex 49.1016 3.14503 49.6629
+      vertex 49.1111 3 49.6629
+    endloop
+  endfacet
+  facet normal 0.751827 0.255117 0.608006
+    outer loop
+      vertex 49.6063 3.4304 49.1111
+      vertex 49.3892 3.57543 49.3187
+      vertex 49.4524 3.38918 49.3187
+    endloop
+  endfacet
+  facet normal 0.597056 0.523528 0.607818
+    outer loop
+      vertex 49.1759 4.17587 49.1111
+      vertex 49.0633 4.06326 49.3187
+      vertex 49.3193 4.01233 49.1111
+    endloop
+  endfacet
+  facet normal 0.792455 0.0520848 0.607702
+    outer loop
+      vertex 49.6629 3 49.1111
+      vertex 49.4908 3.19627 49.3187
+      vertex 49.5037 3 49.3187
+    endloop
+  endfacet
+  facet normal 0.964002 0.0632527 0.258262
+    outer loop
+      vertex 49.9448 3.25604 48.3902
+      vertex 49.8939 3 48.6429
+      vertex 49.9616 3 48.3902
+    endloop
+  endfacet
+  facet normal 0.849887 0.16891 0.499161
+    outer loop
+      vertex 49.7326 3.46426 48.8846
+      vertex 49.6063 3.4304 49.1111
+      vertex 49.6487 3.21706 49.1111
+    endloop
+  endfacet
+  facet normal 0.751829 0.255136 0.607995
+    outer loop
+      vertex 49.5364 3.63638 49.1111
+      vertex 49.3892 3.57543 49.3187
+      vertex 49.6063 3.4304 49.1111
+    endloop
+  endfacet
+  facet normal 0.778651 0.154996 0.608012
+    outer loop
+      vertex 49.6063 3.4304 49.1111
+      vertex 49.4524 3.38918 49.3187
+      vertex 49.4908 3.19627 49.3187
+    endloop
+  endfacet
+  facet normal 0.989379 -0.0649178 0.130061
+    outer loop
+      vertex 49.9616 2 48.3902
+      vertex 49.9448 1.74396 48.3902
+      vertex 49.9957 2 48.1308
+    endloop
+  endfacet
+  facet normal 0.964002 -0.0632527 0.258262
+    outer loop
+      vertex 49.9616 2 48.3902
+      vertex 49.8939 2 48.6429
+      vertex 49.9448 1.74396 48.3902
+    endloop
+  endfacet
+  facet normal 0.98938 -0.0649484 0.130031
+    outer loop
+      vertex 49.9957 2 48.1308
+      vertex 49.9448 1.74396 48.3902
+      vertex 49.9786 1.73951 48.1308
+    endloop
+  endfacet
+  facet normal 0.864562 -0.0565594 0.499334
+    outer loop
+      vertex 49.6629 2 49.1111
+      vertex 49.6487 1.78294 49.1111
+      vertex 49.7784 1.76587 48.8846
+    endloop
+  endfacet
+  facet normal 0.694829 -0.609333 0.382002
+    outer loop
+      vertex 49.4231 0.908037 48.8846
+      vertex 49.2684 0.731631 48.8846
+      vertex 49.3392 0.660839 48.6429
+    endloop
+  endfacet
+  facet normal 0.849746 -0.169115 0.499332
+    outer loop
+      vertex 49.7784 1.76587 48.8846
+      vertex 49.6487 1.78294 49.1111
+      vertex 49.7326 1.53574 48.8846
+    endloop
+  endfacet
+  facet normal 0.914834 -0.31043 0.258286
+    outer loop
+      vertex 49.8293 1.50983 48.6429
+      vertex 49.7497 1.27525 48.6429
+      vertex 49.8947 1.49231 48.3902
+    endloop
+  endfacet
+  facet normal 0.597118 -0.523299 0.607954
+    outer loop
+      vertex 49.1929 1.08462 49.3187
+      vertex 49.0633 0.936738 49.3187
+      vertex 49.3193 0.987667 49.1111
+    endloop
+  endfacet
+  facet normal 0.458211 -0.401726 0.792881
+    outer loop
+      vertex 48.8815 1.32358 49.6629
+      vertex 48.7857 1.21431 49.6629
+      vertex 48.9325 1.06754 49.5037
+    endloop
+  endfacet
+  facet normal 0.449303 -0.221231 0.865554
+    outer loop
+      vertex 48.8172 1.66149 49.7937
+      vertex 48.7661 1.55771 49.7937
+      vertex 48.9623 1.44443 49.6629
+    endloop
+  endfacet
+  facet normal 0.318905 -0.213134 0.923512
+    outer loop
+      vertex 48.7661 1.55771 49.7937
+      vertex 48.5567 1.67856 49.8939
+      vertex 48.7018 1.4615 49.7937
+    endloop
+  endfacet
+  facet normal 0.245476 -0.0835415 0.965796
+    outer loop
+      vertex 48.621 1.83361 49.8939
+      vertex 48.3769 1.89901 49.9616
+      vertex 48.5939 1.75398 49.8939
+    endloop
+  endfacet
+  facet normal 0.258645 -0.0172667 0.965818
+    outer loop
+      vertex 48.3902 2 49.9616
+      vertex 48.3868 1.94907 49.9616
+      vertex 48.6374 1.91609 49.8939
+    endloop
+  endfacet
+  facet normal 0.506691 -0.338773 0.792778
+    outer loop
+      vertex 48.9623 1.44443 49.6629
+      vertex 48.8815 1.32358 49.6629
+      vertex 49.142 1.34065 49.5037
+    endloop
+  endfacet
+  facet normal 0.577082 -0.195813 0.792864
+    outer loop
+      vertex 49.0733 1.71242 49.6629
+      vertex 49.0266 1.57479 49.6629
+      vertex 49.2738 1.6587 49.5037
+    endloop
+  endfacet
+  facet normal 0.128159 -0.025345 0.99143
+    outer loop
+      vertex 48.3868 1.94907 49.9616
+      vertex 48.1297 1.98293 49.9957
+      vertex 48.3769 1.89901 49.9616
+    endloop
+  endfacet
+  facet normal 0.376381 -0.0748381 0.923437
+    outer loop
+      vertex 48.6374 1.91609 49.8939
+      vertex 48.621 1.83361 49.8939
+      vertex 48.8544 1.77106 49.7937
+    endloop
+  endfacet
+  facet normal 0.0860872 0.0982392 0.991432
+    outer loop
+      vertex 48.2375 3.30955 49.9616
+      vertex 48.0796 3.10378 49.9957
+      vertex 48.2759 3.2759 49.9616
+    endloop
+  endfacet
+  facet normal 0.550913 -0.824329 -0.130292
+    outer loop
+      vertex 48.9979 0.271658 -58.1308
+      vertex 48.9808 0.30123 -58.3902
+      vertex 49.1941 0.443782 -58.3902
+    endloop
+  endfacet
+  facet normal 0.438413 -0.889281 -0.13028
+    outer loop
+      vertex 48.9979 0.271658 -58.1308
+      vertex 48.7637 0.156198 -58.1308
+      vertex 48.9808 0.30123 -58.3902
+    endloop
+  endfacet
+  facet normal 0.914848 -0.310258 -0.258442
+    outer loop
+      vertex 49.8123 1.24934 -58.3902
+      vertex 49.7497 1.27525 -58.6429
+      vertex 49.8947 1.49231 -58.3902
+    endloop
+  endfacet
+  facet normal 0.947499 -0.188634 -0.25819
+    outer loop
+      vertex 49.8947 1.49231 -58.3902
+      vertex 49.8777 1.7528 -58.6429
+      vertex 49.9448 1.74396 -58.3902
+    endloop
+  endfacet
+  facet normal 0.71219 -0.35123 -0.607801
+    outer loop
+      vertex 49.4401 1.16853 -59.1111
+      vertex 49.3022 1.24816 -59.3187
+      vertex 49.3892 1.42457 -59.3187
+    endloop
+  endfacet
+  facet normal 0.866341 -0.42736 -0.25849
+    outer loop
+      vertex 49.6988 1.01922 -58.3902
+      vertex 49.6401 1.05307 -58.6429
+      vertex 49.7497 1.27525 -58.6429
+    endloop
+  endfacet
+  facet normal 0.922148 -0.0602608 -0.382114
+    outer loop
+      vertex 49.8777 1.7528 -58.6429
+      vertex 49.7784 1.76587 -58.8846
+      vertex 49.7937 2 -58.8846
+    endloop
+  endfacet
+  facet normal 0.922077 -0.0604274 -0.38226
+    outer loop
+      vertex 49.8777 1.7528 -58.6429
+      vertex 49.7937 2 -58.8846
+      vertex 49.8939 2 -58.6429
+    endloop
+  endfacet
+  facet normal 0.269492 -0.546699 -0.792776
+    outer loop
+      vertex 48.6593 0.85798 -59.5037
+      vertex 48.4252 0.97344 -59.6629
+      vertex 48.5556 1.03772 -59.6629
+    endloop
+  endfacet
+  facet normal 0.571285 -0.651399 -0.499313
+    outer loop
+      vertex 49.2684 0.731631 -58.8846
+      vertex 49.092 0.576926 -58.8846
+      vertex 49.1759 0.824125 -59.1111
+    endloop
+  endfacet
+  facet normal 0.597118 -0.523299 -0.607954
+    outer loop
+      vertex 49.3193 0.987667 -59.1111
+      vertex 49.0633 0.936738 -59.3187
+      vertex 49.1929 1.08462 -59.3187
+    endloop
+  endfacet
+  facet normal 0.376531 -0.33026 -0.865536
+    outer loop
+      vertex 48.8815 1.32358 -59.6629
+      vertex 48.6255 1.37451 -59.7937
+      vertex 48.7018 1.4615 -59.7937
+    endloop
+  endfacet
+  facet normal 0.751829 -0.255136 -0.607995
+    outer loop
+      vertex 49.5364 1.36362 -59.1111
+      vertex 49.3892 1.42457 -59.3187
+      vertex 49.6063 1.5696 -59.1111
+    endloop
+  endfacet
+  facet normal 0.71194 -0.351426 -0.607981
+    outer loop
+      vertex 49.4401 1.16853 -59.1111
+      vertex 49.3892 1.42457 -59.3187
+      vertex 49.5364 1.36362 -59.1111
+    endloop
+  endfacet
+  facet normal 0.864562 -0.0565594 -0.499334
+    outer loop
+      vertex 49.7784 1.76587 -58.8846
+      vertex 49.6487 1.78294 -59.1111
+      vertex 49.6629 2 -59.1111
+    endloop
+  endfacet
+  facet normal 0.820542 -0.278454 -0.499174
+    outer loop
+      vertex 49.7326 1.53574 -58.8846
+      vertex 49.5364 1.36362 -59.1111
+      vertex 49.6063 1.5696 -59.1111
+    endloop
+  endfacet
+  facet normal 0.792355 -0.0518356 -0.607854
+    outer loop
+      vertex 49.6487 1.78294 -59.1111
+      vertex 49.4908 1.80373 -59.3187
+      vertex 49.6629 2 -59.1111
+    endloop
+  endfacet
+  facet normal 0.634888 -0.313107 -0.706315
+    outer loop
+      vertex 49.3022 1.24816 -59.3187
+      vertex 49.142 1.34065 -59.5037
+      vertex 49.3892 1.42457 -59.3187
+    endloop
+  endfacet
+  facet normal 0.634888 -0.313115 -0.706312
+    outer loop
+      vertex 49.3892 1.42457 -59.3187
+      vertex 49.142 1.34065 -59.5037
+      vertex 49.2183 1.49536 -59.5037
+    endloop
+  endfacet
+  facet normal 0.458211 -0.401726 -0.792881
+    outer loop
+      vertex 48.9325 1.06754 -59.5037
+      vertex 48.7857 1.21431 -59.6629
+      vertex 48.8815 1.32358 -59.6629
+    endloop
+  endfacet
+  facet normal 0.532303 -0.466673 -0.706308
+    outer loop
+      vertex 49.0633 0.936738 -59.3187
+      vertex 48.9325 1.06754 -59.5037
+      vertex 49.0462 1.19723 -59.5037
+    endloop
+  endfacet
+  facet normal 0.313097 -0.634876 -0.706331
+    outer loop
+      vertex 48.7518 0.697776 -59.3187
+      vertex 48.5754 0.610782 -59.3187
+      vertex 48.6593 0.85798 -59.5037
+    endloop
+  endfacet
+  facet normal 0.118878 -0.597729 -0.792835
+    outer loop
+      vertex 48.1721 0.692591 -59.5037
+      vertex 48.145 0.898366 -59.6629
+      vertex 48.3413 0.726242 -59.5037
+    endloop
+  endfacet
+  facet normal 0.0327521 -0.499719 -0.865568
+    outer loop
+      vertex 48.1155 1.12299 -59.7937
+      vertex 48 0.88886 -59.6629
+      vertex 48 1.11542 -59.7937
+    endloop
+  endfacet
+  facet normal 0.0976671 -0.49116 -0.865577
+    outer loop
+      vertex 48.2876 0.926722 -59.6629
+      vertex 48.145 0.898366 -59.6629
+      vertex 48.2289 1.14556 -59.7937
+    endloop
+  endfacet
+  facet normal 0.636887 -0.726415 -0.258256
+    outer loop
+      vertex 49.1941 0.443782 -58.3902
+      vertex 49.1529 0.4975 -58.6429
+      vertex 49.3392 0.660839 -58.6429
+    endloop
+  endfacet
+  facet normal 0.513425 -0.768472 -0.381896
+    outer loop
+      vertex 49.1529 0.4975 -58.6429
+      vertex 48.9469 0.359869 -58.6429
+      vertex 49.092 0.576926 -58.8846
+    endloop
+  endfacet
+  facet normal 0.513447 -0.768467 -0.381878
+    outer loop
+      vertex 48.9469 0.359869 -58.6429
+      vertex 48.8969 0.446571 -58.8846
+      vertex 49.092 0.576926 -58.8846
+    endloop
+  endfacet
+  facet normal 0.297162 -0.875096 -0.381971
+    outer loop
+      vertex 48.7247 0.250301 -58.6429
+      vertex 48.4643 0.267375 -58.8846
+      vertex 48.6864 0.342795 -58.8846
+    endloop
+  endfacet
+  facet normal 0.188449 -0.94751 -0.258286
+    outer loop
+      vertex 48.5077 0.105268 -58.3902
+      vertex 48.2472 0.122342 -58.6429
+      vertex 48.4902 0.170672 -58.6429
+    endloop
+  endfacet
+  facet normal 0.180277 -0.90642 -0.381972
+    outer loop
+      vertex 48.4902 0.170672 -58.6429
+      vertex 48.2472 0.122342 -58.6429
+      vertex 48.4643 0.267375 -58.8846
+    endloop
+  endfacet
+  facet normal 0.0604523 -0.922187 -0.381991
+    outer loop
+      vertex 48.2472 0.122342 -58.6429
+      vertex 48 0.206255 -58.8846
+      vertex 48.2341 0.221601 -58.8846
+    endloop
+  endfacet
+  facet normal 0.0566756 -0.864574 -0.4993
+    outer loop
+      vertex 48.2341 0.221601 -58.8846
+      vertex 48 0.206255 -58.8846
+      vertex 48 0.337061 -59.1111
+    endloop
+  endfacet
+  facet normal -0.32144 -0.94693 0
+    outer loop
+      vertex -48.7637 0.156198 -58.1308
+      vertex -48.5165 0.0722847 48.1308
+      vertex -48.7637 0.156198 48.1308
+    endloop
+  endfacet
+  facet normal -0.32144 -0.94693 -0
+    outer loop
+      vertex -48.5165 0.0722847 48.1308
+      vertex -48.7637 0.156198 -58.1308
+      vertex -48.5165 0.0722847 -58.1308
+    endloop
+  endfacet
+  facet normal -0.636887 -0.726415 -0.258256
+    outer loop
+      vertex -49.1941 0.443782 -58.3902
+      vertex -49.3392 0.660839 -58.6429
+      vertex -49.1529 0.4975 -58.6429
+    endloop
+  endfacet
+  facet normal -0.659288 -0.75189 0
+    outer loop
+      vertex -49.4112 0.588815 -58.1308
+      vertex -49.2149 0.416691 48.1308
+      vertex -49.4112 0.588815 48.1308
+    endloop
+  endfacet
+  facet normal -0.659288 -0.75189 -0
+    outer loop
+      vertex -49.2149 0.416691 48.1308
+      vertex -49.4112 0.588815 -58.1308
+      vertex -49.2149 0.416691 -58.1308
+    endloop
+  endfacet
+  facet normal -0.609286 -0.694935 -0.381884
+    outer loop
+      vertex -49.1529 0.4975 -58.6429
+      vertex -49.3392 0.660839 -58.6429
+      vertex -49.092 0.576926 -58.8846
+    endloop
+  endfacet
+  facet normal -0.408726 -0.828882 -0.381965
+    outer loop
+      vertex -48.7247 0.250301 -58.6429
+      vertex -48.9469 0.359869 -58.6429
+      vertex -48.6864 0.342795 -58.8846
+    endloop
+  endfacet
+  facet normal -0.550913 -0.824329 0.130292
+    outer loop
+      vertex -48.9808 0.30123 48.3902
+      vertex -49.1941 0.443782 48.3902
+      vertex -48.9979 0.271658 48.1308
+    endloop
+  endfacet
+  facet normal -0.513425 -0.768472 0.381896
+    outer loop
+      vertex -49.092 0.576926 48.8846
+      vertex -49.1529 0.4975 48.6429
+      vertex -48.9469 0.359869 48.6429
+    endloop
+  endfacet
+  facet normal -0.16906 -0.84976 -0.499326
+    outer loop
+      vertex -48.2171 0.351288 -59.1111
+      vertex -48.4643 0.267375 -58.8846
+      vertex -48.4304 0.393724 -59.1111
+    endloop
+  endfacet
+  facet normal -0.13811 -0.694276 -0.706333
+    outer loop
+      vertex -48.1963 0.509185 -59.3187
+      vertex -48.3892 0.547558 -59.3187
+      vertex -48.3413 0.726242 -59.5037
+    endloop
+  endfacet
+  facet normal -0.195948 -0.577096 -0.792821
+    outer loop
+      vertex -48.3413 0.726242 -59.5037
+      vertex -48.5046 0.781689 -59.5037
+      vertex -48.4252 0.97344 -59.6629
+    endloop
+  endfacet
+  facet normal -0.0519244 -0.792351 -0.607851
+    outer loop
+      vertex -48 0.337061 -59.1111
+      vertex -48.2171 0.351288 -59.1111
+      vertex -48.1963 0.509185 -59.3187
+    endloop
+  endfacet
+  facet normal -0.441076 -0.660346 -0.607779
+    outer loop
+      vertex -48.7518 0.697776 -59.3187
+      vertex -49.0123 0.680702 -59.1111
+      vertex -48.9154 0.807052 -59.3187
+    endloop
+  endfacet
+  facet normal -0.44122 -0.660101 -0.60794
+    outer loop
+      vertex -48.8315 0.559853 -59.1111
+      vertex -49.0123 0.680702 -59.1111
+      vertex -48.7518 0.697776 -59.3187
+    endloop
+  endfacet
+  facet normal -0.875143 -0.296992 -0.381996
+    outer loop
+      vertex -49.6572 1.31356 -58.8846
+      vertex -49.7497 1.27525 -58.6429
+      vertex -49.7326 1.53574 -58.8846
+    endloop
+  endfacet
+  facet normal -0.0604523 -0.922187 -0.381991
+    outer loop
+      vertex -48 0.206255 -58.8846
+      vertex -48.2472 0.122342 -58.6429
+      vertex -48.2341 0.221601 -58.8846
+    endloop
+  endfacet
+  facet normal -0.318704 -0.93887 -0.130191
+    outer loop
+      vertex -48.5165 0.0722847 -58.1308
+      vertex -48.7637 0.156198 -58.1308
+      vertex -48.5077 0.105268 -58.3902
+    endloop
+  endfacet
+  facet normal -0.427298 -0.866388 -0.258435
+    outer loop
+      vertex -48.7507 0.187746 -58.3902
+      vertex -48.9808 0.30123 -58.3902
+      vertex -48.7247 0.250301 -58.6429
+    endloop
+  endfacet
+  facet normal -0.227592 -0.670295 -0.706333
+    outer loop
+      vertex -48.3413 0.726242 -59.5037
+      vertex -48.5754 0.610782 -59.3187
+      vertex -48.5046 0.781689 -59.5037
+    endloop
+  endfacet
+  facet normal 0.138078 -0.694268 -0.706348
+    outer loop
+      vertex 48.1963 0.509185 -59.3187
+      vertex 48.1721 0.692591 -59.5037
+      vertex 48.3413 0.726242 -59.5037
+    endloop
+  endfacet
+  facet normal 0.118861 -0.597742 -0.792828
+    outer loop
+      vertex 48.3413 0.726242 -59.5037
+      vertex 48.145 0.898366 -59.6629
+      vertex 48.2876 0.926722 -59.6629
+    endloop
+  endfacet
+  facet normal 0.16906 -0.84976 -0.499326
+    outer loop
+      vertex 48.4643 0.267375 -58.8846
+      vertex 48.2171 0.351288 -59.1111
+      vertex 48.4304 0.393724 -59.1111
+    endloop
+  endfacet
+  facet normal 0.154939 -0.778785 -0.607855
+    outer loop
+      vertex 48.2171 0.351288 -59.1111
+      vertex 48.1963 0.509185 -59.3187
+      vertex 48.4304 0.393724 -59.1111
+    endloop
+  endfacet
+  facet normal -0.40176 -0.458185 -0.792878
+    outer loop
+      vertex -48.6764 1.11847 -59.6629
+      vertex -48.9325 1.06754 -59.5037
+      vertex -48.7857 1.21431 -59.6629
+    endloop
+  endfacet
+  facet normal -0.171006 -0.194906 -0.965799
+    outer loop
+      vertex -48.3914 1.48997 -59.8939
+      vertex -48.4546 1.54542 -59.8939
+      vertex -48.2759 1.7241 -59.9616
+    endloop
+  endfacet
+  facet normal -0.0250917 -0.382839 -0.923474
+    outer loop
+      vertex -48 1.11542 -59.7937
+      vertex -48.1155 1.12299 -59.7937
+      vertex -48 1.35712 -59.8939
+    endloop
+  endfacet
+  facet normal -0.0327521 -0.499719 -0.865568
+    outer loop
+      vertex -48 0.88886 -59.6629
+      vertex -48.1155 1.12299 -59.7937
+      vertex -48 1.11542 -59.7937
+    endloop
+  endfacet
+  facet normal -0.258781 0 -0.965936
+    outer loop
+      vertex -48.6429 2 -59.8939
+      vertex -48.3902 3 -59.9616
+      vertex -48.3902 2 -59.9616
+    endloop
+  endfacet
+  facet normal -0.258781 0 -0.965936
+    outer loop
+      vertex -48.3902 3 -59.9616
+      vertex -48.6429 2 -59.8939
+      vertex -48.6429 3 -59.8939
+    endloop
+  endfacet
+  facet normal -0.258645 -0.0172667 -0.965818
+    outer loop
+      vertex -48.3868 1.94907 -59.9616
+      vertex -48.6374 1.91609 -59.8939
+      vertex -48.3902 2 -59.9616
+    endloop
+  endfacet
+  facet normal -0.130336 0 -0.99147
+    outer loop
+      vertex -48.3902 2 -59.9616
+      vertex -48.1308 3 -59.9957
+      vertex -48.1308 2 -59.9957
+    endloop
+  endfacet
+  facet normal -0.130336 0 -0.99147
+    outer loop
+      vertex -48.1308 3 -59.9957
+      vertex -48.3902 2 -59.9616
+      vertex -48.3902 3 -59.9616
+    endloop
+  endfacet
+  facet normal -0.11462 -0.232591 -0.965797
+    outer loop
+      vertex -48.1493 1.63952 -59.9616
+      vertex -48.246 1.40606 -59.8939
+      vertex -48.1951 1.66209 -59.9616
+    endloop
+  endfacet
+  facet normal -0.0169781 -0.258738 -0.965798
+    outer loop
+      vertex -48 1.60982 -59.9616
+      vertex -48.0839 1.36262 -59.8939
+      vertex -48.0509 1.61316 -59.9616
+    endloop
+  endfacet
+  facet normal -0.0833786 -0.24554 -0.965794
+    outer loop
+      vertex -48.1664 1.37903 -59.8939
+      vertex -48.246 1.40606 -59.8939
+      vertex -48.101 1.62311 -59.9616
+    endloop
+  endfacet
+  facet normal -0.254299 -0.0502908 -0.965817
+    outer loop
+      vertex -48.3769 1.89901 -59.9616
+      vertex -48.6374 1.91609 -59.8939
+      vertex -48.3868 1.94907 -59.9616
+    endloop
+  endfacet
+  facet normal -0.597056 -0.523522 -0.607823
+    outer loop
+      vertex -49.1759 0.824125 -59.1111
+      vertex -49.3193 0.987667 -59.1111
+      vertex -49.0633 0.936738 -59.3187
+    endloop
+  endfacet
+  facet normal -0.466716 -0.532262 -0.70631
+    outer loop
+      vertex -48.8028 0.953812 -59.5037
+      vertex -49.0633 0.936738 -59.3187
+      vertex -48.9325 1.06754 -59.5037
+    endloop
+  endfacet
+  facet normal -0.117135 -0.0578253 -0.991431
+    outer loop
+      vertex -48.3379 1.80491 -59.9616
+      vertex -48.3605 1.85069 -59.9616
+      vertex -48.1133 1.9346 -59.9957
+    endloop
+  endfacet
+  facet normal -0.232563 -0.114808 -0.965781
+    outer loop
+      vertex -48.3379 1.80491 -59.9616
+      vertex -48.5939 1.75398 -59.8939
+      vertex -48.3605 1.85069 -59.9616
+    endloop
+  endfacet
+  facet normal -0.670487 -0.227516 -0.706175
+    outer loop
+      vertex -49.3892 1.42457 -59.3187
+      vertex -49.4524 1.61082 -59.3187
+      vertex -49.2738 1.6587 -59.5037
+    endloop
+  endfacet
+  facet normal -0.597714 -0.118709 -0.792872
+    outer loop
+      vertex -49.2738 1.6587 -59.5037
+      vertex -49.3074 1.82788 -59.5037
+      vertex -49.1016 1.85497 -59.6629
+    endloop
+  endfacet
+  facet normal -0.363296 -0.123342 -0.923473
+    outer loop
+      vertex -48.8172 1.66149 -59.7937
+      vertex -48.8544 1.77106 -59.7937
+      vertex -48.5939 1.75398 -59.8939
+    endloop
+  endfacet
+  facet normal -0.634888 -0.313107 -0.706315
+    outer loop
+      vertex -49.3022 1.24816 -59.3187
+      vertex -49.3892 1.42457 -59.3187
+      vertex -49.142 1.34065 -59.5037
+    endloop
+  endfacet
+  facet normal -0.330173 -0.376543 -0.865564
+    outer loop
+      vertex -48.6764 1.11847 -59.6629
+      vertex -48.7857 1.21431 -59.6629
+      vertex -48.6255 1.37451 -59.7937
+    endloop
+  endfacet
+  facet normal -0.3633 -0.12364 -0.923432
+    outer loop
+      vertex -48.5939 1.75398 -59.8939
+      vertex -48.8544 1.77106 -59.7937
+      vertex -48.621 1.83361 -59.8939
+    endloop
+  endfacet
+  facet normal -0.947452 -0.188734 -0.25829
+    outer loop
+      vertex -49.8293 1.50983 -58.6429
+      vertex -49.8947 1.49231 -58.3902
+      vertex -49.8777 1.7528 -58.6429
+    endloop
+  endfacet
+  facet normal -0.778811 -0.154784 -0.607862
+    outer loop
+      vertex -49.6063 1.5696 -59.1111
+      vertex -49.6487 1.78294 -59.1111
+      vertex -49.4908 1.80373 -59.3187
+    endloop
+  endfacet
+  facet normal 0 0.382959 -0.923765
+    outer loop
+      vertex -48 3.64288 -59.8939
+      vertex 48 3.88458 -59.7937
+      vertex 48 3.64288 -59.8939
+    endloop
+  endfacet
+  facet normal 0 0.382959 -0.923765
+    outer loop
+      vertex 48 3.88458 -59.7937
+      vertex -48 3.64288 -59.8939
+      vertex -48 3.88458 -59.7937
+    endloop
+  endfacet
+  facet normal -0.0250917 0.382839 -0.923474
+    outer loop
+      vertex -48 3.64288 -59.8939
+      vertex -48.1155 3.87701 -59.7937
+      vertex -48 3.88458 -59.7937
+    endloop
+  endfacet
+  facet normal -0.636888 0.726412 -0.258261
+    outer loop
+      vertex -49.1529 4.5025 -58.6429
+      vertex -49.3392 4.33916 -58.6429
+      vertex -49.1941 4.55622 -58.3902
+    endloop
+  endfacet
+  facet normal 0.130331 0.00870067 -0.991432
+    outer loop
+      vertex 48.3902 3 -59.9616
+      vertex 48.1308 3 -59.9957
+      vertex 48.3868 3.05093 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0505091 0.254322 -0.9658
+    outer loop
+      vertex 48.101 3.37689 -59.9616
+      vertex 48.0509 3.38684 -59.9616
+      vertex 48.0839 3.63738 -59.8939
+    endloop
+  endfacet
+  facet normal 0.577082 0.195813 -0.792864
+    outer loop
+      vertex 49.0733 3.28758 -59.6629
+      vertex 49.0266 3.42521 -59.6629
+      vertex 49.2738 3.3413 -59.5037
+    endloop
+  endfacet
+  facet normal 0.597744 -0.118668 -0.792855
+    outer loop
+      vertex 49.2738 1.6587 -59.5037
+      vertex 49.0733 1.71242 -59.6629
+      vertex 49.1016 1.85497 -59.6629
+    endloop
+  endfacet
+  facet normal 0.382838 0.0251998 -0.923472
+    outer loop
+      vertex 48.8846 3 -59.7937
+      vertex 48.6429 3 -59.8939
+      vertex 48.877 3.11546 -59.7937
+    endloop
+  endfacet
+  facet normal 0.288396 -0.252955 -0.923494
+    outer loop
+      vertex 48.6255 1.37451 -59.7937
+      vertex 48.51 1.60864 -59.8939
+      vertex 48.7018 1.4615 -59.7937
+    endloop
+  endfacet
+  facet normal 0.330185 -0.376539 -0.865561
+    outer loop
+      vertex 48.6764 1.11847 -59.6629
+      vertex 48.5385 1.29822 -59.7937
+      vertex 48.6255 1.37451 -59.7937
+    endloop
+  endfacet
+  facet normal 0.252976 -0.28849 -0.923459
+    outer loop
+      vertex 48.5385 1.29822 -59.7937
+      vertex 48.3914 1.48997 -59.8939
+      vertex 48.6255 1.37451 -59.7937
+    endloop
+  endfacet
+  facet normal 0.474078 -0.160954 -0.865647
+    outer loop
+      vertex 49.0266 1.57479 -59.6629
+      vertex 48.8172 1.66149 -59.7937
+      vertex 48.8544 1.77106 -59.7937
+    endloop
+  endfacet
+  facet normal 0.849887 0.16891 -0.499161
+    outer loop
+      vertex 49.6487 3.21706 -59.1111
+      vertex 49.6063 3.4304 -59.1111
+      vertex 49.7326 3.46426 -58.8846
+    endloop
+  endfacet
+  facet normal 0.792355 0.0518356 -0.607854
+    outer loop
+      vertex 49.6629 3 -59.1111
+      vertex 49.4908 3.19627 -59.3187
+      vertex 49.6487 3.21706 -59.1111
+    endloop
+  endfacet
+  facet normal 0.449303 0.221231 -0.865554
+    outer loop
+      vertex 48.8172 3.33851 -59.7937
+      vertex 48.7661 3.44229 -59.7937
+      vertex 48.9623 3.55557 -59.6629
+    endloop
+  endfacet
+  facet normal 0.670487 0.227516 -0.706175
+    outer loop
+      vertex 49.4524 3.38918 -59.3187
+      vertex 49.2738 3.3413 -59.5037
+      vertex 49.3892 3.57543 -59.3187
+    endloop
+  endfacet
+  facet normal 0.215653 -0.144036 -0.965788
+    outer loop
+      vertex 48.51 1.60864 -59.8939
+      vertex 48.3379 1.80491 -59.9616
+      vertex 48.5567 1.67856 -59.8939
+    endloop
+  endfacet
+  facet normal 0.123311 -0.363304 -0.923474
+    outer loop
+      vertex 48.3385 1.18276 -59.7937
+      vertex 48.2289 1.14556 -59.7937
+      vertex 48.246 1.40606 -59.8939
+    endloop
+  endfacet
+  facet normal 0.278308 -0.416342 -0.865566
+    outer loop
+      vertex 48.5556 1.03772 -59.6629
+      vertex 48.5385 1.29822 -59.7937
+      vertex 48.6764 1.11847 -59.6629
+    endloop
+  endfacet
+  facet normal 0.0169617 -0.258743 -0.965797
+    outer loop
+      vertex 48.0839 1.36262 -59.8939
+      vertex 48 1.35712 -59.8939
+      vertex 48 1.60982 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0860326 -0.0983012 -0.991431
+    outer loop
+      vertex 48.2759 1.7241 -59.9616
+      vertex 48.0796 1.89622 -59.9957
+      vertex 48.0925 1.90751 -59.9957
+    endloop
+  endfacet
+  facet normal 0.778811 0.154784 -0.607862
+    outer loop
+      vertex 49.6487 3.21706 -59.1111
+      vertex 49.4908 3.19627 -59.3187
+      vertex 49.6063 3.4304 -59.1111
+    endloop
+  endfacet
+  facet normal 0.778651 0.154996 -0.608012
+    outer loop
+      vertex 49.4908 3.19627 -59.3187
+      vertex 49.4524 3.38918 -59.3187
+      vertex 49.6063 3.4304 -59.1111
+    endloop
+  endfacet
+  facet normal -0.964026 -0.0631765 -0.25819
+    outer loop
+      vertex -49.8777 1.7528 -58.6429
+      vertex -49.9448 1.74396 -58.3902
+      vertex -49.8939 2 -58.6429
+    endloop
+  endfacet
+  facet normal -0.914848 -0.310258 -0.258442
+    outer loop
+      vertex -49.8123 1.24934 -58.3902
+      vertex -49.8947 1.49231 -58.3902
+      vertex -49.7497 1.27525 -58.6429
+    endloop
+  endfacet
+  facet normal -0.965936 0 -0.258781
+    outer loop
+      vertex -49.8939 2 -58.6429
+      vertex -49.9616 3 -58.3902
+      vertex -49.8939 3 -58.6429
+    endloop
+  endfacet
+  facet normal -0.965936 -0 -0.258781
+    outer loop
+      vertex -49.9616 3 -58.3902
+      vertex -49.8939 2 -58.6429
+      vertex -49.9616 2 -58.3902
+    endloop
+  endfacet
+  facet normal -0.964002 -0.0632527 -0.258262
+    outer loop
+      vertex -49.9448 1.74396 -58.3902
+      vertex -49.9616 2 -58.3902
+      vertex -49.8939 2 -58.6429
+    endloop
+  endfacet
+  facet normal -0.875143 0.296992 0.381996
+    outer loop
+      vertex -49.6572 3.68644 48.8846
+      vertex -49.7497 3.72475 48.6429
+      vertex -49.7326 3.46426 48.8846
+    endloop
+  endfacet
+  facet normal -0.58865 0.3932 0.706318
+    outer loop
+      vertex -49.0462 3.80277 49.5037
+      vertex -49.3022 3.75184 49.3187
+      vertex -49.142 3.65935 49.5037
+    endloop
+  endfacet
+  facet normal -0.824445 0.550744 0.130272
+    outer loop
+      vertex -49.5833 4.21492 48.1308
+      vertex -49.7283 3.99786 48.1308
+      vertex -49.5562 4.19413 48.3902
+    endloop
+  endfacet
+  facet normal -0.745478 0.653675 0.130271
+    outer loop
+      vertex -49.4112 4.41119 48.1308
+      vertex -49.5833 4.21492 48.1308
+      vertex -49.5562 4.19413 48.3902
+    endloop
+  endfacet
+  facet normal -0.694913 0.609284 0.381928
+    outer loop
+      vertex -49.3392 4.33916 48.6429
+      vertex -49.5025 4.15291 48.6429
+      vertex -49.4231 4.09196 48.8846
+    endloop
+  endfacet
+  facet normal -0.653742 0.7454 0.130385
+    outer loop
+      vertex -49.1941 4.55622 48.3902
+      vertex -49.4112 4.41119 48.1308
+      vertex -49.387 4.38704 48.3902
+    endloop
+  endfacet
+  facet normal -0.694837 0.609327 -0.381997
+    outer loop
+      vertex -49.2684 4.26837 -58.8846
+      vertex -49.4231 4.09196 -58.8846
+      vertex -49.3392 4.33916 -58.6429
+    endloop
+  endfacet
+  facet normal -0.824332 0.550972 -0.130025
+    outer loop
+      vertex -49.6988 3.98078 -58.3902
+      vertex -49.7283 3.99786 -58.1308
+      vertex -49.5562 4.19413 -58.3902
+    endloop
+  endfacet
+  facet normal -0.946945 0.321394 0
+    outer loop
+      vertex -49.9277 3.51653 -58.1308
+      vertex -49.8438 3.76373 48.1308
+      vertex -49.8438 3.76373 -58.1308
+    endloop
+  endfacet
+  facet normal -0.946945 0.321394 0
+    outer loop
+      vertex -49.8438 3.76373 48.1308
+      vertex -49.9277 3.51653 -58.1308
+      vertex -49.9277 3.51653 48.1308
+    endloop
+  endfacet
+  facet normal -0.896812 0.442412 0
+    outer loop
+      vertex -49.8438 3.76373 -58.1308
+      vertex -49.7283 3.99786 48.1308
+      vertex -49.7283 3.99786 -58.1308
+    endloop
+  endfacet
+  facet normal -0.896812 0.442412 0
+    outer loop
+      vertex -49.7283 3.99786 48.1308
+      vertex -49.8438 3.76373 -58.1308
+      vertex -49.8438 3.76373 48.1308
+    endloop
+  endfacet
+  facet normal -0.278641 0.820446 -0.499226
+    outer loop
+      vertex -48.6364 4.53636 -59.1111
+      vertex -48.6864 4.6572 -58.8846
+      vertex -48.4643 4.73263 -58.8846
+    endloop
+  endfacet
+  facet normal -0.278247 0.416353 -0.86558
+    outer loop
+      vertex -48.5385 3.70178 -59.7937
+      vertex -48.5556 3.96228 -59.6629
+      vertex -48.4423 3.76607 -59.7937
+    endloop
+  endfacet
+  facet normal -0.577082 0.195813 -0.792864
+    outer loop
+      vertex -49.0733 3.28758 -59.6629
+      vertex -49.2738 3.3413 -59.5037
+      vertex -49.0266 3.42521 -59.6629
+    endloop
+  endfacet
+  facet normal -0.792355 -0.0518356 -0.607854
+    outer loop
+      vertex -49.6487 1.78294 -59.1111
+      vertex -49.6629 2 -59.1111
+      vertex -49.4908 1.80373 -59.3187
+    endloop
+  endfacet
+  facet normal -0.499757 0.0327359 -0.865547
+    outer loop
+      vertex -48.877 3.11546 -59.7937
+      vertex -49.1111 3 -59.6629
+      vertex -49.1016 3.14503 -59.6629
+    endloop
+  endfacet
+  facet normal -0.123311 0.363304 -0.923474
+    outer loop
+      vertex -48.246 3.59394 -59.8939
+      vertex -48.3385 3.81724 -59.7937
+      vertex -48.2289 3.85444 -59.7937
+    endloop
+  endfacet
+  facet normal -0.376381 0.0748381 -0.923437
+    outer loop
+      vertex -48.6374 3.08391 -59.8939
+      vertex -48.8544 3.22894 -59.7937
+      vertex -48.621 3.16639 -59.8939
+    endloop
+  endfacet
+  facet normal -0.128159 0.025345 -0.99143
+    outer loop
+      vertex -48.1297 3.01707 -59.9957
+      vertex -48.3868 3.05093 -59.9616
+      vertex -48.3769 3.10099 -59.9616
+    endloop
+  endfacet
+  facet normal -0.254299 0.0502908 -0.965817
+    outer loop
+      vertex -48.3868 3.05093 -59.9616
+      vertex -48.6374 3.08391 -59.8939
+      vertex -48.3769 3.10099 -59.9616
+    endloop
+  endfacet
+  facet normal -0.651436 -0.571205 -0.499356
+    outer loop
+      vertex -49.1759 0.824125 -59.1111
+      vertex -49.4231 0.908037 -58.8846
+      vertex -49.3193 0.987667 -59.1111
+    endloop
+  endfacet
+  facet normal -0.694829 -0.609333 -0.382002
+    outer loop
+      vertex -49.3392 0.660839 -58.6429
+      vertex -49.4231 0.908037 -58.8846
+      vertex -49.2684 0.731631 -58.8846
+    endloop
+  endfacet
+  facet normal -0.972391 -0.19359 -0.130302
+    outer loop
+      vertex -49.9277 1.48347 -58.1308
+      vertex -49.9448 1.74396 -58.3902
+      vertex -49.8947 1.49231 -58.3902
+    endloop
+  endfacet
+  facet normal -0.889226 -0.438585 -0.130081
+    outer loop
+      vertex -49.6988 1.01922 -58.3902
+      vertex -49.8438 1.23627 -58.1308
+      vertex -49.8123 1.24934 -58.3902
+    endloop
+  endfacet
+  facet normal -0.318679 0.938883 0.130164
+    outer loop
+      vertex -48.5077 4.89473 48.3902
+      vertex -48.7637 4.8438 48.1308
+      vertex -48.7507 4.81225 48.3902
+    endloop
+  endfacet
+  facet normal -0.481448 0.72028 0.499404
+    outer loop
+      vertex -48.8315 4.44015 49.1111
+      vertex -49.092 4.42307 48.8846
+      vertex -49.0123 4.3193 49.1111
+    endloop
+  endfacet
+  facet normal -0.0648686 0.989359 0.13023
+    outer loop
+      vertex -48 4.99572 48.1308
+      vertex -48.2605 4.97864 48.1308
+      vertex -48.256 4.94479 48.3902
+    endloop
+  endfacet
+  facet normal -0.193423 0.972431 0.130251
+    outer loop
+      vertex -48.2605 4.97864 48.1308
+      vertex -48.5165 4.92772 48.1308
+      vertex -48.256 4.94479 48.3902
+    endloop
+  endfacet
+  facet normal -0.0566898 0.864566 0.499311
+    outer loop
+      vertex -48 4.79375 48.8846
+      vertex -48.2341 4.7784 48.8846
+      vertex -48 4.66294 49.1111
+    endloop
+  endfacet
+  facet normal -0.169036 0.849763 0.499329
+    outer loop
+      vertex -48.2171 4.64871 49.1111
+      vertex -48.4643 4.73263 48.8846
+      vertex -48.4304 4.60628 49.1111
+    endloop
+  endfacet
+  facet normal -0.0169781 0.258738 0.965798
+    outer loop
+      vertex -48 3.39018 49.9616
+      vertex -48.0839 3.63738 49.8939
+      vertex -48.0509 3.38684 49.9616
+    endloop
+  endfacet
+  facet normal -0.0169617 0.258743 0.965797
+    outer loop
+      vertex -48 3.64288 49.8939
+      vertex -48.0839 3.63738 49.8939
+      vertex -48 3.39018 49.9616
+    endloop
+  endfacet
+  facet normal 0.0462969 0.706356 0.706341
+    outer loop
+      vertex 48.1963 4.49082 49.3187
+      vertex 48 4.31869 49.5037
+      vertex 48.1721 4.30741 49.5037
+    endloop
+  endfacet
+  facet normal -0.0398585 0.608125 0.79284
+    outer loop
+      vertex -48 4.31869 49.5037
+      vertex -48.1721 4.30741 49.5037
+      vertex -48.145 4.10163 49.6629
+    endloop
+  endfacet
+  facet normal -0.0976467 0.491161 0.865578
+    outer loop
+      vertex -48.145 4.10163 49.6629
+      vertex -48.2876 4.07328 49.6629
+      vertex -48.2289 3.85444 49.7937
+    endloop
+  endfacet
+  facet normal -0.0462969 0.706356 0.706341
+    outer loop
+      vertex -48 4.31869 49.5037
+      vertex -48.1963 4.49082 49.3187
+      vertex -48.1721 4.30741 49.5037
+    endloop
+  endfacet
+  facet normal -0.160998 0.474173 0.865586
+    outer loop
+      vertex -48.2876 4.07328 49.6629
+      vertex -48.4252 4.02656 49.6629
+      vertex -48.2289 3.85444 49.7937
+    endloop
+  endfacet
+  facet normal -0.338431 0.506781 0.792866
+    outer loop
+      vertex -48.6593 4.14202 49.5037
+      vertex -48.8028 4.04619 49.5037
+      vertex -48.6764 3.88153 49.6629
+    endloop
+  endfacet
+  facet normal -0.393126 0.588684 0.706331
+    outer loop
+      vertex -48.7518 4.30222 49.3187
+      vertex -48.8028 4.04619 49.5037
+      vertex -48.6593 4.14202 49.5037
+    endloop
+  endfacet
+  facet normal -0.313086 0.634873 0.706338
+    outer loop
+      vertex -48.5754 4.38922 49.3187
+      vertex -48.6593 4.14202 49.5037
+      vertex -48.5046 4.21831 49.5037
+    endloop
+  endfacet
+  facet normal -0.0604679 0.922184 0.381995
+    outer loop
+      vertex -48 4.79375 48.8846
+      vertex -48.2472 4.87766 48.6429
+      vertex -48.2341 4.7784 48.8846
+    endloop
+  endfacet
+  facet normal -0.351199 0.712086 0.607941
+    outer loop
+      vertex -48.5754 4.38922 49.3187
+      vertex -48.8315 4.44015 49.1111
+      vertex -48.7518 4.30222 49.3187
+    endloop
+  endfacet
+  facet normal -0.255203 0.751885 0.607898
+    outer loop
+      vertex -48.4304 4.60628 49.1111
+      vertex -48.6364 4.53636 49.1111
+      vertex -48.5754 4.38922 49.3187
+    endloop
+  endfacet
+  facet normal -0.866341 0.42736 0.25849
+    outer loop
+      vertex -49.6988 3.98078 48.3902
+      vertex -49.7497 3.72475 48.6429
+      vertex -49.6401 3.94693 48.6429
+    endloop
+  endfacet
+  facet normal -0.914848 0.310258 0.258442
+    outer loop
+      vertex -49.8123 3.75066 48.3902
+      vertex -49.8947 3.50769 48.3902
+      vertex -49.7497 3.72475 48.6429
+    endloop
+  endfacet
+  facet normal -0.532437 0.46662 0.706241
+    outer loop
+      vertex -49.0633 4.06326 49.3187
+      vertex -49.1929 3.91538 49.3187
+      vertex -49.0462 3.80277 49.5037
+    endloop
+  endfacet
+  facet normal -0.776999 0.383541 0.499168
+    outer loop
+      vertex -49.4401 3.83147 49.1111
+      vertex -49.6572 3.68644 48.8846
+      vertex -49.5364 3.63638 49.1111
+    endloop
+  endfacet
+  facet normal -0.751829 -0.255136 0.607995
+    outer loop
+      vertex -49.3892 1.42457 49.3187
+      vertex -49.6063 1.5696 49.1111
+      vertex -49.5364 1.36362 49.1111
+    endloop
+  endfacet
+  facet normal -0.660338 -0.441046 0.607809
+    outer loop
+      vertex -49.3022 1.24816 49.3187
+      vertex -49.4401 1.16853 49.1111
+      vertex -49.3193 0.987667 49.1111
+    endloop
+  endfacet
+  facet normal -0.376531 -0.33026 0.865536
+    outer loop
+      vertex -48.7018 1.4615 49.7937
+      vertex -48.8815 1.32358 49.6629
+      vertex -48.6255 1.37451 49.7937
+    endloop
+  endfacet
+  facet normal -0.474141 -0.160884 0.865625
+    outer loop
+      vertex -48.8544 1.77106 49.7937
+      vertex -49.0733 1.71242 49.6629
+      vertex -49.0266 1.57479 49.6629
+    endloop
+  endfacet
+  facet normal -0.597714 -0.118709 0.792872
+    outer loop
+      vertex -49.1016 1.85497 49.6629
+      vertex -49.3074 1.82788 49.5037
+      vertex -49.2738 1.6587 49.5037
+    endloop
+  endfacet
+  facet normal -0.706374 -0.0463748 0.706318
+    outer loop
+      vertex -49.3187 2 49.5037
+      vertex -49.4908 1.80373 49.3187
+      vertex -49.3074 1.82788 49.5037
+    endloop
+  endfacet
+  facet normal -0.466716 -0.532262 0.70631
+    outer loop
+      vertex -48.9325 1.06754 49.5037
+      vertex -49.0633 0.936738 49.3187
+      vertex -48.8028 0.953812 49.5037
+    endloop
+  endfacet
+  facet normal -0.491187 -0.0978218 0.865544
+    outer loop
+      vertex -48.877 1.88454 49.7937
+      vertex -49.1016 1.85497 49.6629
+      vertex -48.8544 1.77106 49.7937
+    endloop
+  endfacet
+  facet normal -0.608045 0.0398292 0.792903
+    outer loop
+      vertex -49.1016 3.14503 49.6629
+      vertex -49.3187 3 49.5037
+      vertex -49.1111 3 49.6629
+    endloop
+  endfacet
+  facet normal -0.499757 0.0327359 0.865547
+    outer loop
+      vertex -49.1016 3.14503 49.6629
+      vertex -49.1111 3 49.6629
+      vertex -48.877 3.11546 49.7937
+    endloop
+  endfacet
+  facet normal -0.474141 0.160884 0.865625
+    outer loop
+      vertex -49.0266 3.42521 49.6629
+      vertex -49.0733 3.28758 49.6629
+      vertex -48.8544 3.22894 49.7937
+    endloop
+  endfacet
+  facet normal -0.416373 0.278275 0.865561
+    outer loop
+      vertex -48.7018 3.5385 49.7937
+      vertex -48.9623 3.55557 49.6629
+      vertex -48.7661 3.44229 49.7937
+    endloop
+  endfacet
+  facet normal -0.330173 0.376543 0.865564
+    outer loop
+      vertex -48.6764 3.88153 49.6629
+      vertex -48.7857 3.78569 49.6629
+      vertex -48.6255 3.62549 49.7937
+    endloop
+  endfacet
+  facet normal -0.376531 0.33026 0.865536
+    outer loop
+      vertex -48.6255 3.62549 49.7937
+      vertex -48.8815 3.67642 49.6629
+      vertex -48.7018 3.5385 49.7937
+    endloop
+  endfacet
+  facet normal -0.376381 0.0748381 0.923437
+    outer loop
+      vertex -48.621 3.16639 49.8939
+      vertex -48.8544 3.22894 49.7937
+      vertex -48.6374 3.08391 49.8939
+    endloop
+  endfacet
+  facet normal -0.130336 0 0.99147
+    outer loop
+      vertex -48.3902 3 49.9616
+      vertex -48.1308 2 49.9957
+      vertex -48.1308 3 49.9957
+    endloop
+  endfacet
+  facet normal -0.130336 0 0.99147
+    outer loop
+      vertex -48.1308 2 49.9957
+      vertex -48.3902 3 49.9616
+      vertex -48.3902 2 49.9616
+    endloop
+  endfacet
+  facet normal -0.803137 -0.53681 0.258469
+    outer loop
+      vertex -49.6401 1.05307 48.6429
+      vertex -49.6988 1.01922 48.3902
+      vertex -49.5562 0.805872 48.3902
+    endloop
+  endfacet
+  facet normal -0.875143 -0.296992 0.381996
+    outer loop
+      vertex -49.7326 1.53574 48.8846
+      vertex -49.7497 1.27525 48.6429
+      vertex -49.6572 1.31356 48.8846
+    endloop
+  endfacet
+  facet normal -0.694829 -0.609333 0.382002
+    outer loop
+      vertex -49.2684 0.731631 48.8846
+      vertex -49.4231 0.908037 48.8846
+      vertex -49.3392 0.660839 48.6429
+    endloop
+  endfacet
+  facet normal -0.597056 -0.523522 0.607823
+    outer loop
+      vertex -49.0633 0.936738 49.3187
+      vertex -49.3193 0.987667 49.1111
+      vertex -49.1759 0.824125 49.1111
+    endloop
+  endfacet
+  facet normal -0.637025 -0.726344 0.258115
+    outer loop
+      vertex -49.3392 0.660839 48.6429
+      vertex -49.387 0.612961 48.3902
+      vertex -49.1941 0.443782 48.3902
+    endloop
+  endfacet
+  facet normal -0.481346 -0.720422 0.499298
+    outer loop
+      vertex -48.8315 0.559853 49.1111
+      vertex -49.092 0.576926 48.8846
+      vertex -48.8969 0.446571 48.8846
+    endloop
+  endfacet
+  facet normal -0.577116 -0.196094 0.79277
+    outer loop
+      vertex -49.0266 1.57479 49.6629
+      vertex -49.2738 1.6587 49.5037
+      vertex -49.2183 1.49536 49.5037
+    endloop
+  endfacet
+  facet normal -0.401761 -0.458184 0.792878
+    outer loop
+      vertex -48.6764 1.11847 49.6629
+      vertex -48.9325 1.06754 49.5037
+      vertex -48.8028 0.953812 49.5037
+    endloop
+  endfacet
+  facet normal -0.254299 -0.0502908 0.965817
+    outer loop
+      vertex -48.3868 1.94907 49.9616
+      vertex -48.6374 1.91609 49.8939
+      vertex -48.3769 1.89901 49.9616
+    endloop
+  endfacet
+  facet normal -0.491118 -0.0975 0.86562
+    outer loop
+      vertex -48.8544 1.77106 49.7937
+      vertex -49.1016 1.85497 49.6629
+      vertex -49.0733 1.71242 49.6629
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48 3.13081 49.9957
+      vertex 48.1308 3 49.9957
+      vertex 48.1297 3.01707 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.1308 3 49.9957
+      vertex 48 3.13081 49.9957
+      vertex 48.1308 2 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48 3.13081 49.9957
+      vertex 48.1297 3.01707 49.9957
+      vertex 48.1264 3.03385 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48 1.86919 49.9957
+      vertex 48.1308 2 49.9957
+      vertex 48 3.13081 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48 3.13081 49.9957
+      vertex 48.1264 3.03385 49.9957
+      vertex 48.1208 3.05006 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.1308 2 49.9957
+      vertex 48 1.86919 49.9957
+      vertex 48.1297 1.98293 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48 3.13081 49.9957
+      vertex 48.1208 3.05006 49.9957
+      vertex 48.1133 3.0654 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.1297 1.98293 49.9957
+      vertex 48 1.86919 49.9957
+      vertex 48.1264 1.96615 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48 3.13081 49.9957
+      vertex 48.1133 3.0654 49.9957
+      vertex 48.1038 3.07963 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.1264 1.96615 49.9957
+      vertex 48 1.86919 49.9957
+      vertex 48.1208 1.94994 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48 3.13081 49.9957
+      vertex 48.1038 3.07963 49.9957
+      vertex 48.0925 3.09249 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.1208 1.94994 49.9957
+      vertex 48 1.86919 49.9957
+      vertex 48.1133 1.9346 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48 3.13081 49.9957
+      vertex 48.0925 3.09249 49.9957
+      vertex 48.0796 3.10378 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.1133 1.9346 49.9957
+      vertex 48 1.86919 49.9957
+      vertex 48.1038 1.92037 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48 3.13081 49.9957
+      vertex 48.0796 3.10378 49.9957
+      vertex 48.0654 3.11328 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.1038 1.92037 49.9957
+      vertex 48 1.86919 49.9957
+      vertex 48.0925 1.90751 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48 3.13081 49.9957
+      vertex 48.0654 3.11328 49.9957
+      vertex 48.0501 3.12085 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.0925 1.90751 49.9957
+      vertex 48 1.86919 49.9957
+      vertex 48.0796 1.89622 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48 3.13081 49.9957
+      vertex 48.0501 3.12085 49.9957
+      vertex 48.0339 3.12635 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.0796 1.89622 49.9957
+      vertex 48 1.86919 49.9957
+      vertex 48.0654 1.88672 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48 3.13081 49.9957
+      vertex 48.0339 3.12635 49.9957
+      vertex 48.0171 3.12969 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.0654 1.88672 49.9957
+      vertex 48 1.86919 49.9957
+      vertex 48.0501 1.87915 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.0501 1.87915 49.9957
+      vertex 48 1.86919 49.9957
+      vertex 48.0339 1.87365 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.0339 1.87365 49.9957
+      vertex 48 1.86919 49.9957
+      vertex 48.0171 1.87031 49.9957
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -48 3.13081 49.9957
+      vertex 48 1.86919 49.9957
+      vertex 48 3.13081 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48 3.13081 49.9957
+      vertex -48 1.86919 49.9957
+      vertex 48 1.86919 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1308 3 49.9957
+      vertex -48 3.13081 49.9957
+      vertex -48.0171 3.12969 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48 3.13081 49.9957
+      vertex -48.1308 3 49.9957
+      vertex -48 1.86919 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1308 3 49.9957
+      vertex -48.0171 3.12969 49.9957
+      vertex -48.0339 3.12635 49.9957
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -48.1308 2 49.9957
+      vertex -48 1.86919 49.9957
+      vertex -48.1308 3 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1308 3 49.9957
+      vertex -48.0339 3.12635 49.9957
+      vertex -48.0501 3.12085 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48 1.86919 49.9957
+      vertex -48.1308 2 49.9957
+      vertex -48.0171 1.87031 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1308 3 49.9957
+      vertex -48.0501 3.12085 49.9957
+      vertex -48.0654 3.11328 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.0171 1.87031 49.9957
+      vertex -48.1308 2 49.9957
+      vertex -48.0339 1.87365 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1308 3 49.9957
+      vertex -48.0654 3.11328 49.9957
+      vertex -48.0796 3.10378 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.0339 1.87365 49.9957
+      vertex -48.1308 2 49.9957
+      vertex -48.0501 1.87915 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1308 3 49.9957
+      vertex -48.0796 3.10378 49.9957
+      vertex -48.0925 3.09249 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.0501 1.87915 49.9957
+      vertex -48.1308 2 49.9957
+      vertex -48.0654 1.88672 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1308 3 49.9957
+      vertex -48.0925 3.09249 49.9957
+      vertex -48.1038 3.07963 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.0654 1.88672 49.9957
+      vertex -48.1308 2 49.9957
+      vertex -48.0796 1.89622 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1308 3 49.9957
+      vertex -48.1038 3.07963 49.9957
+      vertex -48.1133 3.0654 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.0796 1.89622 49.9957
+      vertex -48.1308 2 49.9957
+      vertex -48.0925 1.90751 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1308 3 49.9957
+      vertex -48.1133 3.0654 49.9957
+      vertex -48.1208 3.05006 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.0925 1.90751 49.9957
+      vertex -48.1308 2 49.9957
+      vertex -48.1038 1.92037 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1308 3 49.9957
+      vertex -48.1208 3.05006 49.9957
+      vertex -48.1264 3.03385 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1038 1.92037 49.9957
+      vertex -48.1308 2 49.9957
+      vertex -48.1133 1.9346 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1308 3 49.9957
+      vertex -48.1264 3.03385 49.9957
+      vertex -48.1297 3.01707 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1133 1.9346 49.9957
+      vertex -48.1308 2 49.9957
+      vertex -48.1208 1.94994 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1208 1.94994 49.9957
+      vertex -48.1308 2 49.9957
+      vertex -48.1264 1.96615 49.9957
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1264 1.96615 49.9957
+      vertex -48.1308 2 49.9957
+      vertex -48.1297 1.98293 49.9957
+    endloop
+  endfacet
+  facet normal -0.382838 -0.0251998 0.923472
+    outer loop
+      vertex -48.6429 2 49.8939
+      vertex -48.8846 2 49.7937
+      vertex -48.877 1.88454 49.7937
+    endloop
+  endfacet
+  facet normal -0.13039 0.00840238 0.991427
+    outer loop
+      vertex -48.1297 3.01707 49.9957
+      vertex -48.3868 3.05093 49.9616
+      vertex -48.1308 3 49.9957
+    endloop
+  endfacet
+  facet normal -0.215801 0.143902 0.965775
+    outer loop
+      vertex -48.3096 3.23753 49.9616
+      vertex -48.51 3.39136 49.8939
+      vertex -48.3379 3.19509 49.9616
+    endloop
+  endfacet
+  facet normal 0.193406 0.972437 0.130234
+    outer loop
+      vertex 48.5165 4.92772 48.1308
+      vertex 48.256 4.94479 48.3902
+      vertex 48.5077 4.89473 48.3902
+    endloop
+  endfacet
+  facet normal 0.193423 0.972431 0.130251
+    outer loop
+      vertex 48.2605 4.97864 48.1308
+      vertex 48.256 4.94479 48.3902
+      vertex 48.5165 4.92772 48.1308
+    endloop
+  endfacet
+  facet normal 0.154921 0.778801 0.607839
+    outer loop
+      vertex 48.2171 4.64871 49.1111
+      vertex 48.1963 4.49082 49.3187
+      vertex 48.4304 4.60628 49.1111
+    endloop
+  endfacet
+  facet normal 0.0519361 0.792363 0.607835
+    outer loop
+      vertex 48.2171 4.64871 49.1111
+      vertex 48 4.66294 49.1111
+      vertex 48.1963 4.49082 49.3187
+    endloop
+  endfacet
+  facet normal 0.278641 0.820446 0.499226
+    outer loop
+      vertex 48.6864 4.6572 48.8846
+      vertex 48.4643 4.73263 48.8846
+      vertex 48.6364 4.53636 49.1111
+    endloop
+  endfacet
+  facet normal 0.195943 0.577093 0.792824
+    outer loop
+      vertex 48.3413 4.27376 49.5037
+      vertex 48.2876 4.07328 49.6629
+      vertex 48.4252 4.02656 49.6629
+    endloop
+  endfacet
+  facet normal 0.297195 0.875076 0.381991
+    outer loop
+      vertex 48.7247 4.7497 48.6429
+      vertex 48.4643 4.73263 48.8846
+      vertex 48.6864 4.6572 48.8846
+    endloop
+  endfacet
+  facet normal 0.195958 0.577094 0.79282
+    outer loop
+      vertex 48.5046 4.21831 49.5037
+      vertex 48.3413 4.27376 49.5037
+      vertex 48.4252 4.02656 49.6629
+    endloop
+  endfacet
+  facet normal 0.160998 0.474173 0.865586
+    outer loop
+      vertex 48.2876 4.07328 49.6629
+      vertex 48.2289 3.85444 49.7937
+      vertex 48.4252 4.02656 49.6629
+    endloop
+  endfacet
+  facet normal 0.506732 0.338481 0.792876
+    outer loop
+      vertex 49.0462 3.80277 49.5037
+      vertex 48.8815 3.67642 49.6629
+      vertex 49.142 3.65935 49.5037
+    endloop
+  endfacet
+  facet normal 0.0420229 -0.123687 0.991431
+    outer loop
+      vertex 48.1493 1.63952 49.9616
+      vertex 48.0501 1.87915 49.9957
+      vertex 48.101 1.62311 49.9616
+    endloop
+  endfacet
+  facet normal 0.117135 -0.0578253 0.991431
+    outer loop
+      vertex 48.3605 1.85069 49.9616
+      vertex 48.1133 1.9346 49.9957
+      vertex 48.3379 1.80491 49.9616
+    endloop
+  endfacet
+  facet normal 0.057739 -0.117166 0.991432
+    outer loop
+      vertex 48.1951 1.66209 49.9616
+      vertex 48.0654 1.88672 49.9957
+      vertex 48.1493 1.63952 49.9616
+    endloop
+  endfacet
+  facet normal 0.0726313 -0.108565 0.991432
+    outer loop
+      vertex 48.0796 1.89622 49.9957
+      vertex 48.0654 1.88672 49.9957
+      vertex 48.2375 1.69045 49.9616
+    endloop
+  endfacet
+  facet normal 0.169714 -0.344082 0.923474
+    outer loop
+      vertex 48.3214 1.44325 49.8939
+      vertex 48.246 1.40606 49.8939
+      vertex 48.3385 1.18276 49.7937
+    endloop
+  endfacet
+  facet normal 0.00855315 -0.130346 0.991432
+    outer loop
+      vertex 48 1.86919 49.9957
+      vertex 48 1.60982 49.9616
+      vertex 48.0509 1.61316 49.9616
+    endloop
+  endfacet
+  facet normal 0.0505091 -0.254322 0.9658
+    outer loop
+      vertex 48.101 1.62311 49.9616
+      vertex 48.0509 1.61316 49.9616
+      vertex 48.0839 1.36262 49.8939
+    endloop
+  endfacet
+  facet normal -0.0981411 -0.0861964 0.991433
+    outer loop
+      vertex -48.1038 1.92037 49.9957
+      vertex -48.3096 1.76247 49.9616
+      vertex -48.2759 1.7241 49.9616
+    endloop
+  endfacet
+  facet normal -0.108679 -0.0724696 0.991432
+    outer loop
+      vertex -48.1133 1.9346 49.9957
+      vertex -48.3379 1.80491 49.9616
+      vertex -48.3096 1.76247 49.9616
+    endloop
+  endfacet
+  facet normal -0.195935 -0.577095 0.792825
+    outer loop
+      vertex -48.2876 0.926722 49.6629
+      vertex -48.4252 0.97344 49.6629
+      vertex -48.3413 0.726242 49.5037
+    endloop
+  endfacet
+  facet normal -0.160993 -0.474178 0.865584
+    outer loop
+      vertex -48.2289 1.14556 49.7937
+      vertex -48.4252 0.97344 49.6629
+      vertex -48.2876 0.926722 49.6629
+    endloop
+  endfacet
+  facet normal -0.0327611 -0.499722 0.865566
+    outer loop
+      vertex -48.1155 1.12299 49.7937
+      vertex -48.145 0.898366 49.6629
+      vertex -48 0.88886 49.6629
+    endloop
+  endfacet
+  facet normal -0.057739 -0.117166 0.991432
+    outer loop
+      vertex -48.0654 1.88672 49.9957
+      vertex -48.1951 1.66209 49.9616
+      vertex -48.1493 1.63952 49.9616
+    endloop
+  endfacet
+  facet normal -0.118861 -0.597742 0.792828
+    outer loop
+      vertex -48.2876 0.926722 49.6629
+      vertex -48.3413 0.726242 49.5037
+      vertex -48.145 0.898366 49.6629
+    endloop
+  endfacet
+  facet normal -0.0398661 -0.608133 0.792833
+    outer loop
+      vertex -48.145 0.898366 49.6629
+      vertex -48.1721 0.692591 49.5037
+      vertex -48 0.681309 49.5037
+    endloop
+  endfacet
+  facet normal 0.330185 -0.376539 0.865561
+    outer loop
+      vertex 48.6255 1.37451 49.7937
+      vertex 48.5385 1.29822 49.7937
+      vertex 48.6764 1.11847 49.6629
+    endloop
+  endfacet
+  facet normal 0.330173 -0.376543 0.865564
+    outer loop
+      vertex 48.7857 1.21431 49.6629
+      vertex 48.6255 1.37451 49.7937
+      vertex 48.6764 1.11847 49.6629
+    endloop
+  endfacet
+  facet normal 0.0976671 -0.49116 0.865577
+    outer loop
+      vertex 48.2289 1.14556 49.7937
+      vertex 48.145 0.898366 49.6629
+      vertex 48.2876 0.926722 49.6629
+    endloop
+  endfacet
+  facet normal 0.160993 -0.474178 0.865584
+    outer loop
+      vertex 48.4252 0.97344 49.6629
+      vertex 48.2289 1.14556 49.7937
+      vertex 48.2876 0.926722 49.6629
+    endloop
+  endfacet
+  facet normal -0.215801 -0.143902 0.965775
+    outer loop
+      vertex -48.3379 1.80491 49.9616
+      vertex -48.51 1.60864 49.8939
+      vertex -48.3096 1.76247 49.9616
+    endloop
+  endfacet
+  facet normal -0.170862 -0.194981 0.96581
+    outer loop
+      vertex -48.2759 1.7241 49.9616
+      vertex -48.3914 1.48997 49.8939
+      vertex -48.2375 1.69045 49.9616
+    endloop
+  endfacet
+  facet normal -0.252976 0.28849 0.923459
+    outer loop
+      vertex -48.5385 3.70178 49.7937
+      vertex -48.6255 3.62549 49.7937
+      vertex -48.3914 3.51003 49.8939
+    endloop
+  endfacet
+  facet normal -0.143959 0.215692 0.965791
+    outer loop
+      vertex -48.3214 3.55675 49.8939
+      vertex -48.3914 3.51003 49.8939
+      vertex -48.1951 3.33791 49.9616
+    endloop
+  endfacet
+  facet normal -0.00853748 0.130349 0.991431
+    outer loop
+      vertex -48 3.13081 49.9957
+      vertex -48.0509 3.38684 49.9616
+      vertex -48.0171 3.12969 49.9957
+    endloop
+  endfacet
+  facet normal 0.00853748 0.130349 0.991431
+    outer loop
+      vertex 48.0509 3.38684 49.9616
+      vertex 48 3.13081 49.9957
+      vertex 48.0171 3.12969 49.9957
+    endloop
+  endfacet
+  facet normal 0.0254711 0.128118 0.991432
+    outer loop
+      vertex 48.101 3.37689 49.9616
+      vertex 48.0171 3.12969 49.9957
+      vertex 48.0339 3.12635 49.9957
+    endloop
+  endfacet
+  facet normal 0.114712 0.232571 0.965791
+    outer loop
+      vertex 48.246 3.59394 49.8939
+      vertex 48.1951 3.33791 49.9616
+      vertex 48.3214 3.55675 49.8939
+    endloop
+  endfacet
+  facet normal 0.0579371 0.117099 0.991429
+    outer loop
+      vertex 48.1493 3.36048 49.9616
+      vertex 48.0501 3.12085 49.9957
+      vertex 48.0654 3.11328 49.9957
+    endloop
+  endfacet
+  facet normal 0.0327521 0.499719 0.865568
+    outer loop
+      vertex 48 4.11114 49.6629
+      vertex 48 3.88458 49.7937
+      vertex 48.1155 3.87701 49.7937
+    endloop
+  endfacet
+  facet normal 0.0250917 0.382839 0.923474
+    outer loop
+      vertex 48 3.88458 49.7937
+      vertex 48 3.64288 49.8939
+      vertex 48.1155 3.87701 49.7937
+    endloop
+  endfacet
+  facet normal 0.221416 0.449171 0.865575
+    outer loop
+      vertex 48.4252 4.02656 49.6629
+      vertex 48.3385 3.81724 49.7937
+      vertex 48.5556 3.96228 49.6629
+    endloop
+  endfacet
+  facet normal 0.123311 0.363304 0.923474
+    outer loop
+      vertex 48.3385 3.81724 49.7937
+      vertex 48.2289 3.85444 49.7937
+      vertex 48.246 3.59394 49.8939
+    endloop
+  endfacet
+  facet normal 0.130336 0 0.99147
+    outer loop
+      vertex 48.1308 3 49.9957
+      vertex 48.3902 2 49.9616
+      vertex 48.3902 3 49.9616
+    endloop
+  endfacet
+  facet normal 0.130336 0 0.99147
+    outer loop
+      vertex 48.3902 2 49.9616
+      vertex 48.1308 3 49.9957
+      vertex 48.1308 2 49.9957
+    endloop
+  endfacet
+  facet normal 0.117135 0.0578253 0.991431
+    outer loop
+      vertex 48.3379 3.19509 49.9616
+      vertex 48.1133 3.0654 49.9957
+      vertex 48.3605 3.14931 49.9616
+    endloop
+  endfacet
+  facet normal 0.108679 0.0724696 0.991432
+    outer loop
+      vertex 48.3096 3.23753 49.9616
+      vertex 48.1133 3.0654 49.9957
+      vertex 48.3379 3.19509 49.9616
+    endloop
+  endfacet
+  facet normal -0.188449 0.947514 -0.258271
+    outer loop
+      vertex -48.2472 4.87766 -58.6429
+      vertex -48.5077 4.89473 -58.3902
+      vertex -48.256 4.94479 -58.3902
+    endloop
+  endfacet
+  facet normal -0.0631748 0.964 -0.258288
+    outer loop
+      vertex -48.2472 4.87766 -58.6429
+      vertex -48.256 4.94479 -58.3902
+      vertex -48 4.89386 -58.6429
+    endloop
+  endfacet
+  facet normal -0.138136 0.694278 -0.706326
+    outer loop
+      vertex -48.3413 4.27376 -59.5037
+      vertex -48.3892 4.45244 -59.3187
+      vertex -48.1963 4.49082 -59.3187
+    endloop
+  endfacet
+  facet normal -0.154949 0.77878 -0.607859
+    outer loop
+      vertex -48.3892 4.45244 -59.3187
+      vertex -48.4304 4.60628 -59.1111
+      vertex -48.1963 4.49082 -59.3187
+    endloop
+  endfacet
+  facet normal 0.0604679 0.922184 -0.381995
+    outer loop
+      vertex 48.2341 4.7784 -58.8846
+      vertex 48 4.79375 -58.8846
+      vertex 48.2472 4.87766 -58.6429
+    endloop
+  endfacet
+  facet normal 0.0462756 0.706368 -0.70633
+    outer loop
+      vertex 48.1963 4.49082 -59.3187
+      vertex 48 4.31869 -59.5037
+      vertex 48 4.50368 -59.3187
+    endloop
+  endfacet
+  facet normal 0.466723 0.532257 -0.706309
+    outer loop
+      vertex 49.0633 4.06326 -59.3187
+      vertex 48.8028 4.04619 -59.5037
+      vertex 48.9154 4.19295 -59.3187
+    endloop
+  endfacet
+  facet normal 0.532304 0.466674 -0.706305
+    outer loop
+      vertex 49.0462 3.80277 -59.5037
+      vertex 48.9325 3.93246 -59.5037
+      vertex 49.0633 4.06326 -59.3187
+    endloop
+  endfacet
+  facet normal 0.194878 0.17116 -0.965778
+    outer loop
+      vertex 48.3096 3.23753 -59.9616
+      vertex 48.2759 3.2759 -59.9616
+      vertex 48.51 3.39136 -59.8939
+    endloop
+  endfacet
+  facet normal 0.221416 0.449171 -0.865575
+    outer loop
+      vertex 48.5556 3.96228 -59.6629
+      vertex 48.3385 3.81724 -59.7937
+      vertex 48.4252 4.02656 -59.6629
+    endloop
+  endfacet
+  facet normal 0.458211 0.401726 -0.792881
+    outer loop
+      vertex 48.8815 3.67642 -59.6629
+      vertex 48.7857 3.78569 -59.6629
+      vertex 48.9325 3.93246 -59.5037
+    endloop
+  endfacet
+  facet normal 0.255203 0.751885 -0.607898
+    outer loop
+      vertex 48.5754 4.38922 -59.3187
+      vertex 48.4304 4.60628 -59.1111
+      vertex 48.6364 4.53636 -59.1111
+    endloop
+  endfacet
+  facet normal 0.227586 0.670302 -0.706329
+    outer loop
+      vertex 48.5754 4.38922 -59.3187
+      vertex 48.3413 4.27376 -59.5037
+      vertex 48.3892 4.45244 -59.3187
+    endloop
+  endfacet
+  facet normal 0 0.60862 -0.793462
+    outer loop
+      vertex -48 4.11114 -59.6629
+      vertex 48 4.31869 -59.5037
+      vertex 48 4.11114 -59.6629
+    endloop
+  endfacet
+  facet normal 0 0.60862 -0.793462
+    outer loop
+      vertex 48 4.31869 -59.5037
+      vertex -48 4.11114 -59.6629
+      vertex -48 4.31869 -59.5037
+    endloop
+  endfacet
+  facet normal -0.0398853 0.608136 -0.79283
+    outer loop
+      vertex -48 4.11114 -59.6629
+      vertex -48.145 4.10163 -59.6629
+      vertex -48 4.31869 -59.5037
+    endloop
+  endfacet
+  facet normal 0.297162 0.875102 -0.381957
+    outer loop
+      vertex 48.7247 4.7497 -58.6429
+      vertex 48.4643 4.73263 -58.8846
+      vertex 48.4902 4.82933 -58.6429
+    endloop
+  endfacet
+  facet normal 0.310633 0.914773 -0.25826
+    outer loop
+      vertex 48.7247 4.7497 -58.6429
+      vertex 48.4902 4.82933 -58.6429
+      vertex 48.5077 4.89473 -58.3902
+    endloop
+  endfacet
+  facet normal 0.351199 0.712086 -0.607941
+    outer loop
+      vertex 48.7518 4.30222 -59.3187
+      vertex 48.5754 4.38922 -59.3187
+      vertex 48.8315 4.44015 -59.1111
+    endloop
+  endfacet
+  facet normal 0.35117 0.712123 -0.607915
+    outer loop
+      vertex 48.8315 4.44015 -59.1111
+      vertex 48.5754 4.38922 -59.3187
+      vertex 48.6364 4.53636 -59.1111
+    endloop
+  endfacet
+  facet normal 0.875143 -0.296992 0.381996
+    outer loop
+      vertex 49.7326 1.53574 48.8846
+      vertex 49.6572 1.31356 48.8846
+      vertex 49.7497 1.27525 48.6429
+    endloop
+  endfacet
+  facet normal 0.40176 -0.458185 0.792878
+    outer loop
+      vertex 48.7857 1.21431 49.6629
+      vertex 48.6764 1.11847 49.6629
+      vertex 48.9325 1.06754 49.5037
+    endloop
+  endfacet
+  facet normal 0.338438 -0.506781 0.792864
+    outer loop
+      vertex 48.6764 1.11847 49.6629
+      vertex 48.6593 0.85798 49.5037
+      vertex 48.8028 0.953812 49.5037
+    endloop
+  endfacet
+  facet normal 0.481346 -0.720422 0.499298
+    outer loop
+      vertex 49.092 0.576926 48.8846
+      vertex 48.8315 0.559853 49.1111
+      vertex 48.8969 0.446571 48.8846
+    endloop
+  endfacet
+  facet normal 0.768522 -0.513285 0.381985
+    outer loop
+      vertex 49.5534 1.10313 48.8846
+      vertex 49.4231 0.908037 48.8846
+      vertex 49.6401 1.05307 48.6429
+    endloop
+  endfacet
+  facet normal 0.866378 -0.427316 0.258437
+    outer loop
+      vertex 49.7497 1.27525 48.6429
+      vertex 49.6988 1.01922 48.3902
+      vertex 49.8123 1.24934 48.3902
+    endloop
+  endfacet
+  facet normal 0.653741 -0.745403 0.130374
+    outer loop
+      vertex 49.387 0.612961 48.3902
+      vertex 49.1941 0.443782 48.3902
+      vertex 49.4112 0.588815 48.1308
+    endloop
+  endfacet
+  facet normal 0.745479 -0.653676 0.130264
+    outer loop
+      vertex 49.5562 0.805872 48.3902
+      vertex 49.4112 0.588815 48.1308
+      vertex 49.5833 0.785085 48.1308
+    endloop
+  endfacet
+  facet normal 0.57111 -0.651455 0.499439
+    outer loop
+      vertex 49.1759 0.824125 49.1111
+      vertex 49.0123 0.680702 49.1111
+      vertex 49.092 0.576926 48.8846
+    endloop
+  endfacet
+  facet normal 0.523551 -0.597082 0.607772
+    outer loop
+      vertex 49.0633 0.936738 49.3187
+      vertex 48.9154 0.807052 49.3187
+      vertex 49.0123 0.680702 49.1111
+    endloop
+  endfacet
+  facet normal -0.193452 -0.972423 -0.130268
+    outer loop
+      vertex -48.2605 0.0213566 -58.1308
+      vertex -48.5165 0.0722847 -58.1308
+      vertex -48.256 0.0552111 -58.3902
+    endloop
+  endfacet
+  facet normal -0.0604423 -0.922191 -0.381982
+    outer loop
+      vertex -48 0.10614 -58.6429
+      vertex -48.2472 0.122342 -58.6429
+      vertex -48 0.206255 -58.8846
+    endloop
+  endfacet
+  facet normal -0.180235 -0.906414 0.382006
+    outer loop
+      vertex -48.2341 0.221601 48.8846
+      vertex -48.4643 0.267375 48.8846
+      vertex -48.2472 0.122342 48.6429
+    endloop
+  endfacet
+  facet normal -0.0463055 -0.706363 0.706334
+    outer loop
+      vertex -48.1721 0.692591 49.5037
+      vertex -48.1963 0.509185 49.3187
+      vertex -48 0.681309 49.5037
+    endloop
+  endfacet
+  facet normal -0.849887 0.16891 0.499161
+    outer loop
+      vertex -49.6063 3.4304 49.1111
+      vertex -49.7326 3.46426 48.8846
+      vertex -49.6487 3.21706 49.1111
+    endloop
+  endfacet
+  facet normal -0.792455 0.0520848 0.607702
+    outer loop
+      vertex -49.4908 3.19627 49.3187
+      vertex -49.6629 3 49.1111
+      vertex -49.5037 3 49.3187
+    endloop
+  endfacet
+  facet normal -0.864592 0.0564996 0.499288
+    outer loop
+      vertex -49.7784 3.23413 48.8846
+      vertex -49.7937 3 48.8846
+      vertex -49.6629 3 49.1111
+    endloop
+  endfacet
+  facet normal -0.864562 0.0565594 0.499334
+    outer loop
+      vertex -49.6487 3.21706 49.1111
+      vertex -49.7784 3.23413 48.8846
+      vertex -49.6629 3 49.1111
+    endloop
+  endfacet
+  facet normal -0.694328 0.137897 0.706324
+    outer loop
+      vertex -49.2738 3.3413 49.5037
+      vertex -49.4908 3.19627 49.3187
+      vertex -49.3074 3.17212 49.5037
+    endloop
+  endfacet
+  facet normal -0.694418 0.138228 0.70617
+    outer loop
+      vertex -49.4524 3.38918 49.3187
+      vertex -49.4908 3.19627 49.3187
+      vertex -49.2738 3.3413 49.5037
+    endloop
+  endfacet
+  facet normal -0.922148 -0.0602608 0.382114
+    outer loop
+      vertex -49.7937 2 48.8846
+      vertex -49.8777 1.7528 48.6429
+      vertex -49.7784 1.76587 48.8846
+    endloop
+  endfacet
+  facet normal -0.90634 -0.180378 0.382115
+    outer loop
+      vertex -49.7784 1.76587 48.8846
+      vertex -49.8777 1.7528 48.6429
+      vertex -49.7326 1.53574 48.8846
+    endloop
+  endfacet
+  facet normal -0.98938 -0.0649484 0.130031
+    outer loop
+      vertex -49.9448 1.74396 48.3902
+      vertex -49.9957 2 48.1308
+      vertex -49.9786 1.73951 48.1308
+    endloop
+  endfacet
+  facet normal -0.97248 -0.193326 0.130031
+    outer loop
+      vertex -49.9448 1.74396 48.3902
+      vertex -49.9786 1.73951 48.1308
+      vertex -49.9277 1.48347 48.1308
+    endloop
+  endfacet
+  facet normal -0.792455 -0.0520848 0.607702
+    outer loop
+      vertex -49.5037 2 49.3187
+      vertex -49.6629 2 49.1111
+      vertex -49.4908 1.80373 49.3187
+    endloop
+  endfacet
+  facet normal 0.118878 -0.597729 0.792835
+    outer loop
+      vertex 48.3413 0.726242 49.5037
+      vertex 48.145 0.898366 49.6629
+      vertex 48.1721 0.692591 49.5037
+    endloop
+  endfacet
+  facet normal 0.0398661 -0.608133 0.792833
+    outer loop
+      vertex 48.145 0.898366 49.6629
+      vertex 48 0.681309 49.5037
+      vertex 48.1721 0.692591 49.5037
+    endloop
+  endfacet
+  facet normal 0.896812 0.442412 0
+    outer loop
+      vertex 49.8438 3.76373 48.1308
+      vertex 49.7283 3.99786 -58.1308
+      vertex 49.7283 3.99786 48.1308
+    endloop
+  endfacet
+  facet normal 0.896812 0.442412 0
+    outer loop
+      vertex 49.7283 3.99786 -58.1308
+      vertex 49.8438 3.76373 48.1308
+      vertex 49.8438 3.76373 -58.1308
+    endloop
+  endfacet
+  facet normal 0.914848 0.310258 0.258442
+    outer loop
+      vertex 49.8123 3.75066 48.3902
+      vertex 49.7497 3.72475 48.6429
+      vertex 49.8947 3.50769 48.3902
+    endloop
+  endfacet
+  facet normal 0.427287 0.866398 0.25842
+    outer loop
+      vertex 48.7507 4.81225 48.3902
+      vertex 48.7247 4.7497 48.6429
+      vertex 48.9808 4.69877 48.3902
+    endloop
+  endfacet
+  facet normal 0.43855 0.889235 0.130133
+    outer loop
+      vertex 48.7637 4.8438 48.1308
+      vertex 48.7507 4.81225 48.3902
+      vertex 48.9808 4.69877 48.3902
+    endloop
+  endfacet
+  facet normal 0.803322 0.53664 0.258246
+    outer loop
+      vertex 49.5562 4.19413 48.3902
+      vertex 49.5025 4.15291 48.6429
+      vertex 49.6401 3.94693 48.6429
+    endloop
+  endfacet
+  facet normal 0.777012 0.383281 0.499347
+    outer loop
+      vertex 49.5534 3.89687 48.8846
+      vertex 49.4401 3.83147 49.1111
+      vertex 49.6572 3.68644 48.8846
+    endloop
+  endfacet
+  facet normal 0.609347 0.694821 0.381995
+    outer loop
+      vertex 49.3392 4.33916 48.6429
+      vertex 49.092 4.42307 48.8846
+      vertex 49.2684 4.26837 48.8846
+    endloop
+  endfacet
+  facet normal 0.57127 0.651403 0.499325
+    outer loop
+      vertex 49.2684 4.26837 48.8846
+      vertex 49.092 4.42307 48.8846
+      vertex 49.1759 4.17587 49.1111
+    endloop
+  endfacet
+  facet normal 0.278308 0.416342 0.865566
+    outer loop
+      vertex 48.5556 3.96228 49.6629
+      vertex 48.5385 3.70178 49.7937
+      vertex 48.6764 3.88153 49.6629
+    endloop
+  endfacet
+  facet normal 0.252976 0.28849 0.923459
+    outer loop
+      vertex 48.5385 3.70178 49.7937
+      vertex 48.3914 3.51003 49.8939
+      vertex 48.6255 3.62549 49.7937
+    endloop
+  endfacet
+  facet normal 0.449303 0.221231 0.865554
+    outer loop
+      vertex 48.9623 3.55557 49.6629
+      vertex 48.7661 3.44229 49.7937
+      vertex 48.8172 3.33851 49.7937
+    endloop
+  endfacet
+  facet normal 0.416373 0.278275 0.865561
+    outer loop
+      vertex 48.9623 3.55557 49.6629
+      vertex 48.7018 3.5385 49.7937
+      vertex 48.7661 3.44229 49.7937
+    endloop
+  endfacet
+  facet normal 0.254299 0.0502908 0.965817
+    outer loop
+      vertex 48.6374 3.08391 49.8939
+      vertex 48.3769 3.10099 49.9616
+      vertex 48.3868 3.05093 49.9616
+    endloop
+  endfacet
+  facet normal 0.258645 0.0172667 0.965818
+    outer loop
+      vertex 48.6374 3.08391 49.8939
+      vertex 48.3868 3.05093 49.9616
+      vertex 48.3902 3 49.9616
+    endloop
+  endfacet
+  facet normal 0.232583 0.114719 0.965787
+    outer loop
+      vertex 48.5567 3.32144 49.8939
+      vertex 48.3379 3.19509 49.9616
+      vertex 48.5939 3.24602 49.8939
+    endloop
+  endfacet
+  facet normal 0.232563 0.114808 0.965781
+    outer loop
+      vertex 48.5939 3.24602 49.8939
+      vertex 48.3379 3.19509 49.9616
+      vertex 48.3605 3.14931 49.9616
+    endloop
+  endfacet
+  facet normal 0.608082 -0.0399217 0.79287
+    outer loop
+      vertex 49.3187 2 49.5037
+      vertex 49.1016 1.85497 49.6629
+      vertex 49.3074 1.82788 49.5037
+    endloop
+  endfacet
+  facet normal 0.608045 -0.0398292 0.792903
+    outer loop
+      vertex 49.1111 2 49.6629
+      vertex 49.1016 1.85497 49.6629
+      vertex 49.3187 2 49.5037
+    endloop
+  endfacet
+  facet normal 0.694328 0.137897 0.706324
+    outer loop
+      vertex 49.4908 3.19627 49.3187
+      vertex 49.2738 3.3413 49.5037
+      vertex 49.3074 3.17212 49.5037
+    endloop
+  endfacet
+  facet normal 0.597714 0.118709 0.792872
+    outer loop
+      vertex 49.2738 3.3413 49.5037
+      vertex 49.1016 3.14503 49.6629
+      vertex 49.3074 3.17212 49.5037
+    endloop
+  endfacet
+  facet normal 0.546657 0.269601 0.792768
+    outer loop
+      vertex 49.142 3.65935 49.5037
+      vertex 49.0266 3.42521 49.6629
+      vertex 49.2183 3.50464 49.5037
+    endloop
+  endfacet
+  facet normal 0.597118 0.523306 0.607949
+    outer loop
+      vertex 49.3193 4.01233 49.1111
+      vertex 49.0633 4.06326 49.3187
+      vertex 49.1929 3.91538 49.3187
+    endloop
+  endfacet
+  facet normal 0.449015 0.221476 0.865641
+    outer loop
+      vertex 48.9623 3.55557 49.6629
+      vertex 48.8172 3.33851 49.7937
+      vertex 49.0266 3.42521 49.6629
+    endloop
+  endfacet
+  facet normal 0.597744 0.118668 0.792855
+    outer loop
+      vertex 49.2738 3.3413 49.5037
+      vertex 49.0733 3.28758 49.6629
+      vertex 49.1016 3.14503 49.6629
+    endloop
+  endfacet
+  facet normal 0.792355 0.0518356 0.607854
+    outer loop
+      vertex 49.6487 3.21706 49.1111
+      vertex 49.4908 3.19627 49.3187
+      vertex 49.6629 3 49.1111
+    endloop
+  endfacet
+  facet normal 0.922148 0.0602608 0.382114
+    outer loop
+      vertex 49.8777 3.2472 48.6429
+      vertex 49.7784 3.23413 48.8846
+      vertex 49.7937 3 48.8846
+    endloop
+  endfacet
+  facet normal 0.947499 0.188634 0.25819
+    outer loop
+      vertex 49.8947 3.50769 48.3902
+      vertex 49.8777 3.2472 48.6429
+      vertex 49.9448 3.25604 48.3902
+    endloop
+  endfacet
+  facet normal 0.906365 0.180549 0.381976
+    outer loop
+      vertex 49.8293 3.49017 48.6429
+      vertex 49.7326 3.46426 48.8846
+      vertex 49.8777 3.2472 48.6429
+    endloop
+  endfacet
+  facet normal 0.947499 -0.188634 0.25819
+    outer loop
+      vertex 49.9448 1.74396 48.3902
+      vertex 49.8777 1.7528 48.6429
+      vertex 49.8947 1.49231 48.3902
+    endloop
+  endfacet
+  facet normal 0.964026 -0.0631765 0.25819
+    outer loop
+      vertex 49.8939 2 48.6429
+      vertex 49.8777 1.7528 48.6429
+      vertex 49.9448 1.74396 48.3902
+    endloop
+  endfacet
+  facet normal 0.792455 -0.0520848 0.607702
+    outer loop
+      vertex 49.5037 2 49.3187
+      vertex 49.4908 1.80373 49.3187
+      vertex 49.6629 2 49.1111
+    endloop
+  endfacet
+  facet normal 0.707107 -0 0.707107
+    outer loop
+      vertex 49.3187 2 49.5037
+      vertex 49.5037 3 49.3187
+      vertex 49.3187 3 49.5037
+    endloop
+  endfacet
+  facet normal 0.707107 0 0.707107
+    outer loop
+      vertex 49.5037 3 49.3187
+      vertex 49.3187 2 49.5037
+      vertex 49.5037 2 49.3187
+    endloop
+  endfacet
+  facet normal 0.82881 -0.408847 0.381993
+    outer loop
+      vertex 49.6572 1.31356 48.8846
+      vertex 49.6401 1.05307 48.6429
+      vertex 49.7497 1.27525 48.6429
+    endloop
+  endfacet
+  facet normal 0.820542 -0.278454 0.499174
+    outer loop
+      vertex 49.6063 1.5696 49.1111
+      vertex 49.5364 1.36362 49.1111
+      vertex 49.7326 1.53574 48.8846
+    endloop
+  endfacet
+  facet normal 0.792355 -0.0518356 0.607854
+    outer loop
+      vertex 49.6629 2 49.1111
+      vertex 49.4908 1.80373 49.3187
+      vertex 49.6487 1.78294 49.1111
+    endloop
+  endfacet
+  facet normal 0.778811 -0.154784 0.607862
+    outer loop
+      vertex 49.6487 1.78294 49.1111
+      vertex 49.4908 1.80373 49.3187
+      vertex 49.6063 1.5696 49.1111
+    endloop
+  endfacet
+  facet normal 0.466715 -0.532264 0.706309
+    outer loop
+      vertex 49.0633 0.936738 49.3187
+      vertex 48.8028 0.953812 49.5037
+      vertex 48.9154 0.807052 49.3187
+    endloop
+  endfacet
+  facet normal 0.751827 -0.255117 0.608006
+    outer loop
+      vertex 49.4524 1.61082 49.3187
+      vertex 49.3892 1.42457 49.3187
+      vertex 49.6063 1.5696 49.1111
+    endloop
+  endfacet
+  facet normal 0.232563 -0.114808 0.965781
+    outer loop
+      vertex 48.3605 1.85069 49.9616
+      vertex 48.3379 1.80491 49.9616
+      vertex 48.5939 1.75398 49.8939
+    endloop
+  endfacet
+  facet normal 0.215653 -0.144036 0.965788
+    outer loop
+      vertex 48.5567 1.67856 49.8939
+      vertex 48.3379 1.80491 49.9616
+      vertex 48.51 1.60864 49.8939
+    endloop
+  endfacet
+  facet normal 0.634888 -0.313115 0.706312
+    outer loop
+      vertex 49.2183 1.49536 49.5037
+      vertex 49.142 1.34065 49.5037
+      vertex 49.3892 1.42457 49.3187
+    endloop
+  endfacet
+  facet normal 0.694328 -0.137897 0.706324
+    outer loop
+      vertex 49.3074 1.82788 49.5037
+      vertex 49.2738 1.6587 49.5037
+      vertex 49.4908 1.80373 49.3187
+    endloop
+  endfacet
+  facet normal 0.128203 -0.0252128 0.991427
+    outer loop
+      vertex 48.1297 1.98293 49.9957
+      vertex 48.1264 1.96615 49.9957
+      vertex 48.3769 1.89901 49.9616
+    endloop
+  endfacet
+  facet normal 0.0981186 0.0862162 0.991433
+    outer loop
+      vertex 48.2759 3.2759 49.9616
+      vertex 48.0925 3.09249 49.9957
+      vertex 48.1038 3.07963 49.9957
+    endloop
+  endfacet
+  facet normal 0.0860326 0.0983012 0.991431
+    outer loop
+      vertex 48.2759 3.2759 49.9616
+      vertex 48.0796 3.10378 49.9957
+      vertex 48.0925 3.09249 49.9957
+    endloop
+  endfacet
+  facet normal 0.427298 -0.866388 -0.258435
+    outer loop
+      vertex 48.7507 0.187746 -58.3902
+      vertex 48.7247 0.250301 -58.6429
+      vertex 48.9808 0.30123 -58.3902
+    endloop
+  endfacet
+  facet normal 0.438563 -0.88923 -0.130126
+    outer loop
+      vertex 48.7637 0.156198 -58.1308
+      vertex 48.7507 0.187746 -58.3902
+      vertex 48.9808 0.30123 -58.3902
+    endloop
+  endfacet
+  facet normal 0.536685 -0.803287 -0.25826
+    outer loop
+      vertex 49.1941 0.443782 -58.3902
+      vertex 48.9469 0.359869 -58.6429
+      vertex 49.1529 0.4975 -58.6429
+    endloop
+  endfacet
+  facet normal 0.536781 -0.803183 -0.258388
+    outer loop
+      vertex 48.9808 0.30123 -58.3902
+      vertex 48.9469 0.359869 -58.6429
+      vertex 49.1941 0.443782 -58.3902
+    endloop
+  endfacet
+  facet normal 0.972391 -0.19359 -0.130302
+    outer loop
+      vertex 49.9277 1.48347 -58.1308
+      vertex 49.8947 1.49231 -58.3902
+      vertex 49.9448 1.74396 -58.3902
+    endloop
+  endfacet
+  facet normal 0.938872 -0.318655 -0.1303
+    outer loop
+      vertex 49.9277 1.48347 -58.1308
+      vertex 49.8438 1.23627 -58.1308
+      vertex 49.8947 1.49231 -58.3902
+    endloop
+  endfacet
+  facet normal 0.768497 -0.513381 -0.381906
+    outer loop
+      vertex 49.5025 0.847092 -58.6429
+      vertex 49.4231 0.908037 -58.8846
+      vertex 49.6401 1.05307 -58.6429
+    endloop
+  endfacet
+  facet normal 0.768522 -0.513285 -0.381985
+    outer loop
+      vertex 49.6401 1.05307 -58.6429
+      vertex 49.4231 0.908037 -58.8846
+      vertex 49.5534 1.10313 -58.8846
+    endloop
+  endfacet
+  facet normal 0.82881 -0.408847 -0.381993
+    outer loop
+      vertex 49.7497 1.27525 -58.6429
+      vertex 49.6401 1.05307 -58.6429
+      vertex 49.6572 1.31356 -58.8846
+    endloop
+  endfacet
+  facet normal 0.82882 -0.408837 -0.381982
+    outer loop
+      vertex 49.6401 1.05307 -58.6429
+      vertex 49.5534 1.10313 -58.8846
+      vertex 49.6572 1.31356 -58.8846
+    endloop
+  endfacet
+  facet normal 0.383121 -0.777125 -0.499295
+    outer loop
+      vertex 48.8969 0.446571 -58.8846
+      vertex 48.6864 0.342795 -58.8846
+      vertex 48.8315 0.559853 -59.1111
+    endloop
+  endfacet
+  facet normal 0.57111 -0.651455 -0.499439
+    outer loop
+      vertex 49.092 0.576926 -58.8846
+      vertex 49.0123 0.680702 -59.1111
+      vertex 49.1759 0.824125 -59.1111
+    endloop
+  endfacet
+  facet normal 0.44122 -0.660101 -0.60794
+    outer loop
+      vertex 48.8315 0.559853 -59.1111
+      vertex 48.7518 0.697776 -59.3187
+      vertex 49.0123 0.680702 -59.1111
+    endloop
+  endfacet
+  facet normal 0.351185 -0.712107 -0.607925
+    outer loop
+      vertex 48.8315 0.559853 -59.1111
+      vertex 48.5754 0.610782 -59.3187
+      vertex 48.7518 0.697776 -59.3187
+    endloop
+  endfacet
+  facet normal 0.651436 -0.571205 -0.499356
+    outer loop
+      vertex 49.4231 0.908037 -58.8846
+      vertex 49.1759 0.824125 -59.1111
+      vertex 49.3193 0.987667 -59.1111
+    endloop
+  endfacet
+  facet normal 0.651417 -0.571263 -0.499314
+    outer loop
+      vertex 49.2684 0.731631 -58.8846
+      vertex 49.1759 0.824125 -59.1111
+      vertex 49.4231 0.908037 -58.8846
+    endloop
+  endfacet
+  facet normal 0.660338 -0.441046 -0.607809
+    outer loop
+      vertex 49.3193 0.987667 -59.1111
+      vertex 49.3022 1.24816 -59.3187
+      vertex 49.4401 1.16853 -59.1111
+    endloop
+  endfacet
+  facet normal 0.720473 -0.48121 -0.499355
+    outer loop
+      vertex 49.4231 0.908037 -58.8846
+      vertex 49.3193 0.987667 -59.1111
+      vertex 49.4401 1.16853 -59.1111
+    endloop
+  endfacet
+  facet normal 0.778811 -0.154784 -0.607862
+    outer loop
+      vertex 49.6063 1.5696 -59.1111
+      vertex 49.4908 1.80373 -59.3187
+      vertex 49.6487 1.78294 -59.1111
+    endloop
+  endfacet
+  facet normal 0.707107 0 -0.707107
+    outer loop
+      vertex 49.5037 2 -59.3187
+      vertex 49.3187 3 -59.5037
+      vertex 49.5037 3 -59.3187
+    endloop
+  endfacet
+  facet normal 0.707107 0 -0.707107
+    outer loop
+      vertex 49.3187 3 -59.5037
+      vertex 49.5037 2 -59.3187
+      vertex 49.3187 2 -59.5037
+    endloop
+  endfacet
+  facet normal 0.58865 -0.3932 -0.706318
+    outer loop
+      vertex 49.3022 1.24816 -59.3187
+      vertex 49.0462 1.19723 -59.5037
+      vertex 49.142 1.34065 -59.5037
+    endloop
+  endfacet
+  facet normal 0.588625 -0.3934 -0.706227
+    outer loop
+      vertex 49.1929 1.08462 -59.3187
+      vertex 49.0462 1.19723 -59.5037
+      vertex 49.3022 1.24816 -59.3187
+    endloop
+  endfacet
+  facet normal 0.313092 -0.634876 -0.706333
+    outer loop
+      vertex 48.5754 0.610782 -59.3187
+      vertex 48.5046 0.781689 -59.5037
+      vertex 48.6593 0.85798 -59.5037
+    endloop
+  endfacet
+  facet normal 0.269563 -0.546609 -0.792814
+    outer loop
+      vertex 48.5046 0.781689 -59.5037
+      vertex 48.4252 0.97344 -59.6629
+      vertex 48.6593 0.85798 -59.5037
+    endloop
+  endfacet
+  facet normal 0.0748893 -0.376272 -0.923478
+    outer loop
+      vertex 48.1155 1.12299 -59.7937
+      vertex 48.0839 1.36262 -59.8939
+      vertex 48.2289 1.14556 -59.7937
+    endloop
+  endfacet
+  facet normal 0.0977595 -0.49118 -0.865555
+    outer loop
+      vertex 48.145 0.898366 -59.6629
+      vertex 48.1155 1.12299 -59.7937
+      vertex 48.2289 1.14556 -59.7937
+    endloop
+  endfacet
+  facet normal -0.438413 -0.889281 -0.13028
+    outer loop
+      vertex -48.7637 0.156198 -58.1308
+      vertex -48.9979 0.271658 -58.1308
+      vertex -48.9808 0.30123 -58.3902
+    endloop
+  endfacet
+  facet normal -0.442182 -0.896925 0
+    outer loop
+      vertex -48.9979 0.271658 -58.1308
+      vertex -48.7637 0.156198 48.1308
+      vertex -48.9979 0.271658 48.1308
+    endloop
+  endfacet
+  facet normal -0.442182 -0.896925 -0
+    outer loop
+      vertex -48.7637 0.156198 48.1308
+      vertex -48.9979 0.271658 -58.1308
+      vertex -48.7637 0.156198 -58.1308
+    endloop
+  endfacet
+  facet normal -0.82444 -0.550754 -0.130265
+    outer loop
+      vertex -49.5833 0.785085 -58.1308
+      vertex -49.7283 1.00214 -58.1308
+      vertex -49.5562 0.805872 -58.3902
+    endloop
+  endfacet
+  facet normal -0.745479 -0.653676 -0.130264
+    outer loop
+      vertex -49.4112 0.588815 -58.1308
+      vertex -49.5833 0.785085 -58.1308
+      vertex -49.5562 0.805872 -58.3902
+    endloop
+  endfacet
+  facet normal -0.555672 -0.831402 0
+    outer loop
+      vertex -49.2149 0.416691 -58.1308
+      vertex -48.9979 0.271658 48.1308
+      vertex -49.2149 0.416691 48.1308
+    endloop
+  endfacet
+  facet normal -0.555672 -0.831402 -0
+    outer loop
+      vertex -48.9979 0.271658 48.1308
+      vertex -49.2149 0.416691 -58.1308
+      vertex -48.9979 0.271658 -58.1308
+    endloop
+  endfacet
+  facet normal -0.768497 -0.513381 -0.381906
+    outer loop
+      vertex -49.5025 0.847092 -58.6429
+      vertex -49.6401 1.05307 -58.6429
+      vertex -49.4231 0.908037 -58.8846
+    endloop
+  endfacet
+  facet normal -0.694921 -0.609282 -0.381917
+    outer loop
+      vertex -49.3392 0.660839 -58.6429
+      vertex -49.5025 0.847092 -58.6429
+      vertex -49.4231 0.908037 -58.8846
+    endloop
+  endfacet
+  facet normal -0.653741 -0.745403 -0.130374
+    outer loop
+      vertex -49.1941 0.443782 -58.3902
+      vertex -49.4112 0.588815 -58.1308
+      vertex -49.387 0.612961 -58.3902
+    endloop
+  endfacet
+  facet normal -0.637025 -0.726344 -0.258115
+    outer loop
+      vertex -49.1941 0.443782 -58.3902
+      vertex -49.387 0.612961 -58.3902
+      vertex -49.3392 0.660839 -58.6429
+    endloop
+  endfacet
+  facet normal -0.438413 -0.889281 0.13028
+    outer loop
+      vertex -48.9808 0.30123 48.3902
+      vertex -48.9979 0.271658 48.1308
+      vertex -48.7637 0.156198 48.1308
+    endloop
+  endfacet
+  facet normal -0.536685 -0.803287 0.25826
+    outer loop
+      vertex -49.1529 0.4975 48.6429
+      vertex -49.1941 0.443782 48.3902
+      vertex -48.9469 0.359869 48.6429
+    endloop
+  endfacet
+  facet normal -0.0463055 -0.706363 -0.706334
+    outer loop
+      vertex -48 0.681309 -59.5037
+      vertex -48.1963 0.509185 -59.3187
+      vertex -48.1721 0.692591 -59.5037
+    endloop
+  endfacet
+  facet normal -0.0462902 -0.706372 -0.706326
+    outer loop
+      vertex -48 0.496321 -59.3187
+      vertex -48.1963 0.509185 -59.3187
+      vertex -48 0.681309 -59.5037
+    endloop
+  endfacet
+  facet normal -0.351185 -0.712107 -0.607925
+    outer loop
+      vertex -48.5754 0.610782 -59.3187
+      vertex -48.8315 0.559853 -59.1111
+      vertex -48.7518 0.697776 -59.3187
+    endloop
+  endfacet
+  facet normal -0.160993 -0.474178 -0.865584
+    outer loop
+      vertex -48.2876 0.926722 -59.6629
+      vertex -48.4252 0.97344 -59.6629
+      vertex -48.2289 1.14556 -59.7937
+    endloop
+  endfacet
+  facet normal -0.523465 -0.597106 -0.607823
+    outer loop
+      vertex -49.0123 0.680702 -59.1111
+      vertex -49.1759 0.824125 -59.1111
+      vertex -49.0633 0.936738 -59.3187
+    endloop
+  endfacet
+  facet normal -0.660113 -0.441179 -0.607957
+    outer loop
+      vertex -49.1929 1.08462 -59.3187
+      vertex -49.3193 0.987667 -59.1111
+      vertex -49.3022 1.24816 -59.3187
+    endloop
+  endfacet
+  facet normal -0.513425 -0.768472 -0.381896
+    outer loop
+      vertex -48.9469 0.359869 -58.6429
+      vertex -49.1529 0.4975 -58.6429
+      vertex -49.092 0.576926 -58.8846
+    endloop
+  endfacet
+  facet normal -0.318673 -0.938886 -0.130157
+    outer loop
+      vertex -48.5077 0.105268 -58.3902
+      vertex -48.7637 0.156198 -58.1308
+      vertex -48.7507 0.187746 -58.3902
+    endloop
+  endfacet
+  facet normal -0.0631903 -0.963996 -0.258298
+    outer loop
+      vertex -48 0.0384302 -58.3902
+      vertex -48.256 0.0552111 -58.3902
+      vertex -48 0.10614 -58.6429
+    endloop
+  endfacet
+  facet normal -0.0648529 -0.989359 -0.130239
+    outer loop
+      vertex -48 0.00428295 -58.1308
+      vertex -48.256 0.0552111 -58.3902
+      vertex -48 0.0384302 -58.3902
+    endloop
+  endfacet
+  facet normal -0.383215 -0.77712 -0.49923
+    outer loop
+      vertex -48.6864 0.342795 -58.8846
+      vertex -48.8315 0.559853 -59.1111
+      vertex -48.6364 0.463645 -59.1111
+    endloop
+  endfacet
+  facet normal -0.278603 -0.820443 -0.499253
+    outer loop
+      vertex -48.4643 0.267375 -58.8846
+      vertex -48.6864 0.342795 -58.8846
+      vertex -48.6364 0.463645 -59.1111
+    endloop
+  endfacet
+  facet normal -0.0631825 -0.963999 -0.258291
+    outer loop
+      vertex -48 0.10614 -58.6429
+      vertex -48.256 0.0552111 -58.3902
+      vertex -48.2472 0.122342 -58.6429
+    endloop
+  endfacet
+  facet normal -0.188437 -0.947516 -0.258274
+    outer loop
+      vertex -48.256 0.0552111 -58.3902
+      vertex -48.5077 0.105268 -58.3902
+      vertex -48.2472 0.122342 -58.6429
+    endloop
+  endfacet
+  facet normal 0.154924 -0.778797 -0.607844
+    outer loop
+      vertex 48.4304 0.393724 -59.1111
+      vertex 48.1963 0.509185 -59.3187
+      vertex 48.3892 0.547558 -59.3187
+    endloop
+  endfacet
+  facet normal 0.13811 -0.694276 -0.706333
+    outer loop
+      vertex 48.3892 0.547558 -59.3187
+      vertex 48.1963 0.509185 -59.3187
+      vertex 48.3413 0.726242 -59.5037
+    endloop
+  endfacet
+  facet normal 0.0463055 -0.706363 -0.706334
+    outer loop
+      vertex 48.1963 0.509185 -59.3187
+      vertex 48 0.681309 -59.5037
+      vertex 48.1721 0.692591 -59.5037
+    endloop
+  endfacet
+  facet normal 0.0398661 -0.608133 -0.792833
+    outer loop
+      vertex 48.1721 0.692591 -59.5037
+      vertex 48 0.681309 -59.5037
+      vertex 48.145 0.898366 -59.6629
+    endloop
+  endfacet
+  facet normal 0.168981 -0.849814 -0.499261
+    outer loop
+      vertex 48.2341 0.221601 -58.8846
+      vertex 48.2171 0.351288 -59.1111
+      vertex 48.4643 0.267375 -58.8846
+    endloop
+  endfacet
+  facet normal 0.0566578 -0.864583 -0.499286
+    outer loop
+      vertex 48.2341 0.221601 -58.8846
+      vertex 48 0.337061 -59.1111
+      vertex 48.2171 0.351288 -59.1111
+    endloop
+  endfacet
+  facet normal -0.0977595 -0.49118 -0.865555
+    outer loop
+      vertex -48.145 0.898366 -59.6629
+      vertex -48.2289 1.14556 -59.7937
+      vertex -48.1155 1.12299 -59.7937
+    endloop
+  endfacet
+  facet normal -0.0327611 -0.499722 -0.865566
+    outer loop
+      vertex -48 0.88886 -59.6629
+      vertex -48.145 0.898366 -59.6629
+      vertex -48.1155 1.12299 -59.7937
+    endloop
+  endfacet
+  facet normal -0.221416 -0.449171 -0.865575
+    outer loop
+      vertex -48.4252 0.97344 -59.6629
+      vertex -48.5556 1.03772 -59.6629
+      vertex -48.3385 1.18276 -59.7937
+    endloop
+  endfacet
+  facet normal -0.253029 -0.288394 -0.923474
+    outer loop
+      vertex -48.3914 1.48997 -59.8939
+      vertex -48.6255 1.37451 -59.7937
+      vertex -48.4546 1.54542 -59.8939
+    endloop
+  endfacet
+  facet normal -0.258743 0.0169597 -0.965797
+    outer loop
+      vertex -48.3902 3 -59.9616
+      vertex -48.6429 3 -59.8939
+      vertex -48.6374 3.08391 -59.8939
+    endloop
+  endfacet
+  facet normal -0.474078 -0.160954 -0.865647
+    outer loop
+      vertex -48.8172 1.66149 -59.7937
+      vertex -49.0266 1.57479 -59.6629
+      vertex -48.8544 1.77106 -59.7937
+    endloop
+  endfacet
+  facet normal -0.258743 -0.0169597 -0.965797
+    outer loop
+      vertex -48.6374 1.91609 -59.8939
+      vertex -48.6429 2 -59.8939
+      vertex -48.3902 2 -59.9616
+    endloop
+  endfacet
+  facet normal -0.0505877 -0.254326 -0.965795
+    outer loop
+      vertex -48.0839 1.36262 -59.8939
+      vertex -48.1664 1.37903 -59.8939
+      vertex -48.101 1.62311 -59.9616
+    endloop
+  endfacet
+  facet normal -0.0169617 -0.258743 -0.965797
+    outer loop
+      vertex -48 1.35712 -59.8939
+      vertex -48.0839 1.36262 -59.8939
+      vertex -48 1.60982 -59.9616
+    endloop
+  endfacet
+  facet normal -0.0254463 -0.128126 -0.991431
+    outer loop
+      vertex -48.0509 1.61316 -59.9616
+      vertex -48.101 1.62311 -59.9616
+      vertex -48.0171 1.87031 -59.9957
+    endloop
+  endfacet
+  facet normal -0.0505091 -0.254322 -0.9658
+    outer loop
+      vertex -48.0839 1.36262 -59.8939
+      vertex -48.101 1.62311 -59.9616
+      vertex -48.0509 1.61316 -59.9616
+    endloop
+  endfacet
+  facet normal -0.057739 -0.117166 -0.991432
+    outer loop
+      vertex -48.1493 1.63952 -59.9616
+      vertex -48.1951 1.66209 -59.9616
+      vertex -48.0654 1.88672 -59.9957
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -50 0 -60
-      vertex 50 5 -60
-      vertex 50 0 -60
+      vertex 48 1.86919 -59.9957
+      vertex 48.1308 2 -59.9957
+      vertex 48.1297 1.98293 -59.9957
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 50 5 -60
-      vertex -50 0 -60
-      vertex -50 5 -60
+      vertex 48.1308 2 -59.9957
+      vertex 48 1.86919 -59.9957
+      vertex 48.1308 3 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -7.5 0 -35
-      vertex 7.5 0 -7.5
-      vertex -7.5 0 -7.5
+      vertex 48 1.86919 -59.9957
+      vertex 48.1297 1.98293 -59.9957
+      vertex 48.1264 1.96615 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 0 -1
     outer loop
-      vertex 7.5 0 -7.5
-      vertex -7.5 0 -35
-      vertex 7.5 0 -35
+      vertex 48 3.13081 -59.9957
+      vertex 48.1308 3 -59.9957
+      vertex 48 1.86919 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -7.5 0 7.5
-      vertex 7.5 0 35
-      vertex -7.5 0 35
+      vertex 48 1.86919 -59.9957
+      vertex 48.1264 1.96615 -59.9957
+      vertex 48.1208 1.94994 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 0 -1
     outer loop
-      vertex 7.5 0 35
-      vertex -7.5 0 7.5
-      vertex 7.5 0 7.5
+      vertex 48.1308 3 -59.9957
+      vertex 48 3.13081 -59.9957
+      vertex 48.1297 3.01707 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -50 0 50
-      vertex 0 0 43.75
-      vertex 50 0 50
+      vertex 48 1.86919 -59.9957
+      vertex 48.1208 1.94994 -59.9957
+      vertex 48.1133 1.9346 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -50 0 50
-      vertex -0.274104 0 43.732
-      vertex 0 0 43.75
+      vertex 48.1297 3.01707 -59.9957
+      vertex 48 3.13081 -59.9957
+      vertex 48.1264 3.03385 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -50 0 50
-      vertex -0.54352 0 43.6784
-      vertex -0.274104 0 43.732
+      vertex 48 1.86919 -59.9957
+      vertex 48.1133 1.9346 -59.9957
+      vertex 48.1038 1.92037 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -50 0 50
-      vertex -0.803635 0 43.5901
-      vertex -0.54352 0 43.6784
+      vertex 48.1264 3.03385 -59.9957
+      vertex 48 3.13081 -59.9957
+      vertex 48.1208 3.05006 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -50 0 50
-      vertex -1.05 0 43.4687
-      vertex -0.803635 0 43.5901
+      vertex 48 1.86919 -59.9957
+      vertex 48.1038 1.92037 -59.9957
+      vertex 48.0925 1.90751 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -50 0 50
-      vertex -1.2784 0 43.316
-      vertex -1.05 0 43.4687
+      vertex 48.1208 3.05006 -59.9957
+      vertex 48 3.13081 -59.9957
+      vertex 48.1133 3.0654 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -50 0 50
-      vertex -1.48492 0 43.1349
-      vertex -1.2784 0 43.316
+      vertex 48 1.86919 -59.9957
+      vertex 48.0925 1.90751 -59.9957
+      vertex 48.0796 1.89622 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -50 0 50
-      vertex -1.66604 0 42.9284
-      vertex -1.48492 0 43.1349
+      vertex 48.1133 3.0654 -59.9957
+      vertex 48 3.13081 -59.9957
+      vertex 48.1038 3.07963 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -50 0 50
-      vertex -1.81865 0 42.7
-      vertex -1.66604 0 42.9284
+      vertex 48 1.86919 -59.9957
+      vertex 48.0796 1.89622 -59.9957
+      vertex 48.0654 1.88672 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -40 0 35
-      vertex -1.81865 0 42.7
-      vertex -50 0 50
+      vertex 48.1038 3.07963 -59.9957
+      vertex 48 3.13081 -59.9957
+      vertex 48.0925 3.09249 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -1.81865 0 42.7
-      vertex -40 0 35
-      vertex -1.94015 0 42.4536
+      vertex 48 1.86919 -59.9957
+      vertex 48.0654 1.88672 -59.9957
+      vertex 48.0501 1.87915 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -7.5 0 35
-      vertex -1.94015 0 42.4536
-      vertex -40 0 35
+      vertex 48.0925 3.09249 -59.9957
+      vertex 48 3.13081 -59.9957
+      vertex 48.0796 3.10378 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -1.94015 0 42.4536
-      vertex -7.5 0 35
-      vertex -2.02844 0 42.1935
+      vertex 48 1.86919 -59.9957
+      vertex 48.0501 1.87915 -59.9957
+      vertex 48.0339 1.87365 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -2.02844 0 42.1935
-      vertex -7.5 0 35
-      vertex -2.08203 0 41.9241
+      vertex 48.0796 3.10378 -59.9957
+      vertex 48 3.13081 -59.9957
+      vertex 48.0654 3.11328 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -2.08203 0 41.9241
-      vertex -7.5 0 35
-      vertex -2.1 0 41.65
+      vertex 48 1.86919 -59.9957
+      vertex 48.0339 1.87365 -59.9957
+      vertex 48.0171 1.87031 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 0 -1
     outer loop
-      vertex -2.1 0 41.65
-      vertex -7.5 0 35
-      vertex -2.08203 0 41.3759
+      vertex 48.0654 3.11328 -59.9957
+      vertex 48 3.13081 -59.9957
+      vertex 48.0501 3.12085 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 0 -1
     outer loop
-      vertex -2.08203 0 41.3759
-      vertex -7.5 0 35
-      vertex -2.02844 0 41.1065
+      vertex 48.0501 3.12085 -59.9957
+      vertex 48 3.13081 -59.9957
+      vertex 48.0339 3.12635 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 0 -1
     outer loop
-      vertex -1.94015 0 40.8464
-      vertex -7.5 0 35
-      vertex -1.81865 0 40.6
+      vertex 48.0339 3.12635 -59.9957
+      vertex 48 3.13081 -59.9957
+      vertex 48.0171 3.12969 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 0 -1
     outer loop
-      vertex -1.81865 0 40.6
-      vertex -7.5 0 35
-      vertex -1.66604 0 40.3716
+      vertex -48 1.86919 -59.9957
+      vertex 48 3.13081 -59.9957
+      vertex 48 1.86919 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 0 -1
     outer loop
-      vertex -1.66604 0 40.3716
-      vertex -7.5 0 35
-      vertex -1.48492 0 40.1651
+      vertex -48 1.86919 -59.9957
+      vertex -48 3.13081 -59.9957
+      vertex 48 3.13081 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 0 -1
     outer loop
-      vertex -1.48492 0 40.1651
-      vertex -7.5 0 35
-      vertex -1.2784 0 39.984
+      vertex -48.1308 2 -59.9957
+      vertex -48 1.86919 -59.9957
+      vertex -48.0171 1.87031 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 0 -1
     outer loop
-      vertex -1.2784 0 39.984
-      vertex -7.5 0 35
-      vertex -1.05 0 39.8313
+      vertex -48 1.86919 -59.9957
+      vertex -48.1308 2 -59.9957
+      vertex -48 3.13081 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 0 -1
     outer loop
-      vertex -1.05 0 39.8313
-      vertex -7.5 0 35
-      vertex -0.803635 0 39.7099
+      vertex -48.1308 2 -59.9957
+      vertex -48.0171 1.87031 -59.9957
+      vertex -48.0339 1.87365 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 0 -1
     outer loop
-      vertex -0.54352 0 39.6216
-      vertex -7.5 0 35
-      vertex -0.274104 0 39.568
+      vertex -48.1308 3 -59.9957
+      vertex -48 3.13081 -59.9957
+      vertex -48.1308 2 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 0 -1
     outer loop
-      vertex -0.803635 0 39.7099
-      vertex -7.5 0 35
-      vertex -0.54352 0 39.6216
+      vertex -48.1308 2 -59.9957
+      vertex -48.0339 1.87365 -59.9957
+      vertex -48.0501 1.87915 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 0 -1
     outer loop
-      vertex -2.02844 0 41.1065
-      vertex -7.5 0 35
-      vertex -1.94015 0 40.8464
+      vertex -48 3.13081 -59.9957
+      vertex -48.1308 3 -59.9957
+      vertex -48.0171 3.12969 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -50 0 50
-      vertex -40 0 7.5
-      vertex -40 0 35
+      vertex -48.1308 2 -59.9957
+      vertex -48.0501 1.87915 -59.9957
+      vertex -48.0654 1.88672 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -7.5 0 -7.5
-      vertex -7.5 0 7.5
-      vertex -40 0 7.5
+      vertex -48.0171 3.12969 -59.9957
+      vertex -48.1308 3 -59.9957
+      vertex -48.0339 3.12635 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -7.5 0 7.5
-      vertex -7.5 0 -7.5
-      vertex 7.5 0 7.5
+      vertex -48.1308 2 -59.9957
+      vertex -48.0654 1.88672 -59.9957
+      vertex -48.0796 1.89622 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -7.5 0 -7.5
-      vertex -40 0 7.5
-      vertex -40 0 -7.5
+      vertex -48.0339 3.12635 -59.9957
+      vertex -48.1308 3 -59.9957
+      vertex -48.0501 3.12085 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -50 0 50
-      vertex -40 0 -7.5
-      vertex -40 0 7.5
+      vertex -48.1308 2 -59.9957
+      vertex -48.0796 1.89622 -59.9957
+      vertex -48.0925 1.90751 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -50 0 -60
-      vertex -40 0 -7.5
-      vertex -50 0 50
+      vertex -48.0501 3.12085 -59.9957
+      vertex -48.1308 3 -59.9957
+      vertex -48.0654 3.11328 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -1.94015 0 -42.4536
-      vertex -7.5 0 -35
-      vertex -40 0 -35
+      vertex -48.1308 2 -59.9957
+      vertex -48.0925 1.90751 -59.9957
+      vertex -48.1038 1.92037 -59.9957
     endloop
   endfacet
-  facet normal -0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -0.54352 0 -39.6216
-      vertex -7.5 0 -35
-      vertex -0.803635 0 -39.7099
+      vertex -48.0654 3.11328 -59.9957
+      vertex -48.1308 3 -59.9957
+      vertex -48.0796 3.10378 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex 0.274104 0 -39.568
-      vertex 7.5 0 -35
-      vertex 0 0 -39.55
+      vertex -48.1308 2 -59.9957
+      vertex -48.1038 1.92037 -59.9957
+      vertex -48.1133 1.9346 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -7.5 0 -35
-      vertex 0 0 -39.55
-      vertex 7.5 0 -35
+      vertex -48.0796 3.10378 -59.9957
+      vertex -48.1308 3 -59.9957
+      vertex -48.0925 3.09249 -59.9957
     endloop
   endfacet
-  facet normal -0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex 0 0 -39.55
-      vertex -7.5 0 -35
-      vertex -0.274104 0 -39.568
+      vertex -48.1308 2 -59.9957
+      vertex -48.1133 1.9346 -59.9957
+      vertex -48.1208 1.94994 -59.9957
     endloop
   endfacet
-  facet normal -0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -0.274104 0 -39.568
-      vertex -7.5 0 -35
-      vertex -0.54352 0 -39.6216
+      vertex -48.0925 3.09249 -59.9957
+      vertex -48.1308 3 -59.9957
+      vertex -48.1038 3.07963 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -7.5 0 -35
-      vertex -1.05 0 -39.8313
-      vertex -0.803635 0 -39.7099
+      vertex -48.1308 2 -59.9957
+      vertex -48.1208 1.94994 -59.9957
+      vertex -48.1264 1.96615 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -7.5 0 -35
-      vertex -1.2784 0 -39.984
-      vertex -1.05 0 -39.8313
+      vertex -48.1038 3.07963 -59.9957
+      vertex -48.1308 3 -59.9957
+      vertex -48.1133 3.0654 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -7.5 0 -35
-      vertex -1.48492 0 -40.1651
-      vertex -1.2784 0 -39.984
+      vertex -48.1308 2 -59.9957
+      vertex -48.1264 1.96615 -59.9957
+      vertex -48.1297 1.98293 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -7.5 0 -35
-      vertex -1.66604 0 -40.3716
-      vertex -1.48492 0 -40.1651
+      vertex -48.1133 3.0654 -59.9957
+      vertex -48.1308 3 -59.9957
+      vertex -48.1208 3.05006 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -7.5 0 -35
-      vertex -1.81865 0 -40.6
-      vertex -1.66604 0 -40.3716
+      vertex -48.1208 3.05006 -59.9957
+      vertex -48.1308 3 -59.9957
+      vertex -48.1264 3.03385 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -7.5 0 -35
-      vertex -1.94015 0 -40.8464
-      vertex -1.81865 0 -40.6
+      vertex -48.1264 3.03385 -59.9957
+      vertex -48.1308 3 -59.9957
+      vertex -48.1297 3.01707 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.416373 -0.278275 -0.865561
     outer loop
-      vertex -7.5 0 -35
-      vertex -2.02844 0 -41.1065
-      vertex -1.94015 0 -40.8464
+      vertex -48.7018 1.4615 -59.7937
+      vertex -48.9623 1.44443 -59.6629
+      vertex -48.7661 1.55771 -59.7937
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.401761 -0.458184 -0.792878
     outer loop
-      vertex -7.5 0 -35
-      vertex -2.08203 0 -41.3759
-      vertex -2.02844 0 -41.1065
+      vertex -48.8028 0.953812 -59.5037
+      vertex -48.9325 1.06754 -59.5037
+      vertex -48.6764 1.11847 -59.6629
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.597118 -0.523299 -0.607954
     outer loop
-      vertex -7.5 0 -35
-      vertex -2.1 0 -41.65
-      vertex -2.08203 0 -41.3759
+      vertex -49.0633 0.936738 -59.3187
+      vertex -49.3193 0.987667 -59.1111
+      vertex -49.1929 1.08462 -59.3187
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.532303 -0.466673 -0.706308
     outer loop
-      vertex -7.5 0 -35
-      vertex -2.08203 0 -41.9241
-      vertex -2.1 0 -41.65
+      vertex -48.9325 1.06754 -59.5037
+      vertex -49.0633 0.936738 -59.3187
+      vertex -49.0462 1.19723 -59.5037
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.777012 -0.383281 -0.499347
     outer loop
-      vertex -7.5 0 -35
-      vertex -2.02844 0 -42.1935
-      vertex -2.08203 0 -41.9241
+      vertex -49.5534 1.10313 -58.8846
+      vertex -49.6572 1.31356 -58.8846
+      vertex -49.4401 1.16853 -59.1111
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.577116 -0.196094 -0.79277
     outer loop
-      vertex -7.5 0 -35
-      vertex -1.94015 0 -42.4536
-      vertex -2.02844 0 -42.1935
+      vertex -49.2183 1.49536 -59.5037
+      vertex -49.2738 1.6587 -59.5037
+      vertex -49.0266 1.57479 -59.6629
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.169714 -0.344082 -0.923474
     outer loop
-      vertex -40 0 -35
-      vertex -1.81865 0 -42.7
-      vertex -1.94015 0 -42.4536
+      vertex -48.246 1.40606 -59.8939
+      vertex -48.3385 1.18276 -59.7937
+      vertex -48.3214 1.44325 -59.8939
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.232583 -0.114719 -0.965787
     outer loop
-      vertex -50 0 -60
-      vertex -1.81865 0 -42.7
-      vertex -40 0 -35
+      vertex -48.5567 1.67856 -59.8939
+      vertex -48.5939 1.75398 -59.8939
+      vertex -48.3379 1.80491 -59.9616
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal -0.128203 -0.0252128 -0.991427
     outer loop
-      vertex -1.81865 0 -42.7
-      vertex -50 0 -60
-      vertex -1.66604 0 -42.9284
+      vertex -48.1264 1.96615 -59.9957
+      vertex -48.3769 1.89901 -59.9616
+      vertex -48.1297 1.98293 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal -0.245596 -0.0833562 -0.965782
     outer loop
-      vertex -1.66604 0 -42.9284
-      vertex -50 0 -60
-      vertex -1.48492 0 -43.1349
+      vertex -48.3605 1.85069 -59.9616
+      vertex -48.5939 1.75398 -59.8939
+      vertex -48.3769 1.89901 -59.9616
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal -0.416355 -0.278374 -0.865538
     outer loop
-      vertex -1.48492 0 -43.1349
-      vertex -50 0 -60
-      vertex -1.2784 0 -43.316
+      vertex -48.8815 1.32358 -59.6629
+      vertex -48.9623 1.44443 -59.6629
+      vertex -48.7018 1.4615 -59.7937
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal -0.506732 -0.338481 -0.792876
     outer loop
-      vertex -1.2784 0 -43.316
-      vertex -50 0 -60
-      vertex -1.05 0 -43.4687
+      vertex -49.0462 1.19723 -59.5037
+      vertex -49.142 1.34065 -59.5037
+      vertex -48.8815 1.32358 -59.6629
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal -0.778651 -0.154996 -0.608012
     outer loop
-      vertex -1.05 0 -43.4687
-      vertex -50 0 -60
-      vertex -0.803635 0 -43.5901
+      vertex -49.4524 1.61082 -59.3187
+      vertex -49.6063 1.5696 -59.1111
+      vertex -49.4908 1.80373 -59.3187
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal -0.694418 -0.138228 -0.70617
     outer loop
-      vertex -0.274104 0 -43.732
-      vertex -50 0 -60
-      vertex 0 0 -43.75
+      vertex -49.4524 1.61082 -59.3187
+      vertex -49.4908 1.80373 -59.3187
+      vertex -49.2738 1.6587 -59.5037
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal -0.608082 -0.0399217 -0.79287
     outer loop
-      vertex -0.54352 0 -43.6784
-      vertex -50 0 -60
-      vertex -0.274104 0 -43.732
+      vertex -49.3074 1.82788 -59.5037
+      vertex -49.3187 2 -59.5037
+      vertex -49.1016 1.85497 -59.6629
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal -0.608045 -0.0398292 -0.792903
     outer loop
-      vertex -0.803635 0 -43.5901
-      vertex -50 0 -60
-      vertex -0.54352 0 -43.6784
+      vertex -49.1016 1.85497 -59.6629
+      vertex -49.3187 2 -59.5037
+      vertex -49.1111 2 -59.6629
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal -0.90634 -0.180378 -0.382115
     outer loop
-      vertex -40 0 -7.5
-      vertex -50 0 -60
-      vertex -40 0 -35
+      vertex -49.7326 1.53574 -58.8846
+      vertex -49.8777 1.7528 -58.6429
+      vertex -49.7784 1.76587 -58.8846
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.849746 -0.169115 -0.499332
     outer loop
-      vertex 0.274104 0 43.732
-      vertex 50 0 50
-      vertex 0 0 43.75
+      vertex -49.7326 1.53574 -58.8846
+      vertex -49.7784 1.76587 -58.8846
+      vertex -49.6487 1.78294 -59.1111
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.864562 -0.0565594 -0.499334
     outer loop
-      vertex 0.54352 0 43.6784
-      vertex 50 0 50
-      vertex 0.274104 0 43.732
+      vertex -49.6487 1.78294 -59.1111
+      vertex -49.7784 1.76587 -58.8846
+      vertex -49.6629 2 -59.1111
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.849887 -0.16891 -0.499161
     outer loop
-      vertex 0.803635 0 43.5901
-      vertex 50 0 50
-      vertex 0.54352 0 43.6784
+      vertex -49.6063 1.5696 -59.1111
+      vertex -49.7326 1.53574 -58.8846
+      vertex -49.6487 1.78294 -59.1111
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0.258781 -0.965936
     outer loop
-      vertex 1.05 0 43.4687
-      vertex 50 0 50
-      vertex 0.803635 0 43.5901
+      vertex -48 3.39018 -59.9616
+      vertex 48 3.64288 -59.8939
+      vertex 48 3.39018 -59.9616
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0.258781 -0.965936
     outer loop
-      vertex 1.2784 0 43.316
-      vertex 50 0 50
-      vertex 1.05 0 43.4687
+      vertex 48 3.64288 -59.8939
+      vertex -48 3.39018 -59.9616
+      vertex -48 3.64288 -59.8939
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.0327752 0.499727 -0.865563
     outer loop
-      vertex 1.48492 0 43.1349
-      vertex 50 0 50
-      vertex 1.2784 0 43.316
+      vertex -48.1155 3.87701 -59.7937
+      vertex -48.145 4.10163 -59.6629
+      vertex -48 4.11114 -59.6629
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.0250966 0.382837 -0.923475
     outer loop
-      vertex 1.66604 0 42.9284
-      vertex 50 0 50
-      vertex 1.48492 0 43.1349
+      vertex -48.0839 3.63738 -59.8939
+      vertex -48.1155 3.87701 -59.7937
+      vertex -48 3.64288 -59.8939
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.330173 0.376543 -0.865564
     outer loop
-      vertex 1.81865 0 42.7
-      vertex 50 0 50
-      vertex 1.66604 0 42.9284
+      vertex 48.7857 3.78569 -59.6629
+      vertex 48.6255 3.62549 -59.7937
+      vertex 48.6764 3.88153 -59.6629
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.160955 0.474212 -0.865573
     outer loop
-      vertex 40 0 35
-      vertex 1.81865 0 42.7
-      vertex 1.94015 0 42.4536
+      vertex 48.3385 3.81724 -59.7937
+      vertex 48.2289 3.85444 -59.7937
+      vertex 48.4252 4.02656 -59.6629
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.213155 0.318953 -0.92349
     outer loop
-      vertex 7.5 0 35
-      vertex 1.94015 0 42.4536
-      vertex 2.02844 0 42.1935
+      vertex 48.5385 3.70178 -59.7937
+      vertex 48.3214 3.55675 -59.8939
+      vertex 48.4423 3.76607 -59.7937
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.288396 0.252955 -0.923494
     outer loop
-      vertex 7.5 0 35
-      vertex 2.02844 0 42.1935
-      vertex 2.08203 0 41.9241
+      vertex 48.7018 3.5385 -59.7937
+      vertex 48.51 3.39136 -59.8939
+      vertex 48.6255 3.62549 -59.7937
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.128159 0.025345 -0.99143
     outer loop
-      vertex 7.5 0 35
-      vertex 2.08203 0 41.9241
-      vertex 2.1 0 41.65
+      vertex 48.3868 3.05093 -59.9616
+      vertex 48.1297 3.01707 -59.9957
+      vertex 48.3769 3.10099 -59.9616
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.245596 0.0833562 -0.965782
     outer loop
-      vertex 7.5 0 35
-      vertex 2.1 0 41.65
-      vertex 2.08203 0 41.3759
+      vertex 48.3769 3.10099 -59.9616
+      vertex 48.3605 3.14931 -59.9616
+      vertex 48.5939 3.24602 -59.8939
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.195016 0.170893 -0.965797
     outer loop
-      vertex 7.5 0 35
-      vertex 2.08203 0 41.3759
-      vertex 2.02844 0 41.1065
+      vertex 48.51 3.39136 -59.8939
+      vertex 48.2759 3.2759 -59.9616
+      vertex 48.4546 3.45458 -59.8939
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.123523 -0.0426729 -0.991424
     outer loop
-      vertex 7.5 0 35
-      vertex 2.02844 0 41.1065
-      vertex 1.94015 0 40.8464
+      vertex 48.3769 1.89901 -59.9616
+      vertex 48.1208 1.94994 -59.9957
+      vertex 48.1264 1.96615 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 -0.130351 -0.991468
     outer loop
-      vertex 7.5 0 35
-      vertex 1.94015 0 40.8464
-      vertex 1.81865 0 40.6
+      vertex -48 1.60982 -59.9616
+      vertex 48 1.86919 -59.9957
+      vertex 48 1.60982 -59.9616
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0 -0.130351 -0.991468
     outer loop
-      vertex 7.5 0 35
-      vertex 1.81865 0 40.6
-      vertex 1.66604 0 40.3716
+      vertex 48 1.86919 -59.9957
+      vertex -48 1.60982 -59.9616
+      vertex -48 1.86919 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.382882 -0.0250965 -0.923456
     outer loop
-      vertex 7.5 0 35
-      vertex 1.66604 0 40.3716
-      vertex 1.48492 0 40.1651
+      vertex 48.877 1.88454 -59.7937
+      vertex 48.6374 1.91609 -59.8939
+      vertex 48.6429 2 -59.8939
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.130331 -0.00870067 -0.991432
     outer loop
-      vertex 7.5 0 35
-      vertex 1.48492 0 40.1651
-      vertex 1.2784 0 39.984
+      vertex 48.3868 1.94907 -59.9616
+      vertex 48.1308 2 -59.9957
+      vertex 48.3902 2 -59.9616
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.491187 0.0978218 -0.865544
     outer loop
-      vertex 7.5 0 35
-      vertex 1.2784 0 39.984
-      vertex 1.05 0 39.8313
+      vertex 48.877 3.11546 -59.7937
+      vertex 48.8544 3.22894 -59.7937
+      vertex 49.1016 3.14503 -59.6629
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.474078 0.160954 -0.865647
     outer loop
-      vertex 7.5 0 35
-      vertex 1.05 0 39.8313
-      vertex 0.803635 0 39.7099
+      vertex 48.8544 3.22894 -59.7937
+      vertex 48.8172 3.33851 -59.7937
+      vertex 49.0266 3.42521 -59.6629
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.597744 0.118668 -0.792855
     outer loop
-      vertex 7.5 0 35
-      vertex 0.803635 0 39.7099
-      vertex 0.54352 0 39.6216
+      vertex 49.1016 3.14503 -59.6629
+      vertex 49.0733 3.28758 -59.6629
+      vertex 49.2738 3.3413 -59.5037
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0.474141 0.160884 -0.865625
     outer loop
-      vertex -0.274104 0 39.568
-      vertex -7.5 0 35
-      vertex 0 0 39.55
+      vertex 49.0733 3.28758 -59.6629
+      vertex 48.8544 3.22894 -59.7937
+      vertex 49.0266 3.42521 -59.6629
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.608528 0 -0.793533
     outer loop
-      vertex 7.5 0 35
-      vertex 0 0 39.55
-      vertex -7.5 0 35
+      vertex 49.1111 2 -59.6629
+      vertex 49.3187 3 -59.5037
+      vertex 49.3187 2 -59.5037
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.608528 0 -0.793533
     outer loop
-      vertex 0 0 39.55
-      vertex 7.5 0 35
-      vertex 0.274104 0 39.568
+      vertex 49.3187 3 -59.5037
+      vertex 49.1111 2 -59.6629
+      vertex 49.1111 3 -59.6629
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.491118 -0.0975 -0.86562
     outer loop
-      vertex 0.274104 0 39.568
-      vertex 7.5 0 35
-      vertex 0.54352 0 39.6216
+      vertex 49.0733 1.71242 -59.6629
+      vertex 48.8544 1.77106 -59.7937
+      vertex 49.1016 1.85497 -59.6629
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.577082 -0.195813 -0.792864
     outer loop
-      vertex 1.94015 0 42.4536
-      vertex 7.5 0 35
-      vertex 40 0 35
+      vertex 49.2738 1.6587 -59.5037
+      vertex 49.0266 1.57479 -59.6629
+      vertex 49.0733 1.71242 -59.6629
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.577116 -0.196094 -0.79277
     outer loop
-      vertex 1.81865 0 42.7
-      vertex 40 0 35
-      vertex 50 0 50
+      vertex 49.2183 1.49536 -59.5037
+      vertex 49.0266 1.57479 -59.6629
+      vertex 49.2738 1.6587 -59.5037
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.577116 0.196094 -0.79277
     outer loop
-      vertex 40 0 7.5
-      vertex 50 0 50
-      vertex 40 0 35
+      vertex 49.2738 3.3413 -59.5037
+      vertex 49.0266 3.42521 -59.6629
+      vertex 49.2183 3.50464 -59.5037
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.670259 0.227742 -0.706319
     outer loop
-      vertex 7.5 0 -7.5
-      vertex 7.5 0 7.5
-      vertex -7.5 0 -7.5
+      vertex 49.2738 3.3413 -59.5037
+      vertex 49.2183 3.50464 -59.5037
+      vertex 49.3892 3.57543 -59.3187
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.58865 0.3932 -0.706318
     outer loop
-      vertex 7.5 0 7.5
-      vertex 7.5 0 -7.5
-      vertex 40 0 7.5
+      vertex 49.142 3.65935 -59.5037
+      vertex 49.0462 3.80277 -59.5037
+      vertex 49.3022 3.75184 -59.3187
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.634888 0.313115 -0.706312
     outer loop
-      vertex 40 0 -7.5
-      vertex 40 0 7.5
-      vertex 7.5 0 -7.5
+      vertex 49.2183 3.50464 -59.5037
+      vertex 49.142 3.65935 -59.5037
+      vertex 49.3892 3.57543 -59.3187
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.751829 0.255136 -0.607995
     outer loop
-      vertex 40 0 -7.5
-      vertex 50 0 50
-      vertex 40 0 7.5
+      vertex 49.6063 3.4304 -59.1111
+      vertex 49.3892 3.57543 -59.3187
+      vertex 49.5364 3.63638 -59.1111
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.751827 0.255117 -0.608006
     outer loop
-      vertex 50 0 -60
-      vertex 40 0 -7.5
-      vertex 40 0 -35
+      vertex 49.4524 3.38918 -59.3187
+      vertex 49.3892 3.57543 -59.3187
+      vertex 49.6063 3.4304 -59.1111
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.117135 -0.0578253 -0.991431
     outer loop
-      vertex 0.54352 0 -39.6216
-      vertex 7.5 0 -35
-      vertex 0.274104 0 -39.568
+      vertex 48.3379 1.80491 -59.9616
+      vertex 48.1133 1.9346 -59.9957
+      vertex 48.3605 1.85069 -59.9616
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.128203 -0.0252128 -0.991427
     outer loop
-      vertex 0.803635 0 -39.7099
-      vertex 7.5 0 -35
-      vertex 0.54352 0 -39.6216
+      vertex 48.3769 1.89901 -59.9616
+      vertex 48.1264 1.96615 -59.9957
+      vertex 48.1297 1.98293 -59.9957
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.34412 -0.169441 -0.92351
     outer loop
-      vertex 1.05 0 -39.8313
-      vertex 7.5 0 -35
-      vertex 0.803635 0 -39.7099
+      vertex 48.7661 1.55771 -59.7937
+      vertex 48.5567 1.67856 -59.8939
+      vertex 48.8172 1.66149 -59.7937
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.449303 -0.221231 -0.865554
     outer loop
-      vertex 1.2784 0 -39.984
-      vertex 7.5 0 -35
-      vertex 1.05 0 -39.8313
+      vertex 48.9623 1.44443 -59.6629
+      vertex 48.7661 1.55771 -59.7937
+      vertex 48.8172 1.66149 -59.7937
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.318905 -0.213134 -0.923512
     outer loop
-      vertex 1.48492 0 -40.1651
-      vertex 7.5 0 -35
-      vertex 1.2784 0 -39.984
+      vertex 48.7018 1.4615 -59.7937
+      vertex 48.5567 1.67856 -59.8939
+      vertex 48.7661 1.55771 -59.7937
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.319 -0.213062 -0.923495
     outer loop
-      vertex 1.66604 0 -40.3716
-      vertex 7.5 0 -35
-      vertex 1.48492 0 -40.1651
+      vertex 48.7018 1.4615 -59.7937
+      vertex 48.51 1.60864 -59.8939
+      vertex 48.5567 1.67856 -59.8939
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.278247 -0.416353 -0.86558
     outer loop
-      vertex 1.81865 0 -40.6
-      vertex 7.5 0 -35
-      vertex 1.66604 0 -40.3716
+      vertex 48.5556 1.03772 -59.6629
+      vertex 48.4423 1.23393 -59.7937
+      vertex 48.5385 1.29822 -59.7937
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.221423 -0.449163 -0.865577
     outer loop
-      vertex 1.94015 0 -40.8464
-      vertex 7.5 0 -35
-      vertex 1.81865 0 -40.6
+      vertex 48.5556 1.03772 -59.6629
+      vertex 48.3385 1.18276 -59.7937
+      vertex 48.4423 1.23393 -59.7937
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.0250917 -0.382839 -0.923474
     outer loop
-      vertex 2.02844 0 -41.1065
-      vertex 7.5 0 -35
-      vertex 1.94015 0 -40.8464
+      vertex 48.1155 1.12299 -59.7937
+      vertex 48 1.11542 -59.7937
+      vertex 48 1.35712 -59.8939
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.660335 0.441051 0.607809
     outer loop
-      vertex 2.08203 0 -41.3759
-      vertex 7.5 0 -35
-      vertex 2.02844 0 -41.1065
+      vertex -49.3193 4.01233 49.1111
+      vertex -49.4401 3.83147 49.1111
+      vertex -49.3022 3.75184 49.3187
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.720482 0.481208 0.499345
     outer loop
-      vertex 2.1 0 -41.65
-      vertex 7.5 0 -35
-      vertex 2.08203 0 -41.3759
+      vertex -49.4231 4.09196 48.8846
+      vertex -49.5534 3.89687 48.8846
+      vertex -49.4401 3.83147 49.1111
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.536682 0.803288 0.258266
     outer loop
-      vertex 2.08203 0 -41.9241
-      vertex 7.5 0 -35
-      vertex 2.1 0 -41.65
+      vertex -48.9469 4.64013 48.6429
+      vertex -49.1941 4.55622 48.3902
+      vertex -49.1529 4.5025 48.6429
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.637026 0.726341 0.258121
     outer loop
-      vertex 2.02844 0 -42.1935
-      vertex 7.5 0 -35
-      vertex 2.08203 0 -41.9241
+      vertex -49.1941 4.55622 48.3902
+      vertex -49.387 4.38704 48.3902
+      vertex -49.3392 4.33916 48.6429
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.550929 0.824323 -0.130263
     outer loop
-      vertex 1.94015 0 -42.4536
-      vertex 7.5 0 -35
-      vertex 2.02844 0 -42.1935
+      vertex -49.1941 4.55622 -58.3902
+      vertex -49.2149 4.58331 -58.1308
+      vertex -48.9979 4.72834 -58.1308
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal -0.408729 0.828873 -0.381982
     outer loop
-      vertex 7.5 0 -35
-      vertex 1.94015 0 -42.4536
-      vertex 40 0 -35
+      vertex -48.6864 4.6572 -58.8846
+      vertex -48.9469 4.64013 -58.6429
+      vertex -48.7247 4.7497 -58.6429
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.82881 0.408847 -0.381993
     outer loop
-      vertex 1.81865 0 -42.7
-      vertex 40 0 -35
-      vertex 1.94015 0 -42.4536
+      vertex -49.6572 3.68644 -58.8846
+      vertex -49.7497 3.72475 -58.6429
+      vertex -49.6401 3.94693 -58.6429
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.889201 0.438657 -0.130007
     outer loop
-      vertex 50 0 -60
-      vertex 1.81865 0 -42.7
-      vertex 1.66604 0 -42.9284
+      vertex -49.6988 3.98078 -58.3902
+      vertex -49.8438 3.76373 -58.1308
+      vertex -49.7283 3.99786 -58.1308
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.481361 0.720416 -0.499292
     outer loop
-      vertex 50 0 -60
-      vertex 1.66604 0 -42.9284
-      vertex 1.48492 0 -43.1349
+      vertex -48.8315 4.44015 -59.1111
+      vertex -49.092 4.42307 -58.8846
+      vertex -48.8969 4.55343 -58.8846
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.278469 0.820432 -0.499345
     outer loop
-      vertex 50 0 -60
-      vertex 1.48492 0 -43.1349
-      vertex 1.2784 0 -43.316
+      vertex -48.4304 4.60628 -59.1111
+      vertex -48.6364 4.53636 -59.1111
+      vertex -48.4643 4.73263 -58.8846
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.227602 0.670286 -0.706339
     outer loop
-      vertex 50 0 -60
-      vertex 1.2784 0 -43.316
-      vertex 1.05 0 -43.4687
+      vertex -48.5046 4.21831 -59.5037
+      vertex -48.5754 4.38922 -59.3187
+      vertex -48.3413 4.27376 -59.5037
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.221416 0.449171 -0.865575
     outer loop
-      vertex 50 0 -60
-      vertex 1.05 0 -43.4687
-      vertex 0.803635 0 -43.5901
+      vertex -48.3385 3.81724 -59.7937
+      vertex -48.5556 3.96228 -59.6629
+      vertex -48.4252 4.02656 -59.6629
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.288396 0.252955 -0.923494
     outer loop
-      vertex 50 0 -60
-      vertex 0.803635 0 -43.5901
-      vertex 0.54352 0 -43.6784
+      vertex -48.51 3.39136 -59.8939
+      vertex -48.7018 3.5385 -59.7937
+      vertex -48.6255 3.62549 -59.7937
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.609347 0.694821 -0.381995
     outer loop
-      vertex 50 0 -60
-      vertex 0 0 -43.75
-      vertex -50 0 -60
+      vertex -49.2684 4.26837 -58.8846
+      vertex -49.3392 4.33916 -58.6429
+      vertex -49.092 4.42307 -58.8846
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.513462 0.76846 -0.381872
     outer loop
-      vertex 0 0 -43.75
-      vertex 50 0 -60
-      vertex 0.274104 0 -43.732
+      vertex -48.8969 4.55343 -58.8846
+      vertex -49.092 4.42307 -58.8846
+      vertex -48.9469 4.64013 -58.6429
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.427249 0.86643 -0.258374
     outer loop
-      vertex 0.274104 0 -43.732
-      vertex 50 0 -60
-      vertex 0.54352 0 -43.6784
+      vertex -48.9469 4.64013 -58.6429
+      vertex -48.9808 4.69877 -58.3902
+      vertex -48.7247 4.7497 -58.6429
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.938977 0.318441 -0.130069
     outer loop
-      vertex 40 0 -7.5
-      vertex 50 0 -60
-      vertex 50 0 50
+      vertex -49.8123 3.75066 -58.3902
+      vertex -49.8947 3.50769 -58.3902
+      vertex -49.8438 3.76373 -58.1308
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.98938 0.0649484 -0.130031
     outer loop
-      vertex 1.81865 0 -42.7
-      vertex 50 0 -60
-      vertex 40 0 -35
+      vertex -49.9448 3.25604 -58.3902
+      vertex -49.9957 3 -58.1308
+      vertex -49.9786 3.26049 -58.1308
+    endloop
+  endfacet
+  facet normal -0.597714 0.118709 -0.792872
+    outer loop
+      vertex -49.1016 3.14503 -59.6629
+      vertex -49.3074 3.17212 -59.5037
+      vertex -49.2738 3.3413 -59.5037
+    endloop
+  endfacet
+  facet normal -0.707107 0 -0.707107
+    outer loop
+      vertex -49.3187 2 -59.5037
+      vertex -49.5037 3 -59.3187
+      vertex -49.3187 3 -59.5037
+    endloop
+  endfacet
+  facet normal -0.707107 -0 -0.707107
+    outer loop
+      vertex -49.5037 3 -59.3187
+      vertex -49.3187 2 -59.5037
+      vertex -49.5037 2 -59.3187
+    endloop
+  endfacet
+  facet normal -0.458218 0.401723 -0.792878
+    outer loop
+      vertex -48.8815 3.67642 -59.6629
+      vertex -49.0462 3.80277 -59.5037
+      vertex -48.9325 3.93246 -59.5037
+    endloop
+  endfacet
+  facet normal -0.491118 0.0975 -0.86562
+    outer loop
+      vertex -48.8544 3.22894 -59.7937
+      vertex -49.1016 3.14503 -59.6629
+      vertex -49.0733 3.28758 -59.6629
+    endloop
+  endfacet
+  facet normal -0.577116 0.196094 -0.79277
+    outer loop
+      vertex -49.0266 3.42521 -59.6629
+      vertex -49.2738 3.3413 -59.5037
+      vertex -49.2183 3.50464 -59.5037
+    endloop
+  endfacet
+  facet normal -0.458211 0.401726 -0.792881
+    outer loop
+      vertex -48.8815 3.67642 -59.6629
+      vertex -48.9325 3.93246 -59.5037
+      vertex -48.7857 3.78569 -59.6629
+    endloop
+  endfacet
+  facet normal -0.232583 0.114719 -0.965787
+    outer loop
+      vertex -48.3379 3.19509 -59.9616
+      vertex -48.5939 3.24602 -59.8939
+      vertex -48.5567 3.32144 -59.8939
+    endloop
+  endfacet
+  facet normal -0.3633 0.12364 -0.923432
+    outer loop
+      vertex -48.621 3.16639 -59.8939
+      vertex -48.8544 3.22894 -59.7937
+      vertex -48.5939 3.24602 -59.8939
+    endloop
+  endfacet
+  facet normal -0.00855315 0.130346 -0.991432
+    outer loop
+      vertex -48 3.13081 -59.9957
+      vertex -48.0509 3.38684 -59.9616
+      vertex -48 3.39018 -59.9616
+    endloop
+  endfacet
+  facet normal -0.660338 -0.441046 -0.607809
+    outer loop
+      vertex -49.3193 0.987667 -59.1111
+      vertex -49.4401 1.16853 -59.1111
+      vertex -49.3022 1.24816 -59.3187
+    endloop
+  endfacet
+  facet normal -0.720473 -0.48121 -0.499355
+    outer loop
+      vertex -49.4231 0.908037 -58.8846
+      vertex -49.4401 1.16853 -59.1111
+      vertex -49.3193 0.987667 -59.1111
+    endloop
+  endfacet
+  facet normal -0.43855 0.889235 0.130133
+    outer loop
+      vertex -48.7637 4.8438 48.1308
+      vertex -48.9808 4.69877 48.3902
+      vertex -48.7507 4.81225 48.3902
+    endloop
+  endfacet
+  facet normal -0.438414 0.889282 0.130273
+    outer loop
+      vertex -48.7637 4.8438 48.1308
+      vertex -48.9979 4.72834 48.1308
+      vertex -48.9808 4.69877 48.3902
+    endloop
+  endfacet
+  facet normal -0.0604353 0.922198 0.381966
+    outer loop
+      vertex -48 4.89386 48.6429
+      vertex -48.2472 4.87766 48.6429
+      vertex -48 4.79375 48.8846
+    endloop
+  endfacet
+  facet normal -0.0631748 0.964 0.258288
+    outer loop
+      vertex -48 4.89386 48.6429
+      vertex -48.256 4.94479 48.3902
+      vertex -48.2472 4.87766 48.6429
+    endloop
+  endfacet
+  facet normal -0.0398853 0.608136 0.79283
+    outer loop
+      vertex -48 4.31869 49.5037
+      vertex -48.145 4.10163 49.6629
+      vertex -48 4.11114 49.6629
+    endloop
+  endfacet
+  facet normal -0 0.60862 0.793462
+    outer loop
+      vertex -48 4.31869 49.5037
+      vertex 48 4.11114 49.6629
+      vertex 48 4.31869 49.5037
+    endloop
+  endfacet
+  facet normal 0 0.60862 0.793462
+    outer loop
+      vertex 48 4.11114 49.6629
+      vertex -48 4.31869 49.5037
+      vertex -48 4.11114 49.6629
+    endloop
+  endfacet
+  facet normal -0.278308 0.416342 0.865566
+    outer loop
+      vertex -48.5556 3.96228 49.6629
+      vertex -48.6764 3.88153 49.6629
+      vertex -48.5385 3.70178 49.7937
+    endloop
+  endfacet
+  facet normal -0.118873 0.597721 0.792842
+    outer loop
+      vertex -48.1721 4.30741 49.5037
+      vertex -48.3413 4.27376 49.5037
+      vertex -48.145 4.10163 49.6629
+    endloop
+  endfacet
+  facet normal -0.169714 0.344082 0.923474
+    outer loop
+      vertex -48.246 3.59394 49.8939
+      vertex -48.3385 3.81724 49.7937
+      vertex -48.3214 3.55675 49.8939
+    endloop
+  endfacet
+  facet normal -0.114712 0.232571 0.965791
+    outer loop
+      vertex -48.246 3.59394 49.8939
+      vertex -48.3214 3.55675 49.8939
+      vertex -48.1951 3.33791 49.9616
+    endloop
+  endfacet
+  facet normal -0.0977607 0.491186 0.865551
+    outer loop
+      vertex -48.145 4.10163 49.6629
+      vertex -48.2289 3.85444 49.7937
+      vertex -48.1155 3.87701 49.7937
+    endloop
+  endfacet
+  facet normal -0.0250966 0.382837 0.923475
+    outer loop
+      vertex -48 3.64288 49.8939
+      vertex -48.1155 3.87701 49.7937
+      vertex -48.0839 3.63738 49.8939
+    endloop
+  endfacet
+  facet normal -0.138073 0.694261 0.706355
+    outer loop
+      vertex -48.1963 4.49082 49.3187
+      vertex -48.3413 4.27376 49.5037
+      vertex -48.1721 4.30741 49.5037
+    endloop
+  endfacet
+  facet normal -0.221416 0.449171 0.865575
+    outer loop
+      vertex -48.4252 4.02656 49.6629
+      vertex -48.5556 3.96228 49.6629
+      vertex -48.3385 3.81724 49.7937
+    endloop
+  endfacet
+  facet normal -0.571131 0.651447 0.499425
+    outer loop
+      vertex -49.092 4.42307 48.8846
+      vertex -49.1759 4.17587 49.1111
+      vertex -49.0123 4.3193 49.1111
+    endloop
+  endfacet
+  facet normal -0.313118 0.634873 0.706324
+    outer loop
+      vertex -48.5754 4.38922 49.3187
+      vertex -48.7518 4.30222 49.3187
+      vertex -48.6593 4.14202 49.5037
+    endloop
+  endfacet
+  facet normal -0.458211 0.401726 0.792881
+    outer loop
+      vertex -48.7857 3.78569 49.6629
+      vertex -48.9325 3.93246 49.5037
+      vertex -48.8815 3.67642 49.6629
+    endloop
+  endfacet
+  facet normal -0.40176 0.458185 0.792878
+    outer loop
+      vertex -48.6764 3.88153 49.6629
+      vertex -48.9325 3.93246 49.5037
+      vertex -48.7857 3.78569 49.6629
+    endloop
+  endfacet
+  facet normal -0.0462756 0.706368 0.70633
+    outer loop
+      vertex -48 4.50368 49.3187
+      vertex -48.1963 4.49082 49.3187
+      vertex -48 4.31869 49.5037
+    endloop
+  endfacet
+  facet normal -0.0519361 0.792363 0.607835
+    outer loop
+      vertex -48 4.66294 49.1111
+      vertex -48.2171 4.64871 49.1111
+      vertex -48.1963 4.49082 49.3187
+    endloop
+  endfacet
+  facet normal -0.297162 0.875102 0.381957
+    outer loop
+      vertex -48.4902 4.82933 48.6429
+      vertex -48.7247 4.7497 48.6429
+      vertex -48.4643 4.73263 48.8846
+    endloop
+  endfacet
+  facet normal -0.3105 0.914784 0.25838
+    outer loop
+      vertex -48.5077 4.89473 48.3902
+      vertex -48.7507 4.81225 48.3902
+      vertex -48.7247 4.7497 48.6429
+    endloop
+  endfacet
+  facet normal -0.820543 0.278463 0.499167
+    outer loop
+      vertex -49.6572 3.68644 48.8846
+      vertex -49.7326 3.46426 48.8846
+      vertex -49.5364 3.63638 49.1111
+    endloop
+  endfacet
+  facet normal -0.71219 0.35123 0.607801
+    outer loop
+      vertex -49.3022 3.75184 49.3187
+      vertex -49.4401 3.83147 49.1111
+      vertex -49.3892 3.57543 49.3187
+    endloop
+  endfacet
+  facet normal -0.889226 0.438585 0.130081
+    outer loop
+      vertex -49.6988 3.98078 48.3902
+      vertex -49.8438 3.76373 48.1308
+      vertex -49.8123 3.75066 48.3902
+    endloop
+  endfacet
+  facet normal -0.938977 0.318441 0.130069
+    outer loop
+      vertex -49.8438 3.76373 48.1308
+      vertex -49.8947 3.50769 48.3902
+      vertex -49.8123 3.75066 48.3902
+    endloop
+  endfacet
+  facet normal -0.751827 -0.255117 0.608006
+    outer loop
+      vertex -49.4524 1.61082 49.3187
+      vertex -49.6063 1.5696 49.1111
+      vertex -49.3892 1.42457 49.3187
+    endloop
+  endfacet
+  facet normal -0.778651 -0.154996 0.608012
+    outer loop
+      vertex -49.4908 1.80373 49.3187
+      vertex -49.6063 1.5696 49.1111
+      vertex -49.4524 1.61082 49.3187
+    endloop
+  endfacet
+  facet normal -0.670487 -0.227516 0.706175
+    outer loop
+      vertex -49.2738 1.6587 49.5037
+      vertex -49.4524 1.61082 49.3187
+      vertex -49.3892 1.42457 49.3187
+    endloop
+  endfacet
+  facet normal -0.694418 -0.138228 0.70617
+    outer loop
+      vertex -49.2738 1.6587 49.5037
+      vertex -49.4908 1.80373 49.3187
+      vertex -49.4524 1.61082 49.3187
+    endloop
+  endfacet
+  facet normal -0.597744 -0.118668 0.792855
+    outer loop
+      vertex -49.1016 1.85497 49.6629
+      vertex -49.2738 1.6587 49.5037
+      vertex -49.0733 1.71242 49.6629
+    endloop
+  endfacet
+  facet normal -0.506732 -0.338481 0.792876
+    outer loop
+      vertex -48.8815 1.32358 49.6629
+      vertex -49.142 1.34065 49.5037
+      vertex -49.0462 1.19723 49.5037
+    endloop
+  endfacet
+  facet normal -0.319 -0.213062 0.923495
+    outer loop
+      vertex -48.5567 1.67856 49.8939
+      vertex -48.7018 1.4615 49.7937
+      vertex -48.51 1.60864 49.8939
+    endloop
+  endfacet
+  facet normal -0.245476 -0.0835415 0.965796
+    outer loop
+      vertex -48.3769 1.89901 49.9616
+      vertex -48.621 1.83361 49.8939
+      vertex -48.5939 1.75398 49.8939
+    endloop
+  endfacet
+  facet normal -0.546628 0.269624 0.79278
+    outer loop
+      vertex -48.9623 3.55557 49.6629
+      vertex -49.142 3.65935 49.5037
+      vertex -49.0266 3.42521 49.6629
+    endloop
+  endfacet
+  facet normal -0.449015 0.221476 0.865641
+    outer loop
+      vertex -48.9623 3.55557 49.6629
+      vertex -49.0266 3.42521 49.6629
+      vertex -48.8172 3.33851 49.7937
+    endloop
+  endfacet
+  facet normal -0.670259 0.227742 0.706319
+    outer loop
+      vertex -49.2183 3.50464 49.5037
+      vertex -49.3892 3.57543 49.3187
+      vertex -49.2738 3.3413 49.5037
+    endloop
+  endfacet
+  facet normal -0.577116 0.196094 0.79277
+    outer loop
+      vertex -49.2183 3.50464 49.5037
+      vertex -49.2738 3.3413 49.5037
+      vertex -49.0266 3.42521 49.6629
+    endloop
+  endfacet
+  facet normal -0.363296 0.123342 0.923473
+    outer loop
+      vertex -48.8172 3.33851 49.7937
+      vertex -48.8544 3.22894 49.7937
+      vertex -48.5939 3.24602 49.8939
+    endloop
+  endfacet
+  facet normal -0.449303 0.221231 0.865554
+    outer loop
+      vertex -48.7661 3.44229 49.7937
+      vertex -48.9623 3.55557 49.6629
+      vertex -48.8172 3.33851 49.7937
+    endloop
+  endfacet
+  facet normal -0.288396 0.252955 0.923494
+    outer loop
+      vertex -48.6255 3.62549 49.7937
+      vertex -48.7018 3.5385 49.7937
+      vertex -48.51 3.39136 49.8939
+    endloop
+  endfacet
+  facet normal -0.330185 0.376539 0.865561
+    outer loop
+      vertex -48.5385 3.70178 49.7937
+      vertex -48.6764 3.88153 49.6629
+      vertex -48.6255 3.62549 49.7937
+    endloop
+  endfacet
+  facet normal -0.34412 0.169441 0.92351
+    outer loop
+      vertex -48.7661 3.44229 49.7937
+      vertex -48.8172 3.33851 49.7937
+      vertex -48.5567 3.32144 49.8939
+    endloop
+  endfacet
+  facet normal -0.128203 0.0252128 0.991427
+    outer loop
+      vertex -48.1264 3.03385 49.9957
+      vertex -48.3769 3.10099 49.9616
+      vertex -48.1297 3.01707 49.9957
+    endloop
+  endfacet
+  facet normal -0.3633 0.12364 0.923432
+    outer loop
+      vertex -48.5939 3.24602 49.8939
+      vertex -48.8544 3.22894 49.7937
+      vertex -48.621 3.16639 49.8939
+    endloop
+  endfacet
+  facet normal -0.914834 -0.31043 0.258286
+    outer loop
+      vertex -49.8293 1.50983 48.6429
+      vertex -49.8947 1.49231 48.3902
+      vertex -49.7497 1.27525 48.6429
+    endloop
+  endfacet
+  facet normal -0.875161 -0.296968 0.381972
+    outer loop
+      vertex -49.7326 1.53574 48.8846
+      vertex -49.8293 1.50983 48.6429
+      vertex -49.7497 1.27525 48.6429
+    endloop
+  endfacet
+  facet normal -0.660113 -0.441179 0.607957
+    outer loop
+      vertex -49.3022 1.24816 49.3187
+      vertex -49.3193 0.987667 49.1111
+      vertex -49.1929 1.08462 49.3187
+    endloop
+  endfacet
+  facet normal -0.820543 -0.278463 0.499167
+    outer loop
+      vertex -49.5364 1.36362 49.1111
+      vertex -49.7326 1.53574 48.8846
+      vertex -49.6572 1.31356 48.8846
+    endloop
+  endfacet
+  facet normal -0.80332 -0.536644 0.258246
+    outer loop
+      vertex -49.5025 0.847092 48.6429
+      vertex -49.6401 1.05307 48.6429
+      vertex -49.5562 0.805872 48.3902
+    endloop
+  endfacet
+  facet normal -0.768497 -0.513381 0.381906
+    outer loop
+      vertex -49.4231 0.908037 48.8846
+      vertex -49.6401 1.05307 48.6429
+      vertex -49.5025 0.847092 48.6429
+    endloop
+  endfacet
+  facet normal -0.74538 -0.653764 0.130393
+    outer loop
+      vertex -49.387 0.612961 48.3902
+      vertex -49.5562 0.805872 48.3902
+      vertex -49.4112 0.588815 48.1308
+    endloop
+  endfacet
+  facet normal -0.653741 -0.745403 0.130374
+    outer loop
+      vertex -49.387 0.612961 48.3902
+      vertex -49.4112 0.588815 48.1308
+      vertex -49.1941 0.443782 48.3902
+    endloop
+  endfacet
+  facet normal -0.383121 -0.777125 0.499295
+    outer loop
+      vertex -48.8315 0.559853 49.1111
+      vertex -48.8969 0.446571 48.8846
+      vertex -48.6864 0.342795 48.8846
+    endloop
+  endfacet
+  facet normal -0.481441 -0.720275 0.499418
+    outer loop
+      vertex -49.0123 0.680702 49.1111
+      vertex -49.092 0.576926 48.8846
+      vertex -48.8315 0.559853 49.1111
+    endloop
+  endfacet
+  facet normal -0.393128 -0.588675 0.706337
+    outer loop
+      vertex -48.6593 0.85798 49.5037
+      vertex -48.8028 0.953812 49.5037
+      vertex -48.7518 0.697776 49.3187
+    endloop
+  endfacet
+  facet normal -0.338438 -0.506781 0.792864
+    outer loop
+      vertex -48.6764 1.11847 49.6629
+      vertex -48.8028 0.953812 49.5037
+      vertex -48.6593 0.85798 49.5037
+    endloop
+  endfacet
+  facet normal -0.532303 -0.466673 0.706308
+    outer loop
+      vertex -49.0462 1.19723 49.5037
+      vertex -49.0633 0.936738 49.3187
+      vertex -48.9325 1.06754 49.5037
+    endloop
+  endfacet
+  facet normal -0.506691 -0.338773 0.792778
+    outer loop
+      vertex -48.9623 1.44443 49.6629
+      vertex -49.142 1.34065 49.5037
+      vertex -48.8815 1.32358 49.6629
+    endloop
+  endfacet
+  facet normal -0.71194 -0.351426 0.607981
+    outer loop
+      vertex -49.3892 1.42457 49.3187
+      vertex -49.5364 1.36362 49.1111
+      vertex -49.4401 1.16853 49.1111
+    endloop
+  endfacet
+  facet normal -0.58865 -0.3932 0.706318
+    outer loop
+      vertex -49.142 1.34065 49.5037
+      vertex -49.3022 1.24816 49.3187
+      vertex -49.0462 1.19723 49.5037
+    endloop
+  endfacet
+  facet normal -0.232563 -0.114808 0.965781
+    outer loop
+      vertex -48.3605 1.85069 49.9616
+      vertex -48.5939 1.75398 49.8939
+      vertex -48.3379 1.80491 49.9616
+    endloop
+  endfacet
+  facet normal -0.117135 -0.0578253 0.991431
+    outer loop
+      vertex -48.1133 1.9346 49.9957
+      vertex -48.3605 1.85069 49.9616
+      vertex -48.3379 1.80491 49.9616
+    endloop
+  endfacet
+  facet normal -0.13039 -0.00840238 0.991427
+    outer loop
+      vertex -48.1308 2 49.9957
+      vertex -48.3868 1.94907 49.9616
+      vertex -48.1297 1.98293 49.9957
+    endloop
+  endfacet
+  facet normal -0.130331 -0.00870067 0.991432
+    outer loop
+      vertex -48.1308 2 49.9957
+      vertex -48.3902 2 49.9616
+      vertex -48.3868 1.94907 49.9616
+    endloop
+  endfacet
+  facet normal -0.254312 -0.0505664 0.965799
+    outer loop
+      vertex -48.3769 1.89901 49.9616
+      vertex -48.6374 1.91609 49.8939
+      vertex -48.621 1.83361 49.8939
+    endloop
+  endfacet
+  facet normal -0.3633 -0.12364 0.923432
+    outer loop
+      vertex -48.621 1.83361 49.8939
+      vertex -48.8544 1.77106 49.7937
+      vertex -48.5939 1.75398 49.8939
+    endloop
+  endfacet
+  facet normal -0.245476 0.0835415 0.965796
+    outer loop
+      vertex -48.5939 3.24602 49.8939
+      vertex -48.621 3.16639 49.8939
+      vertex -48.3769 3.10099 49.9616
+    endloop
+  endfacet
+  facet normal -0.108679 0.0724696 0.991432
+    outer loop
+      vertex -48.3096 3.23753 49.9616
+      vertex -48.3379 3.19509 49.9616
+      vertex -48.1133 3.0654 49.9957
+    endloop
+  endfacet
+  facet normal -0.258743 0.0169597 0.965797
+    outer loop
+      vertex -48.6374 3.08391 49.8939
+      vertex -48.6429 3 49.8939
+      vertex -48.3902 3 49.9616
+    endloop
+  endfacet
+  facet normal -0.123523 0.0426729 0.991424
+    outer loop
+      vertex -48.1208 3.05006 49.9957
+      vertex -48.3769 3.10099 49.9616
+      vertex -48.1264 3.03385 49.9957
+    endloop
+  endfacet
+  facet normal -0.117135 0.0578253 0.991431
+    outer loop
+      vertex -48.3379 3.19509 49.9616
+      vertex -48.3605 3.14931 49.9616
+      vertex -48.1133 3.0654 49.9957
+    endloop
+  endfacet
+  facet normal -0.0981186 0.0862162 0.991433
+    outer loop
+      vertex -48.0925 3.09249 49.9957
+      vertex -48.2759 3.2759 49.9616
+      vertex -48.1038 3.07963 49.9957
+    endloop
+  endfacet
+  facet normal 0.0648493 0.989358 0.130249
+    outer loop
+      vertex 48 4.99572 48.1308
+      vertex 48 4.96157 48.3902
+      vertex 48.256 4.94479 48.3902
+    endloop
+  endfacet
+  facet normal 0.0566898 0.864566 0.499311
+    outer loop
+      vertex 48 4.79375 48.8846
+      vertex 48 4.66294 49.1111
+      vertex 48.2341 4.7784 48.8846
+    endloop
+  endfacet
+  facet normal 0.0398853 0.608136 0.79283
+    outer loop
+      vertex 48 4.31869 49.5037
+      vertex 48 4.11114 49.6629
+      vertex 48.145 4.10163 49.6629
+    endloop
+  endfacet
+  facet normal 0.0327752 0.499727 0.865563
+    outer loop
+      vertex 48.145 4.10163 49.6629
+      vertex 48 4.11114 49.6629
+      vertex 48.1155 3.87701 49.7937
+    endloop
+  endfacet
+  facet normal 0.670259 0.227742 0.706319
+    outer loop
+      vertex 49.3892 3.57543 49.3187
+      vertex 49.2183 3.50464 49.5037
+      vertex 49.2738 3.3413 49.5037
+    endloop
+  endfacet
+  facet normal 0.660116 0.44118 0.607953
+    outer loop
+      vertex 49.3193 4.01233 49.1111
+      vertex 49.1929 3.91538 49.3187
+      vertex 49.3022 3.75184 49.3187
+    endloop
+  endfacet
+  facet normal 0.636888 0.726412 0.258261
+    outer loop
+      vertex 49.1941 4.55622 48.3902
+      vertex 49.1529 4.5025 48.6429
+      vertex 49.3392 4.33916 48.6429
+    endloop
+  endfacet
+  facet normal 0.408649 0.828955 0.38189
+    outer loop
+      vertex 48.9469 4.64013 48.6429
+      vertex 48.6864 4.6572 48.8846
+      vertex 48.8969 4.55343 48.8846
+    endloop
+  endfacet
+  facet normal 0.278469 0.820432 0.499345
+    outer loop
+      vertex 48.4643 4.73263 48.8846
+      vertex 48.4304 4.60628 49.1111
+      vertex 48.6364 4.53636 49.1111
+    endloop
+  endfacet
+  facet normal 0.313118 0.634873 0.706324
+    outer loop
+      vertex 48.7518 4.30222 49.3187
+      vertex 48.5754 4.38922 49.3187
+      vertex 48.6593 4.14202 49.5037
+    endloop
+  endfacet
+  facet normal 0.466722 0.53226 0.706307
+    outer loop
+      vertex 49.0633 4.06326 49.3187
+      vertex 48.8028 4.04619 49.5037
+      vertex 48.9325 3.93246 49.5037
+    endloop
+  endfacet
+  facet normal 0.338431 0.506781 0.792866
+    outer loop
+      vertex 48.8028 4.04619 49.5037
+      vertex 48.6593 4.14202 49.5037
+      vertex 48.6764 3.88153 49.6629
+    endloop
+  endfacet
+  facet normal 0.227586 0.670302 0.706329
+    outer loop
+      vertex 48.3892 4.45244 49.3187
+      vertex 48.3413 4.27376 49.5037
+      vertex 48.5754 4.38922 49.3187
+    endloop
+  endfacet
+  facet normal 0.255289 0.751895 0.607849
+    outer loop
+      vertex 48.4304 4.60628 49.1111
+      vertex 48.3892 4.45244 49.3187
+      vertex 48.5754 4.38922 49.3187
+    endloop
+  endfacet
+  facet normal 0.269492 0.546699 0.792776
+    outer loop
+      vertex 48.6593 4.14202 49.5037
+      vertex 48.4252 4.02656 49.6629
+      vertex 48.5556 3.96228 49.6629
+    endloop
+  endfacet
+  facet normal 0.26956 0.546612 0.792813
+    outer loop
+      vertex 48.5046 4.21831 49.5037
+      vertex 48.4252 4.02656 49.6629
+      vertex 48.6593 4.14202 49.5037
+    endloop
+  endfacet
+  facet normal 0.0254711 -0.128118 0.991432
+    outer loop
+      vertex 48.0339 1.87365 49.9957
+      vertex 48.0171 1.87031 49.9957
+      vertex 48.101 1.62311 49.9616
+    endloop
+  endfacet
+  facet normal 0.170862 -0.194981 0.96581
+    outer loop
+      vertex 48.2759 1.7241 49.9616
+      vertex 48.2375 1.69045 49.9616
+      vertex 48.3914 1.48997 49.8939
+    endloop
+  endfacet
+  facet normal 0.195016 -0.170893 0.965797
+    outer loop
+      vertex 48.51 1.60864 49.8939
+      vertex 48.2759 1.7241 49.9616
+      vertex 48.4546 1.54542 49.8939
+    endloop
+  endfacet
+  facet normal 0.144138 -0.215495 0.965809
+    outer loop
+      vertex 48.2375 1.69045 49.9616
+      vertex 48.1951 1.66209 49.9616
+      vertex 48.3914 1.48997 49.8939
+    endloop
+  endfacet
+  facet normal 0.0169781 -0.258738 0.965798
+    outer loop
+      vertex 48.0509 1.61316 49.9616
+      vertex 48 1.60982 49.9616
+      vertex 48.0839 1.36262 49.8939
+    endloop
+  endfacet
+  facet normal 0.0169617 -0.258743 0.965797
+    outer loop
+      vertex 48 1.60982 49.9616
+      vertex 48 1.35712 49.8939
+      vertex 48.0839 1.36262 49.8939
+    endloop
+  endfacet
+  facet normal 0.11462 -0.232591 0.965797
+    outer loop
+      vertex 48.1951 1.66209 49.9616
+      vertex 48.1493 1.63952 49.9616
+      vertex 48.246 1.40606 49.8939
+    endloop
+  endfacet
+  facet normal 0.0834146 -0.245516 0.965797
+    outer loop
+      vertex 48.1493 1.63952 49.9616
+      vertex 48.101 1.62311 49.9616
+      vertex 48.246 1.40606 49.8939
+    endloop
+  endfacet
+  facet normal -0.215653 -0.144036 0.965788
+    outer loop
+      vertex -48.3379 1.80491 49.9616
+      vertex -48.5567 1.67856 49.8939
+      vertex -48.51 1.60864 49.8939
+    endloop
+  endfacet
+  facet normal -0.232583 -0.114719 0.965787
+    outer loop
+      vertex -48.3379 1.80491 49.9616
+      vertex -48.5939 1.75398 49.8939
+      vertex -48.5567 1.67856 49.8939
+    endloop
+  endfacet
+  facet normal -0.330173 -0.376543 0.865564
+    outer loop
+      vertex -48.6255 1.37451 49.7937
+      vertex -48.7857 1.21431 49.6629
+      vertex -48.6764 1.11847 49.6629
+    endloop
+  endfacet
+  facet normal -0.213009 -0.319148 0.923456
+    outer loop
+      vertex -48.3914 1.48997 49.8939
+      vertex -48.5385 1.29822 49.7937
+      vertex -48.3214 1.44325 49.8939
+    endloop
+  endfacet
+  facet normal -0.252976 -0.28849 0.923459
+    outer loop
+      vertex -48.3914 1.48997 49.8939
+      vertex -48.6255 1.37451 49.7937
+      vertex -48.5385 1.29822 49.7937
+    endloop
+  endfacet
+  facet normal -0.253029 -0.288394 0.923474
+    outer loop
+      vertex -48.4546 1.54542 49.8939
+      vertex -48.6255 1.37451 49.7937
+      vertex -48.3914 1.48997 49.8939
+    endloop
+  endfacet
+  facet normal -0.338735 -0.506739 0.792764
+    outer loop
+      vertex -48.5556 1.03772 49.6629
+      vertex -48.6764 1.11847 49.6629
+      vertex -48.6593 0.85798 49.5037
+    endloop
+  endfacet
+  facet normal -0.351167 -0.71213 0.607909
+    outer loop
+      vertex -48.5754 0.610782 49.3187
+      vertex -48.8315 0.559853 49.1111
+      vertex -48.6364 0.463645 49.1111
+    endloop
+  endfacet
+  facet normal -0.0169781 -0.258738 0.965798
+    outer loop
+      vertex -48.0509 1.61316 49.9616
+      vertex -48.0839 1.36262 49.8939
+      vertex -48 1.60982 49.9616
+    endloop
+  endfacet
+  facet normal -0.0748487 -0.376296 0.923471
+    outer loop
+      vertex -48.1664 1.37903 49.8939
+      vertex -48.2289 1.14556 49.7937
+      vertex -48.0839 1.36262 49.8939
+    endloop
+  endfacet
+  facet normal -0.138078 -0.694268 0.706348
+    outer loop
+      vertex -48.1721 0.692591 49.5037
+      vertex -48.3413 0.726242 49.5037
+      vertex -48.1963 0.509185 49.3187
+    endloop
+  endfacet
+  facet normal -0.297157 -0.8751 0.381966
+    outer loop
+      vertex -48.4643 0.267375 48.8846
+      vertex -48.7247 0.250301 48.6429
+      vertex -48.4902 0.170672 48.6429
+    endloop
+  endfacet
+  facet normal 0.169626 -0.344093 0.923486
+    outer loop
+      vertex 48.4423 1.23393 49.7937
+      vertex 48.3214 1.44325 49.8939
+      vertex 48.3385 1.18276 49.7937
+    endloop
+  endfacet
+  facet normal 0.221423 -0.449163 0.865577
+    outer loop
+      vertex 48.4423 1.23393 49.7937
+      vertex 48.3385 1.18276 49.7937
+      vertex 48.5556 1.03772 49.6629
+    endloop
+  endfacet
+  facet normal -0.128203 -0.0252128 0.991427
+    outer loop
+      vertex -48.1297 1.98293 49.9957
+      vertex -48.3769 1.89901 49.9616
+      vertex -48.1264 1.96615 49.9957
+    endloop
+  endfacet
+  facet normal -0.108632 -0.0725231 0.991433
+    outer loop
+      vertex -48.1133 1.9346 49.9957
+      vertex -48.3096 1.76247 49.9616
+      vertex -48.1038 1.92037 49.9957
+    endloop
+  endfacet
+  facet normal -0.194878 -0.17116 0.965778
+    outer loop
+      vertex -48.3096 1.76247 49.9616
+      vertex -48.51 1.60864 49.8939
+      vertex -48.2759 1.7241 49.9616
+    endloop
+  endfacet
+  facet normal -0.0505091 -0.254322 0.9658
+    outer loop
+      vertex -48.0509 1.61316 49.9616
+      vertex -48.101 1.62311 49.9616
+      vertex -48.0839 1.36262 49.8939
+    endloop
+  endfacet
+  facet normal -0.11462 -0.232591 0.965797
+    outer loop
+      vertex -48.1951 1.66209 49.9616
+      vertex -48.246 1.40606 49.8939
+      vertex -48.1493 1.63952 49.9616
+    endloop
+  endfacet
+  facet normal -0.0726313 -0.108565 0.991432
+    outer loop
+      vertex -48.0796 1.89622 49.9957
+      vertex -48.2375 1.69045 49.9616
+      vertex -48.0654 1.88672 49.9957
+    endloop
+  endfacet
+  facet normal -0.0860872 -0.0982392 0.991432
+    outer loop
+      vertex -48.0796 1.89622 49.9957
+      vertex -48.2759 1.7241 49.9616
+      vertex -48.2375 1.69045 49.9616
+    endloop
+  endfacet
+  facet normal -0.0419945 -0.123693 0.991432
+    outer loop
+      vertex -48.0501 1.87915 49.9957
+      vertex -48.101 1.62311 49.9616
+      vertex -48.0339 1.87365 49.9957
+    endloop
+  endfacet
+  facet normal -0.114712 -0.232571 0.965791
+    outer loop
+      vertex -48.1951 1.66209 49.9616
+      vertex -48.3214 1.44325 49.8939
+      vertex -48.246 1.40606 49.8939
+    endloop
+  endfacet
+  facet normal -0.0976671 -0.49116 0.865577
+    outer loop
+      vertex -48.2289 1.14556 49.7937
+      vertex -48.2876 0.926722 49.6629
+      vertex -48.145 0.898366 49.6629
+    endloop
+  endfacet
+  facet normal -0.00855315 -0.130346 0.991432
+    outer loop
+      vertex -48 1.86919 49.9957
+      vertex -48.0509 1.61316 49.9616
+      vertex -48 1.60982 49.9616
+    endloop
+  endfacet
+  facet normal -0.0726313 0.108565 0.991432
+    outer loop
+      vertex -48.0654 3.11328 49.9957
+      vertex -48.2375 3.30955 49.9616
+      vertex -48.0796 3.10378 49.9957
+    endloop
+  endfacet
+  facet normal -0.0860872 0.0982392 0.991432
+    outer loop
+      vertex -48.2375 3.30955 49.9616
+      vertex -48.2759 3.2759 49.9616
+      vertex -48.0796 3.10378 49.9957
+    endloop
+  endfacet
+  facet normal -0.0419945 0.123693 0.991432
+    outer loop
+      vertex -48.0339 3.12635 49.9957
+      vertex -48.101 3.37689 49.9616
+      vertex -48.0501 3.12085 49.9957
+    endloop
+  endfacet
+  facet normal -0.0834146 0.245516 0.965797
+    outer loop
+      vertex -48.101 3.37689 49.9616
+      vertex -48.246 3.59394 49.8939
+      vertex -48.1493 3.36048 49.9616
+    endloop
+  endfacet
+  facet normal -0.11462 0.232591 0.965797
+    outer loop
+      vertex -48.1493 3.36048 49.9616
+      vertex -48.246 3.59394 49.8939
+      vertex -48.1951 3.33791 49.9616
+    endloop
+  endfacet
+  facet normal 0.0419945 0.123693 0.991432
+    outer loop
+      vertex 48.101 3.37689 49.9616
+      vertex 48.0339 3.12635 49.9957
+      vertex 48.0501 3.12085 49.9957
+    endloop
+  endfacet
+  facet normal 0.0726213 0.108573 0.991432
+    outer loop
+      vertex 48.1951 3.33791 49.9616
+      vertex 48.0654 3.11328 49.9957
+      vertex 48.2375 3.30955 49.9616
+    endloop
+  endfacet
+  facet normal 0.0748893 0.376272 0.923478
+    outer loop
+      vertex 48.1155 3.87701 49.7937
+      vertex 48.0839 3.63738 49.8939
+      vertex 48.2289 3.85444 49.7937
+    endloop
+  endfacet
+  facet normal 0.0250966 0.382837 0.923475
+    outer loop
+      vertex 48.1155 3.87701 49.7937
+      vertex 48 3.64288 49.8939
+      vertex 48.0839 3.63738 49.8939
+    endloop
+  endfacet
+  facet normal 0.171006 0.194906 0.965799
+    outer loop
+      vertex 48.3914 3.51003 49.8939
+      vertex 48.2759 3.2759 49.9616
+      vertex 48.4546 3.45458 49.8939
+    endloop
+  endfacet
+  facet normal 0.194878 0.17116 0.965778
+    outer loop
+      vertex 48.51 3.39136 49.8939
+      vertex 48.2759 3.2759 49.9616
+      vertex 48.3096 3.23753 49.9616
+    endloop
+  endfacet
+  facet normal 0.169626 0.344093 0.923486
+    outer loop
+      vertex 48.3385 3.81724 49.7937
+      vertex 48.3214 3.55675 49.8939
+      vertex 48.4423 3.76607 49.7937
+    endloop
+  endfacet
+  facet normal 0.169714 0.344082 0.923474
+    outer loop
+      vertex 48.3385 3.81724 49.7937
+      vertex 48.246 3.59394 49.8939
+      vertex 48.3214 3.55675 49.8939
+    endloop
+  endfacet
+  facet normal 0.0976467 0.491161 0.865578
+    outer loop
+      vertex 48.2876 4.07328 49.6629
+      vertex 48.145 4.10163 49.6629
+      vertex 48.2289 3.85444 49.7937
+    endloop
+  endfacet
+  facet normal 0.118837 0.597748 0.792827
+    outer loop
+      vertex 48.3413 4.27376 49.5037
+      vertex 48.145 4.10163 49.6629
+      vertex 48.2876 4.07328 49.6629
+    endloop
+  endfacet
+  facet normal 0.128203 0.0252128 0.991427
+    outer loop
+      vertex 48.3769 3.10099 49.9616
+      vertex 48.1264 3.03385 49.9957
+      vertex 48.1297 3.01707 49.9957
+    endloop
+  endfacet
+  facet normal 0.168966 0.849812 -0.49927
+    outer loop
+      vertex 48.4643 4.73263 -58.8846
+      vertex 48.2171 4.64871 -59.1111
+      vertex 48.2341 4.7784 -58.8846
+    endloop
+  endfacet
+  facet normal 0.0566694 0.864577 -0.499295
+    outer loop
+      vertex 48.2171 4.64871 -59.1111
+      vertex 48 4.66294 -59.1111
+      vertex 48.2341 4.7784 -58.8846
+    endloop
+  endfacet
+  facet normal 0.523481 0.597097 -0.607818
+    outer loop
+      vertex 49.0633 4.06326 -59.3187
+      vertex 49.0123 4.3193 -59.1111
+      vertex 49.1759 4.17587 -59.1111
+    endloop
+  endfacet
+  facet normal 0.597056 0.523528 -0.607818
+    outer loop
+      vertex 49.3193 4.01233 -59.1111
+      vertex 49.0633 4.06326 -59.3187
+      vertex 49.1759 4.17587 -59.1111
+    endloop
+  endfacet
+  facet normal 0.313086 0.634873 -0.706338
+    outer loop
+      vertex 48.6593 4.14202 -59.5037
+      vertex 48.5046 4.21831 -59.5037
+      vertex 48.5754 4.38922 -59.3187
+    endloop
+  endfacet
+  facet normal 0.0327521 0.499719 -0.865568
+    outer loop
+      vertex 48.1155 3.87701 -59.7937
+      vertex 48 3.88458 -59.7937
+      vertex 48 4.11114 -59.6629
+    endloop
+  endfacet
+  facet normal 0.169714 0.344082 -0.923474
+    outer loop
+      vertex 48.3214 3.55675 -59.8939
+      vertex 48.246 3.59394 -59.8939
+      vertex 48.3385 3.81724 -59.7937
+    endloop
+  endfacet
+  facet normal 0.34412 0.169441 -0.92351
+    outer loop
+      vertex 48.8172 3.33851 -59.7937
+      vertex 48.5567 3.32144 -59.8939
+      vertex 48.7661 3.44229 -59.7937
+    endloop
+  endfacet
+  facet normal 0.376568 0.330147 -0.865563
+    outer loop
+      vertex 48.8815 3.67642 -59.6629
+      vertex 48.6255 3.62549 -59.7937
+      vertex 48.7857 3.78569 -59.6629
+    endloop
+  endfacet
+  facet normal 0.416373 0.278275 -0.865561
+    outer loop
+      vertex 48.7661 3.44229 -59.7937
+      vertex 48.7018 3.5385 -59.7937
+      vertex 48.9623 3.55557 -59.6629
+    endloop
+  endfacet
+  facet normal 0.319 0.213062 -0.923495
+    outer loop
+      vertex 48.5567 3.32144 -59.8939
+      vertex 48.51 3.39136 -59.8939
+      vertex 48.7018 3.5385 -59.7937
+    endloop
+  endfacet
+  facet normal 0.506691 0.338773 -0.792778
+    outer loop
+      vertex 48.9623 3.55557 -59.6629
+      vertex 48.8815 3.67642 -59.6629
+      vertex 49.142 3.65935 -59.5037
+    endloop
+  endfacet
+  facet normal 0.195943 0.577093 -0.792824
+    outer loop
+      vertex 48.4252 4.02656 -59.6629
+      vertex 48.2876 4.07328 -59.6629
+      vertex 48.3413 4.27376 -59.5037
+    endloop
+  endfacet
+  facet normal 0.195958 0.577094 -0.79282
+    outer loop
+      vertex 48.4252 4.02656 -59.6629
+      vertex 48.3413 4.27376 -59.5037
+      vertex 48.5046 4.21831 -59.5037
+    endloop
+  endfacet
+  facet normal 0.0462969 0.706356 -0.706341
+    outer loop
+      vertex 48.1721 4.30741 -59.5037
+      vertex 48 4.31869 -59.5037
+      vertex 48.1963 4.49082 -59.3187
+    endloop
+  endfacet
+  facet normal 0.255289 0.751895 -0.607849
+    outer loop
+      vertex 48.5754 4.38922 -59.3187
+      vertex 48.3892 4.45244 -59.3187
+      vertex 48.4304 4.60628 -59.1111
+    endloop
+  endfacet
+  facet normal 0.138136 0.694278 -0.706326
+    outer loop
+      vertex 48.3413 4.27376 -59.5037
+      vertex 48.1963 4.49082 -59.3187
+      vertex 48.3892 4.45244 -59.3187
+    endloop
+  endfacet
+  facet normal 0.138073 0.694261 -0.706355
+    outer loop
+      vertex 48.3413 4.27376 -59.5037
+      vertex 48.1721 4.30741 -59.5037
+      vertex 48.1963 4.49082 -59.3187
+    endloop
+  endfacet
+  facet normal -0.0327521 0.499719 -0.865568
+    outer loop
+      vertex -48 3.88458 -59.7937
+      vertex -48.1155 3.87701 -59.7937
+      vertex -48 4.11114 -59.6629
+    endloop
+  endfacet
+  facet normal 0.383104 0.777137 -0.499289
+    outer loop
+      vertex 48.8315 4.44015 -59.1111
+      vertex 48.6864 4.6572 -58.8846
+      vertex 48.8969 4.55343 -58.8846
+    endloop
+  endfacet
+  facet normal 0.383228 0.77713 -0.499204
+    outer loop
+      vertex 48.8315 4.44015 -59.1111
+      vertex 48.6364 4.53636 -59.1111
+      vertex 48.6864 4.6572 -58.8846
+    endloop
+  endfacet
+  facet normal 0.523561 0.597075 -0.607772
+    outer loop
+      vertex 49.0633 4.06326 -59.3187
+      vertex 48.9154 4.19295 -59.3187
+      vertex 49.0123 4.3193 -59.1111
+    endloop
+  endfacet
+  facet normal 0.441059 0.660358 -0.607778
+    outer loop
+      vertex 48.9154 4.19295 -59.3187
+      vertex 48.7518 4.30222 -59.3187
+      vertex 49.0123 4.3193 -59.1111
+    endloop
+  endfacet
+  facet normal 0.651436 -0.571205 0.499356
+    outer loop
+      vertex 49.3193 0.987667 49.1111
+      vertex 49.1759 0.824125 49.1111
+      vertex 49.4231 0.908037 48.8846
+    endloop
+  endfacet
+  facet normal 0.651417 -0.571263 0.499314
+    outer loop
+      vertex 49.4231 0.908037 48.8846
+      vertex 49.1759 0.824125 49.1111
+      vertex 49.2684 0.731631 48.8846
+    endloop
+  endfacet
+  facet normal 0.466716 -0.532262 0.70631
+    outer loop
+      vertex 48.9325 1.06754 49.5037
+      vertex 48.8028 0.953812 49.5037
+      vertex 49.0633 0.936738 49.3187
+    endloop
+  endfacet
+  facet normal 0.523465 -0.597106 0.607823
+    outer loop
+      vertex 49.0633 0.936738 49.3187
+      vertex 49.0123 0.680702 49.1111
+      vertex 49.1759 0.824125 49.1111
+    endloop
+  endfacet
+  facet normal 0.776999 -0.383541 0.499168
+    outer loop
+      vertex 49.5364 1.36362 49.1111
+      vertex 49.4401 1.16853 49.1111
+      vertex 49.6572 1.31356 48.8846
+    endloop
+  endfacet
+  facet normal 0.720485 -0.481202 0.499345
+    outer loop
+      vertex 49.4401 1.16853 49.1111
+      vertex 49.4231 0.908037 48.8846
+      vertex 49.5534 1.10313 48.8846
+    endloop
+  endfacet
+  facet normal 0.74538 -0.653764 0.130393
+    outer loop
+      vertex 49.5562 0.805872 48.3902
+      vertex 49.387 0.612961 48.3902
+      vertex 49.4112 0.588815 48.1308
+    endloop
+  endfacet
+  facet normal 0.726328 -0.637054 0.25809
+    outer loop
+      vertex 49.5562 0.805872 48.3902
+      vertex 49.3392 0.660839 48.6429
+      vertex 49.387 0.612961 48.3902
+    endloop
+  endfacet
+  facet normal 0.536685 -0.803287 0.25826
+    outer loop
+      vertex 49.1529 0.4975 48.6429
+      vertex 48.9469 0.359869 48.6429
+      vertex 49.1941 0.443782 48.3902
+    endloop
+  endfacet
+  facet normal 0.636887 -0.726415 0.258256
+    outer loop
+      vertex 49.3392 0.660839 48.6429
+      vertex 49.1529 0.4975 48.6429
+      vertex 49.1941 0.443782 48.3902
+    endloop
+  endfacet
+  facet normal 0.44122 -0.660101 0.60794
+    outer loop
+      vertex 49.0123 0.680702 49.1111
+      vertex 48.7518 0.697776 49.3187
+      vertex 48.8315 0.559853 49.1111
+    endloop
+  endfacet
+  facet normal 0.481441 -0.720275 0.499418
+    outer loop
+      vertex 49.0123 0.680702 49.1111
+      vertex 48.8315 0.559853 49.1111
+      vertex 49.092 0.576926 48.8846
+    endloop
+  endfacet
+  facet normal -0.513447 -0.768467 0.381878
+    outer loop
+      vertex -48.8969 0.446571 48.8846
+      vertex -49.092 0.576926 48.8846
+      vertex -48.9469 0.359869 48.6429
+    endloop
+  endfacet
+  facet normal -0.313092 -0.634876 0.706333
+    outer loop
+      vertex -48.5046 0.781689 49.5037
+      vertex -48.6593 0.85798 49.5037
+      vertex -48.5754 0.610782 49.3187
+    endloop
+  endfacet
+  facet normal -0.13811 -0.694276 0.706333
+    outer loop
+      vertex -48.3413 0.726242 49.5037
+      vertex -48.3892 0.547558 49.3187
+      vertex -48.1963 0.509185 49.3187
+    endloop
+  endfacet
+  facet normal -0.922148 0.0602608 0.382114
+    outer loop
+      vertex -49.7784 3.23413 48.8846
+      vertex -49.8777 3.2472 48.6429
+      vertex -49.7937 3 48.8846
+    endloop
+  endfacet
+  facet normal -0.922077 0.0604274 0.38226
+    outer loop
+      vertex -49.8777 3.2472 48.6429
+      vertex -49.8939 3 48.6429
+      vertex -49.7937 3 48.8846
+    endloop
+  endfacet
+  facet normal 0.0977595 -0.49118 0.865555
+    outer loop
+      vertex 48.2289 1.14556 49.7937
+      vertex 48.1155 1.12299 49.7937
+      vertex 48.145 0.898366 49.6629
+    endloop
+  endfacet
+  facet normal 0.0327611 -0.499722 0.865566
+    outer loop
+      vertex 48.1155 1.12299 49.7937
+      vertex 48 0.88886 49.6629
+      vertex 48.145 0.898366 49.6629
+    endloop
+  endfacet
+  facet normal 0.0462902 -0.706372 0.706326
+    outer loop
+      vertex 48 0.681309 49.5037
+      vertex 48 0.496321 49.3187
+      vertex 48.1963 0.509185 49.3187
+    endloop
+  endfacet
+  facet normal 0.0519247 -0.792351 0.607851
+    outer loop
+      vertex 48 0.496321 49.3187
+      vertex 48 0.337061 49.1111
+      vertex 48.1963 0.509185 49.3187
+    endloop
+  endfacet
+  facet normal 0.803139 0.536806 0.258469
+    outer loop
+      vertex 49.6988 3.98078 48.3902
+      vertex 49.5562 4.19413 48.3902
+      vertex 49.6401 3.94693 48.6429
+    endloop
+  endfacet
+  facet normal 0.866341 0.42736 0.25849
+    outer loop
+      vertex 49.6988 3.98078 48.3902
+      vertex 49.6401 3.94693 48.6429
+      vertex 49.7497 3.72475 48.6429
+    endloop
+  endfacet
+  facet normal 0.889201 0.438657 0.130007
+    outer loop
+      vertex 49.7283 3.99786 48.1308
+      vertex 49.6988 3.98078 48.3902
+      vertex 49.8438 3.76373 48.1308
+    endloop
+  endfacet
+  facet normal 0.651419 0.571252 0.499325
+    outer loop
+      vertex 49.2684 4.26837 48.8846
+      vertex 49.1759 4.17587 49.1111
+      vertex 49.4231 4.09196 48.8846
+    endloop
+  endfacet
+  facet normal 0.694837 0.609327 0.381997
+    outer loop
+      vertex 49.3392 4.33916 48.6429
+      vertex 49.2684 4.26837 48.8846
+      vertex 49.4231 4.09196 48.8846
+    endloop
+  endfacet
+  facet normal 0.376531 0.33026 0.865536
+    outer loop
+      vertex 48.8815 3.67642 49.6629
+      vertex 48.6255 3.62549 49.7937
+      vertex 48.7018 3.5385 49.7937
+    endloop
+  endfacet
+  facet normal 0.376568 0.330147 0.865563
+    outer loop
+      vertex 48.7857 3.78569 49.6629
+      vertex 48.6255 3.62549 49.7937
+      vertex 48.8815 3.67642 49.6629
+    endloop
+  endfacet
+  facet normal 0.577082 0.195813 0.792864
+    outer loop
+      vertex 49.2738 3.3413 49.5037
+      vertex 49.0266 3.42521 49.6629
+      vertex 49.0733 3.28758 49.6629
+    endloop
+  endfacet
+  facet normal 0.491118 0.0975 0.86562
+    outer loop
+      vertex 49.0733 3.28758 49.6629
+      vertex 48.8544 3.22894 49.7937
+      vertex 49.1016 3.14503 49.6629
+    endloop
+  endfacet
+  facet normal 0.491187 -0.0978218 0.865544
+    outer loop
+      vertex 48.877 1.88454 49.7937
+      vertex 48.8544 1.77106 49.7937
+      vertex 49.1016 1.85497 49.6629
+    endloop
+  endfacet
+  facet normal 0.608528 0 0.793533
+    outer loop
+      vertex 49.1111 3 49.6629
+      vertex 49.3187 2 49.5037
+      vertex 49.3187 3 49.5037
+    endloop
+  endfacet
+  facet normal 0.608528 0 0.793533
+    outer loop
+      vertex 49.3187 2 49.5037
+      vertex 49.1111 3 49.6629
+      vertex 49.1111 2 49.6629
+    endloop
+  endfacet
+  facet normal 0.499816 -0.0328997 0.865507
+    outer loop
+      vertex 48.8846 2 49.7937
+      vertex 48.877 1.88454 49.7937
+      vertex 49.1111 2 49.6629
+    endloop
+  endfacet
+  facet normal 0.500086 0 0.865975
+    outer loop
+      vertex 48.8846 3 49.7937
+      vertex 49.1111 2 49.6629
+      vertex 49.1111 3 49.6629
+    endloop
+  endfacet
+  facet normal 0.500086 0 0.865975
+    outer loop
+      vertex 49.1111 2 49.6629
+      vertex 48.8846 3 49.7937
+      vertex 48.8846 2 49.7937
+    endloop
+  endfacet
+  facet normal 0.597744 -0.118668 0.792855
+    outer loop
+      vertex 49.1016 1.85497 49.6629
+      vertex 49.0733 1.71242 49.6629
+      vertex 49.2738 1.6587 49.5037
+    endloop
+  endfacet
+  facet normal 0.597714 -0.118709 0.792872
+    outer loop
+      vertex 49.3074 1.82788 49.5037
+      vertex 49.1016 1.85497 49.6629
+      vertex 49.2738 1.6587 49.5037
+    endloop
+  endfacet
+  facet normal 0.608082 0.0399217 0.79287
+    outer loop
+      vertex 49.3074 3.17212 49.5037
+      vertex 49.1016 3.14503 49.6629
+      vertex 49.3187 3 49.5037
+    endloop
+  endfacet
+  facet normal 0.706374 0.0463748 0.706318
+    outer loop
+      vertex 49.4908 3.19627 49.3187
+      vertex 49.3074 3.17212 49.5037
+      vertex 49.3187 3 49.5037
+    endloop
+  endfacet
+  facet normal 0.588625 0.3934 0.706227
+    outer loop
+      vertex 49.1929 3.91538 49.3187
+      vertex 49.0462 3.80277 49.5037
+      vertex 49.3022 3.75184 49.3187
+    endloop
+  endfacet
+  facet normal 0.506691 0.338773 0.792778
+    outer loop
+      vertex 49.142 3.65935 49.5037
+      vertex 48.8815 3.67642 49.6629
+      vertex 48.9623 3.55557 49.6629
+    endloop
+  endfacet
+  facet normal 0.3633 0.12364 0.923432
+    outer loop
+      vertex 48.8544 3.22894 49.7937
+      vertex 48.5939 3.24602 49.8939
+      vertex 48.621 3.16639 49.8939
+    endloop
+  endfacet
+  facet normal 0.474141 0.160884 0.865625
+    outer loop
+      vertex 49.0266 3.42521 49.6629
+      vertex 48.8544 3.22894 49.7937
+      vertex 49.0733 3.28758 49.6629
+    endloop
+  endfacet
+  facet normal 0.82882 0.408837 0.381982
+    outer loop
+      vertex 49.6401 3.94693 48.6429
+      vertex 49.5534 3.89687 48.8846
+      vertex 49.6572 3.68644 48.8846
+    endloop
+  endfacet
+  facet normal 0.778811 0.154784 0.607862
+    outer loop
+      vertex 49.6063 3.4304 49.1111
+      vertex 49.4908 3.19627 49.3187
+      vertex 49.6487 3.21706 49.1111
+    endloop
+  endfacet
+  facet normal 0.864592 0.0564996 0.499288
+    outer loop
+      vertex 49.7784 3.23413 48.8846
+      vertex 49.6629 3 49.1111
+      vertex 49.7937 3 48.8846
+    endloop
+  endfacet
+  facet normal 0.875161 0.296968 0.381972
+    outer loop
+      vertex 49.7497 3.72475 48.6429
+      vertex 49.7326 3.46426 48.8846
+      vertex 49.8293 3.49017 48.6429
+    endloop
+  endfacet
+  facet normal 0.90634 -0.180378 0.382115
+    outer loop
+      vertex 49.7784 1.76587 48.8846
+      vertex 49.7326 1.53574 48.8846
+      vertex 49.8777 1.7528 48.6429
+    endloop
+  endfacet
+  facet normal 0.922148 -0.0602608 0.382114
+    outer loop
+      vertex 49.7937 2 48.8846
+      vertex 49.7784 1.76587 48.8846
+      vertex 49.8777 1.7528 48.6429
+    endloop
+  endfacet
+  facet normal 0.906365 -0.180549 0.381976
+    outer loop
+      vertex 49.8777 1.7528 48.6429
+      vertex 49.7326 1.53574 48.8846
+      vertex 49.8293 1.50983 48.6429
+    endloop
+  endfacet
+  facet normal 0.875161 -0.296968 0.381972
+    outer loop
+      vertex 49.8293 1.50983 48.6429
+      vertex 49.7326 1.53574 48.8846
+      vertex 49.7497 1.27525 48.6429
+    endloop
+  endfacet
+  facet normal 0.778651 -0.154996 0.608012
+    outer loop
+      vertex 49.4908 1.80373 49.3187
+      vertex 49.4524 1.61082 49.3187
+      vertex 49.6063 1.5696 49.1111
+    endloop
+  endfacet
+  facet normal 0.660338 -0.441046 0.607809
+    outer loop
+      vertex 49.4401 1.16853 49.1111
+      vertex 49.3022 1.24816 49.3187
+      vertex 49.3193 0.987667 49.1111
+    endloop
+  endfacet
+  facet normal 0.777012 -0.383281 0.499347
+    outer loop
+      vertex 49.6572 1.31356 48.8846
+      vertex 49.4401 1.16853 49.1111
+      vertex 49.5534 1.10313 48.8846
+    endloop
+  endfacet
+  facet normal 0.82882 -0.408837 0.381982
+    outer loop
+      vertex 49.6572 1.31356 48.8846
+      vertex 49.5534 1.10313 48.8846
+      vertex 49.6401 1.05307 48.6429
+    endloop
+  endfacet
+  facet normal 0.376531 -0.33026 0.865536
+    outer loop
+      vertex 48.7018 1.4615 49.7937
+      vertex 48.6255 1.37451 49.7937
+      vertex 48.8815 1.32358 49.6629
+    endloop
+  endfacet
+  facet normal 0.288396 -0.252955 0.923494
+    outer loop
+      vertex 48.7018 1.4615 49.7937
+      vertex 48.51 1.60864 49.8939
+      vertex 48.6255 1.37451 49.7937
+    endloop
+  endfacet
+  facet normal 0.344087 -0.169717 0.923472
+    outer loop
+      vertex 48.5939 1.75398 49.8939
+      vertex 48.5567 1.67856 49.8939
+      vertex 48.8172 1.66149 49.7937
+    endloop
+  endfacet
+  facet normal 0.363296 -0.123342 0.923473
+    outer loop
+      vertex 48.8544 1.77106 49.7937
+      vertex 48.5939 1.75398 49.8939
+      vertex 48.8172 1.66149 49.7937
+    endloop
+  endfacet
+  facet normal 0.670259 -0.227742 0.706319
+    outer loop
+      vertex 49.2738 1.6587 49.5037
+      vertex 49.2183 1.49536 49.5037
+      vertex 49.3892 1.42457 49.3187
+    endloop
+  endfacet
+  facet normal 0.546628 -0.269624 0.79278
+    outer loop
+      vertex 49.0266 1.57479 49.6629
+      vertex 48.9623 1.44443 49.6629
+      vertex 49.142 1.34065 49.5037
+    endloop
+  endfacet
+  facet normal 0.634888 -0.313107 0.706315
+    outer loop
+      vertex 49.3892 1.42457 49.3187
+      vertex 49.142 1.34065 49.5037
+      vertex 49.3022 1.24816 49.3187
+    endloop
+  endfacet
+  facet normal 0.71219 -0.35123 0.607801
+    outer loop
+      vertex 49.3892 1.42457 49.3187
+      vertex 49.3022 1.24816 49.3187
+      vertex 49.4401 1.16853 49.1111
+    endloop
+  endfacet
+  facet normal 0.117298 -0.0573489 0.99144
+    outer loop
+      vertex 48.1208 1.94994 49.9957
+      vertex 48.1133 1.9346 49.9957
+      vertex 48.3605 1.85069 49.9616
+    endloop
+  endfacet
+  facet normal 0.13039 -0.00840238 0.991427
+    outer loop
+      vertex 48.1308 2 49.9957
+      vertex 48.1297 1.98293 49.9957
+      vertex 48.3868 1.94907 49.9616
+    endloop
+  endfacet
+  facet normal 0.820543 -0.278463 -0.499167
+    outer loop
+      vertex 49.6572 1.31356 -58.8846
+      vertex 49.5364 1.36362 -59.1111
+      vertex 49.7326 1.53574 -58.8846
+    endloop
+  endfacet
+  facet normal 0.849887 -0.16891 -0.499161
+    outer loop
+      vertex 49.7326 1.53574 -58.8846
+      vertex 49.6063 1.5696 -59.1111
+      vertex 49.6487 1.78294 -59.1111
+    endloop
+  endfacet
+  facet normal 0.80332 -0.536644 -0.258246
+    outer loop
+      vertex 49.5562 0.805872 -58.3902
+      vertex 49.5025 0.847092 -58.6429
+      vertex 49.6401 1.05307 -58.6429
+    endloop
+  endfacet
+  facet normal 0.726411 -0.636892 -0.258255
+    outer loop
+      vertex 49.5562 0.805872 -58.3902
+      vertex 49.3392 0.660839 -58.6429
+      vertex 49.5025 0.847092 -58.6429
+    endloop
+  endfacet
+  facet normal 0.90634 -0.180378 -0.382115
+    outer loop
+      vertex 49.8777 1.7528 -58.6429
+      vertex 49.7326 1.53574 -58.8846
+      vertex 49.7784 1.76587 -58.8846
+    endloop
+  endfacet
+  facet normal 0.906365 -0.180549 -0.381976
+    outer loop
+      vertex 49.8293 1.50983 -58.6429
+      vertex 49.7326 1.53574 -58.8846
+      vertex 49.8777 1.7528 -58.6429
+    endloop
+  endfacet
+  facet normal 0.351167 -0.71213 -0.607909
+    outer loop
+      vertex 48.6364 0.463645 -59.1111
+      vertex 48.5754 0.610782 -59.3187
+      vertex 48.8315 0.559853 -59.1111
+    endloop
+  endfacet
+  facet normal 0.383215 -0.77712 -0.49923
+    outer loop
+      vertex 48.6864 0.342795 -58.8846
+      vertex 48.6364 0.463645 -59.1111
+      vertex 48.8315 0.559853 -59.1111
+    endloop
+  endfacet
+  facet normal 0.393197 -0.588666 -0.706306
+    outer loop
+      vertex 48.9154 0.807052 -59.3187
+      vertex 48.7518 0.697776 -59.3187
+      vertex 48.8028 0.953812 -59.5037
+    endloop
+  endfacet
+  facet normal 0.466715 -0.532264 -0.706309
+    outer loop
+      vertex 48.9154 0.807052 -59.3187
+      vertex 48.8028 0.953812 -59.5037
+      vertex 49.0633 0.936738 -59.3187
+    endloop
+  endfacet
+  facet normal 0.776999 -0.383541 -0.499168
+    outer loop
+      vertex 49.6572 1.31356 -58.8846
+      vertex 49.4401 1.16853 -59.1111
+      vertex 49.5364 1.36362 -59.1111
+    endloop
+  endfacet
+  facet normal 0.777012 -0.383281 -0.499347
+    outer loop
+      vertex 49.5534 1.10313 -58.8846
+      vertex 49.4401 1.16853 -59.1111
+      vertex 49.6572 1.31356 -58.8846
+    endloop
+  endfacet
+  facet normal 0.751827 -0.255117 -0.608006
+    outer loop
+      vertex 49.6063 1.5696 -59.1111
+      vertex 49.3892 1.42457 -59.3187
+      vertex 49.4524 1.61082 -59.3187
+    endloop
+  endfacet
+  facet normal 0.694328 -0.137897 -0.706324
+    outer loop
+      vertex 49.4908 1.80373 -59.3187
+      vertex 49.2738 1.6587 -59.5037
+      vertex 49.3074 1.82788 -59.5037
+    endloop
+  endfacet
+  facet normal 0.506732 -0.338481 -0.792876
+    outer loop
+      vertex 49.0462 1.19723 -59.5037
+      vertex 48.8815 1.32358 -59.6629
+      vertex 49.142 1.34065 -59.5037
+    endloop
+  endfacet
+  facet normal 0.458218 -0.401723 -0.792878
+    outer loop
+      vertex 48.9325 1.06754 -59.5037
+      vertex 48.8815 1.32358 -59.6629
+      vertex 49.0462 1.19723 -59.5037
+    endloop
+  endfacet
+  facet normal 0.338438 -0.506781 -0.792864
+    outer loop
+      vertex 48.8028 0.953812 -59.5037
+      vertex 48.6593 0.85798 -59.5037
+      vertex 48.6764 1.11847 -59.6629
+    endloop
+  endfacet
+  facet normal 0.393128 -0.588675 -0.706337
+    outer loop
+      vertex 48.7518 0.697776 -59.3187
+      vertex 48.6593 0.85798 -59.5037
+      vertex 48.8028 0.953812 -59.5037
+    endloop
+  endfacet
+  facet normal -0.550937 -0.824318 -0.130266
+    outer loop
+      vertex -48.9979 0.271658 -58.1308
+      vertex -49.2149 0.416691 -58.1308
+      vertex -49.1941 0.443782 -58.3902
+    endloop
+  endfacet
+  facet normal -0.65367 -0.745483 -0.130271
+    outer loop
+      vertex -49.2149 0.416691 -58.1308
+      vertex -49.4112 0.588815 -58.1308
+      vertex -49.1941 0.443782 -58.3902
+    endloop
+  endfacet
+  facet normal -0.438563 -0.88923 0.130126
+    outer loop
+      vertex -48.7507 0.187746 48.3902
+      vertex -48.9808 0.30123 48.3902
+      vertex -48.7637 0.156198 48.1308
+    endloop
+  endfacet
+  facet normal -0.318673 -0.938886 0.130157
+    outer loop
+      vertex -48.7507 0.187746 48.3902
+      vertex -48.7637 0.156198 48.1308
+      vertex -48.5077 0.105268 48.3902
+    endloop
+  endfacet
+  facet normal -0.0566578 -0.864583 -0.499286
+    outer loop
+      vertex -48 0.337061 -59.1111
+      vertex -48.2341 0.221601 -58.8846
+      vertex -48.2171 0.351288 -59.1111
+    endloop
+  endfacet
+  facet normal -0.0566756 -0.864574 -0.4993
+    outer loop
+      vertex -48 0.206255 -58.8846
+      vertex -48.2341 0.221601 -58.8846
+      vertex -48 0.337061 -59.1111
+    endloop
+  endfacet
+  facet normal -0.118878 -0.597729 -0.792835
+    outer loop
+      vertex -48.1721 0.692591 -59.5037
+      vertex -48.3413 0.726242 -59.5037
+      vertex -48.145 0.898366 -59.6629
+    endloop
+  endfacet
+  facet normal -0.0398661 -0.608133 -0.792833
+    outer loop
+      vertex -48 0.681309 -59.5037
+      vertex -48.1721 0.692591 -59.5037
+      vertex -48.145 0.898366 -59.6629
+    endloop
+  endfacet
+  facet normal -0.195935 -0.577095 -0.792825
+    outer loop
+      vertex -48.3413 0.726242 -59.5037
+      vertex -48.4252 0.97344 -59.6629
+      vertex -48.2876 0.926722 -59.6629
+    endloop
+  endfacet
+  facet normal -0.123311 -0.363304 -0.923474
+    outer loop
+      vertex -48.2289 1.14556 -59.7937
+      vertex -48.3385 1.18276 -59.7937
+      vertex -48.246 1.40606 -59.8939
+    endloop
+  endfacet
+  facet normal -0.313092 -0.634876 -0.706333
+    outer loop
+      vertex -48.5754 0.610782 -59.3187
+      vertex -48.6593 0.85798 -59.5037
+      vertex -48.5046 0.781689 -59.5037
+    endloop
+  endfacet
+  facet normal -0.313097 -0.634876 -0.706331
+    outer loop
+      vertex -48.5754 0.610782 -59.3187
+      vertex -48.7518 0.697776 -59.3187
+      vertex -48.6593 0.85798 -59.5037
+    endloop
+  endfacet
+  facet normal -0.297157 -0.8751 -0.381966
+    outer loop
+      vertex -48.4902 0.170672 -58.6429
+      vertex -48.7247 0.250301 -58.6429
+      vertex -48.4643 0.267375 -58.8846
+    endloop
+  endfacet
+  facet normal -0.180277 -0.90642 -0.381972
+    outer loop
+      vertex -48.2472 0.122342 -58.6429
+      vertex -48.4902 0.170672 -58.6429
+      vertex -48.4643 0.267375 -58.8846
+    endloop
+  endfacet
+  facet normal -0.408667 -0.828943 -0.381896
+    outer loop
+      vertex -48.6864 0.342795 -58.8846
+      vertex -48.9469 0.359869 -58.6429
+      vertex -48.8969 0.446571 -58.8846
+    endloop
+  endfacet
+  facet normal -0.383121 -0.777125 -0.499295
+    outer loop
+      vertex -48.6864 0.342795 -58.8846
+      vertex -48.8969 0.446571 -58.8846
+      vertex -48.8315 0.559853 -59.1111
+    endloop
+  endfacet
+  facet normal -0.0726313 -0.108565 -0.991432
+    outer loop
+      vertex -48.0654 1.88672 -59.9957
+      vertex -48.2375 1.69045 -59.9616
+      vertex -48.0796 1.89622 -59.9957
+    endloop
+  endfacet
+  facet normal -0.170862 -0.194981 -0.96581
+    outer loop
+      vertex -48.2375 1.69045 -59.9616
+      vertex -48.3914 1.48997 -59.8939
+      vertex -48.2759 1.7241 -59.9616
+    endloop
+  endfacet
+  facet normal -0.130331 0.00870067 -0.991432
+    outer loop
+      vertex -48.1308 3 -59.9957
+      vertex -48.3902 3 -59.9616
+      vertex -48.3868 3.05093 -59.9616
+    endloop
+  endfacet
+  facet normal -0.13039 0.00840238 -0.991427
+    outer loop
+      vertex -48.1308 3 -59.9957
+      vertex -48.3868 3.05093 -59.9616
+      vertex -48.1297 3.01707 -59.9957
+    endloop
+  endfacet
+  facet normal -0.491187 -0.0978218 -0.865544
+    outer loop
+      vertex -48.8544 1.77106 -59.7937
+      vertex -49.1016 1.85497 -59.6629
+      vertex -48.877 1.88454 -59.7937
+    endloop
+  endfacet
+  facet normal -0.0748487 -0.376296 -0.923471
+    outer loop
+      vertex -48.0839 1.36262 -59.8939
+      vertex -48.2289 1.14556 -59.7937
+      vertex -48.1664 1.37903 -59.8939
+    endloop
+  endfacet
+  facet normal -0.123368 -0.363305 -0.923466
+    outer loop
+      vertex -48.2289 1.14556 -59.7937
+      vertex -48.246 1.40606 -59.8939
+      vertex -48.1664 1.37903 -59.8939
+    endloop
+  endfacet
+  facet normal -0.00855315 -0.130346 -0.991432
+    outer loop
+      vertex -48 1.60982 -59.9616
+      vertex -48.0509 1.61316 -59.9616
+      vertex -48 1.86919 -59.9957
+    endloop
+  endfacet
+  facet normal -0.0579371 -0.117099 -0.991429
+    outer loop
+      vertex -48.0501 1.87915 -59.9957
+      vertex -48.1493 1.63952 -59.9616
+      vertex -48.0654 1.88672 -59.9957
+    endloop
+  endfacet
+  facet normal -0.0834146 -0.245516 -0.965797
+    outer loop
+      vertex -48.101 1.62311 -59.9616
+      vertex -48.246 1.40606 -59.8939
+      vertex -48.1493 1.63952 -59.9616
+    endloop
+  endfacet
+  facet normal -0.0254711 -0.128118 -0.991432
+    outer loop
+      vertex -48.0171 1.87031 -59.9957
+      vertex -48.101 1.62311 -59.9616
+      vertex -48.0339 1.87365 -59.9957
+    endloop
+  endfacet
+  facet normal -0.128159 -0.025345 -0.99143
+    outer loop
+      vertex -48.3769 1.89901 -59.9616
+      vertex -48.3868 1.94907 -59.9616
+      vertex -48.1297 1.98293 -59.9957
+    endloop
+  endfacet
+  facet normal -0.13039 -0.00840238 -0.991427
+    outer loop
+      vertex -48.1297 1.98293 -59.9957
+      vertex -48.3868 1.94907 -59.9616
+      vertex -48.1308 2 -59.9957
+    endloop
+  endfacet
+  facet normal -0.288558 -0.252864 -0.923469
+    outer loop
+      vertex -48.4546 1.54542 -59.8939
+      vertex -48.6255 1.37451 -59.7937
+      vertex -48.51 1.60864 -59.8939
+    endloop
+  endfacet
+  facet normal -0.319 -0.213062 -0.923495
+    outer loop
+      vertex -48.51 1.60864 -59.8939
+      vertex -48.7018 1.4615 -59.7937
+      vertex -48.5567 1.67856 -59.8939
+    endloop
+  endfacet
+  facet normal -0.466715 -0.532264 -0.706309
+    outer loop
+      vertex -48.9154 0.807052 -59.3187
+      vertex -49.0633 0.936738 -59.3187
+      vertex -48.8028 0.953812 -59.5037
+    endloop
+  endfacet
+  facet normal -0.523551 -0.597082 -0.607772
+    outer loop
+      vertex -49.0123 0.680702 -59.1111
+      vertex -49.0633 0.936738 -59.3187
+      vertex -48.9154 0.807052 -59.3187
+    endloop
+  endfacet
+  facet normal -0.108679 -0.0724696 -0.991432
+    outer loop
+      vertex -48.3096 1.76247 -59.9616
+      vertex -48.3379 1.80491 -59.9616
+      vertex -48.1133 1.9346 -59.9957
+    endloop
+  endfacet
+  facet normal -0.108632 -0.0725231 -0.991433
+    outer loop
+      vertex -48.1038 1.92037 -59.9957
+      vertex -48.3096 1.76247 -59.9616
+      vertex -48.1133 1.9346 -59.9957
+    endloop
+  endfacet
+  facet normal -0.0726213 -0.108573 -0.991432
+    outer loop
+      vertex -48.1951 1.66209 -59.9616
+      vertex -48.2375 1.69045 -59.9616
+      vertex -48.0654 1.88672 -59.9957
+    endloop
+  endfacet
+  facet normal -0.144138 -0.215495 -0.965809
+    outer loop
+      vertex -48.1951 1.66209 -59.9616
+      vertex -48.3914 1.48997 -59.8939
+      vertex -48.2375 1.69045 -59.9616
+    endloop
+  endfacet
+  facet normal -0.123664 -0.041972 -0.991436
+    outer loop
+      vertex -48.3605 1.85069 -59.9616
+      vertex -48.3769 1.89901 -59.9616
+      vertex -48.1208 1.94994 -59.9957
+    endloop
+  endfacet
+  facet normal -0.123523 -0.0426729 -0.991424
+    outer loop
+      vertex -48.1208 1.94994 -59.9957
+      vertex -48.3769 1.89901 -59.9616
+      vertex -48.1264 1.96615 -59.9957
+    endloop
+  endfacet
+  facet normal -0.245476 -0.0835415 -0.965796
+    outer loop
+      vertex -48.5939 1.75398 -59.8939
+      vertex -48.621 1.83361 -59.8939
+      vertex -48.3769 1.89901 -59.9616
+    endloop
+  endfacet
+  facet normal -0.597744 -0.118668 -0.792855
+    outer loop
+      vertex -49.0733 1.71242 -59.6629
+      vertex -49.2738 1.6587 -59.5037
+      vertex -49.1016 1.85497 -59.6629
+    endloop
+  endfacet
+  facet normal -0.634888 -0.313115 -0.706312
+    outer loop
+      vertex -49.142 1.34065 -59.5037
+      vertex -49.3892 1.42457 -59.3187
+      vertex -49.2183 1.49536 -59.5037
+    endloop
+  endfacet
+  facet normal -0.670259 -0.227742 -0.706319
+    outer loop
+      vertex -49.2183 1.49536 -59.5037
+      vertex -49.3892 1.42457 -59.3187
+      vertex -49.2738 1.6587 -59.5037
+    endloop
+  endfacet
+  facet normal -0.449015 -0.221476 -0.865641
+    outer loop
+      vertex -48.9623 1.44443 -59.6629
+      vertex -49.0266 1.57479 -59.6629
+      vertex -48.8172 1.66149 -59.7937
+    endloop
+  endfacet
+  facet normal -0.449303 -0.221231 -0.865554
+    outer loop
+      vertex -48.7661 1.55771 -59.7937
+      vertex -48.9623 1.44443 -59.6629
+      vertex -48.8172 1.66149 -59.7937
+    endloop
+  endfacet
+  facet normal -0.499816 -0.0328997 -0.865507
+    outer loop
+      vertex -48.877 1.88454 -59.7937
+      vertex -49.1111 2 -59.6629
+      vertex -48.8846 2 -59.7937
+    endloop
+  endfacet
+  facet normal -0.382838 -0.0251998 -0.923472
+    outer loop
+      vertex -48.877 1.88454 -59.7937
+      vertex -48.8846 2 -59.7937
+      vertex -48.6429 2 -59.8939
+    endloop
+  endfacet
+  facet normal -0.864592 0.0564996 -0.499288
+    outer loop
+      vertex -49.6629 3 -59.1111
+      vertex -49.7937 3 -58.8846
+      vertex -49.7784 3.23413 -58.8846
+    endloop
+  endfacet
+  facet normal -0.793533 0 -0.608528
+    outer loop
+      vertex -49.5037 2 -59.3187
+      vertex -49.6629 3 -59.1111
+      vertex -49.5037 3 -59.3187
+    endloop
+  endfacet
+  facet normal -0.793533 -0 -0.608528
+    outer loop
+      vertex -49.6629 3 -59.1111
+      vertex -49.5037 2 -59.3187
+      vertex -49.6629 2 -59.1111
+    endloop
+  endfacet
+  facet normal -0.82881 -0.408847 -0.381993
+    outer loop
+      vertex -49.6401 1.05307 -58.6429
+      vertex -49.7497 1.27525 -58.6429
+      vertex -49.6572 1.31356 -58.8846
+    endloop
+  endfacet
+  facet normal -0.866341 -0.42736 -0.25849
+    outer loop
+      vertex -49.6988 1.01922 -58.3902
+      vertex -49.7497 1.27525 -58.6429
+      vertex -49.6401 1.05307 -58.6429
+    endloop
+  endfacet
+  facet normal -0.922148 -0.0602608 -0.382114
+    outer loop
+      vertex -49.7784 1.76587 -58.8846
+      vertex -49.8777 1.7528 -58.6429
+      vertex -49.7937 2 -58.8846
+    endloop
+  endfacet
+  facet normal -0.922077 -0.0604274 -0.38226
+    outer loop
+      vertex -49.8777 1.7528 -58.6429
+      vertex -49.8939 2 -58.6429
+      vertex -49.7937 2 -58.8846
+    endloop
+  endfacet
+  facet normal -0.195943 0.577093 -0.792824
+    outer loop
+      vertex -48.2876 4.07328 -59.6629
+      vertex -48.4252 4.02656 -59.6629
+      vertex -48.3413 4.27376 -59.5037
+    endloop
+  endfacet
+  facet normal -0.245596 0.0833562 -0.965782
+    outer loop
+      vertex -48.3769 3.10099 -59.9616
+      vertex -48.5939 3.24602 -59.8939
+      vertex -48.3605 3.14931 -59.9616
+    endloop
+  endfacet
+  facet normal 0.123311 0.363304 -0.923474
+    outer loop
+      vertex 48.246 3.59394 -59.8939
+      vertex 48.2289 3.85444 -59.7937
+      vertex 48.3385 3.81724 -59.7937
+    endloop
+  endfacet
+  facet normal 0.0748893 0.376272 -0.923478
+    outer loop
+      vertex 48.2289 3.85444 -59.7937
+      vertex 48.0839 3.63738 -59.8939
+      vertex 48.1155 3.87701 -59.7937
+    endloop
+  endfacet
+  facet normal 0.0860872 0.0982392 -0.991432
+    outer loop
+      vertex 48.2759 3.2759 -59.9616
+      vertex 48.0796 3.10378 -59.9957
+      vertex 48.2375 3.30955 -59.9616
+    endloop
+  endfacet
+  facet normal 0.00855315 0.130346 -0.991432
+    outer loop
+      vertex 48.0509 3.38684 -59.9616
+      vertex 48 3.13081 -59.9957
+      vertex 48 3.39018 -59.9616
+    endloop
+  endfacet
+  facet normal 0.123664 0.041972 -0.991436
+    outer loop
+      vertex 48.3769 3.10099 -59.9616
+      vertex 48.1208 3.05006 -59.9957
+      vertex 48.3605 3.14931 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0981411 0.0861964 -0.991433
+    outer loop
+      vertex 48.3096 3.23753 -59.9616
+      vertex 48.1038 3.07963 -59.9957
+      vertex 48.2759 3.2759 -59.9616
+    endloop
+  endfacet
+  facet normal 0.108632 0.0725231 -0.991433
+    outer loop
+      vertex 48.1133 3.0654 -59.9957
+      vertex 48.1038 3.07963 -59.9957
+      vertex 48.3096 3.23753 -59.9616
+    endloop
+  endfacet
+  facet normal 0.13039 -0.00840238 -0.991427
+    outer loop
+      vertex 48.3868 1.94907 -59.9616
+      vertex 48.1297 1.98293 -59.9957
+      vertex 48.1308 2 -59.9957
+    endloop
+  endfacet
+  facet normal 0.117298 -0.0573489 -0.99144
+    outer loop
+      vertex 48.3605 1.85069 -59.9616
+      vertex 48.1133 1.9346 -59.9957
+      vertex 48.1208 1.94994 -59.9957
+    endloop
+  endfacet
+  facet normal 0.0420229 -0.123687 -0.991431
+    outer loop
+      vertex 48.101 1.62311 -59.9616
+      vertex 48.0501 1.87915 -59.9957
+      vertex 48.1493 1.63952 -59.9616
+    endloop
+  endfacet
+  facet normal 0.382838 -0.0251998 -0.923472
+    outer loop
+      vertex 48.877 1.88454 -59.7937
+      vertex 48.6429 2 -59.8939
+      vertex 48.8846 2 -59.7937
+    endloop
+  endfacet
+  facet normal 0.376381 -0.0748381 -0.923437
+    outer loop
+      vertex 48.8544 1.77106 -59.7937
+      vertex 48.621 1.83361 -59.8939
+      vertex 48.6374 1.91609 -59.8939
+    endloop
+  endfacet
+  facet normal 0.258781 0 -0.965936
+    outer loop
+      vertex 48.3902 2 -59.9616
+      vertex 48.6429 3 -59.8939
+      vertex 48.6429 2 -59.8939
+    endloop
+  endfacet
+  facet normal 0.258781 0 -0.965936
+    outer loop
+      vertex 48.6429 3 -59.8939
+      vertex 48.3902 2 -59.9616
+      vertex 48.3902 3 -59.9616
+    endloop
+  endfacet
+  facet normal 0.258743 -0.0169597 -0.965797
+    outer loop
+      vertex 48.6374 1.91609 -59.8939
+      vertex 48.3902 2 -59.9616
+      vertex 48.6429 2 -59.8939
+    endloop
+  endfacet
+  facet normal 0.245476 0.0835415 -0.965796
+    outer loop
+      vertex 48.621 3.16639 -59.8939
+      vertex 48.3769 3.10099 -59.9616
+      vertex 48.5939 3.24602 -59.8939
+    endloop
+  endfacet
+  facet normal 0.363296 0.123342 -0.923473
+    outer loop
+      vertex 48.8544 3.22894 -59.7937
+      vertex 48.5939 3.24602 -59.8939
+      vertex 48.8172 3.33851 -59.7937
+    endloop
+  endfacet
+  facet normal 0.608045 -0.0398292 -0.792903
+    outer loop
+      vertex 49.3187 2 -59.5037
+      vertex 49.1016 1.85497 -59.6629
+      vertex 49.1111 2 -59.6629
+    endloop
+  endfacet
+  facet normal 0.608082 -0.0399217 -0.79287
+    outer loop
+      vertex 49.3074 1.82788 -59.5037
+      vertex 49.1016 1.85497 -59.6629
+      vertex 49.3187 2 -59.5037
+    endloop
+  endfacet
+  facet normal 0.546628 0.269624 -0.79278
+    outer loop
+      vertex 49.0266 3.42521 -59.6629
+      vertex 48.9623 3.55557 -59.6629
+      vertex 49.142 3.65935 -59.5037
+    endloop
+  endfacet
+  facet normal 0.449015 0.221476 -0.865641
+    outer loop
+      vertex 49.0266 3.42521 -59.6629
+      vertex 48.8172 3.33851 -59.7937
+      vertex 48.9623 3.55557 -59.6629
+    endloop
+  endfacet
+  facet normal 0.344087 -0.169717 -0.923472
+    outer loop
+      vertex 48.8172 1.66149 -59.7937
+      vertex 48.5567 1.67856 -59.8939
+      vertex 48.5939 1.75398 -59.8939
+    endloop
+  endfacet
+  facet normal 0.363296 -0.123342 -0.923473
+    outer loop
+      vertex 48.8172 1.66149 -59.7937
+      vertex 48.5939 1.75398 -59.8939
+      vertex 48.8544 1.77106 -59.7937
+    endloop
+  endfacet
+  facet normal 0.253029 -0.288394 -0.923474
+    outer loop
+      vertex 48.6255 1.37451 -59.7937
+      vertex 48.3914 1.48997 -59.8939
+      vertex 48.4546 1.54542 -59.8939
+    endloop
+  endfacet
+  facet normal -0.597056 0.523528 0.607818
+    outer loop
+      vertex -49.1759 4.17587 49.1111
+      vertex -49.3193 4.01233 49.1111
+      vertex -49.0633 4.06326 49.3187
+    endloop
+  endfacet
+  facet normal -0.588625 0.3934 0.706227
+    outer loop
+      vertex -49.1929 3.91538 49.3187
+      vertex -49.3022 3.75184 49.3187
+      vertex -49.0462 3.80277 49.5037
+    endloop
+  endfacet
+  facet normal -0.694837 0.609327 0.381997
+    outer loop
+      vertex -49.3392 4.33916 48.6429
+      vertex -49.4231 4.09196 48.8846
+      vertex -49.2684 4.26837 48.8846
+    endloop
+  endfacet
+  facet normal -0.651419 0.571252 0.499325
+    outer loop
+      vertex -49.2684 4.26837 48.8846
+      vertex -49.4231 4.09196 48.8846
+      vertex -49.1759 4.17587 49.1111
+    endloop
+  endfacet
+  facet normal -0.438414 0.889282 -0.130273
+    outer loop
+      vertex -48.9808 4.69877 -58.3902
+      vertex -48.9979 4.72834 -58.1308
+      vertex -48.7637 4.8438 -58.1308
+    endloop
+  endfacet
+  facet normal -0.43855 0.889235 -0.130133
+    outer loop
+      vertex -48.7507 4.81225 -58.3902
+      vertex -48.9808 4.69877 -58.3902
+      vertex -48.7637 4.8438 -58.1308
+    endloop
+  endfacet
+  facet normal -0.35117 0.712123 -0.607915
+    outer loop
+      vertex -48.5754 4.38922 -59.3187
+      vertex -48.8315 4.44015 -59.1111
+      vertex -48.6364 4.53636 -59.1111
+    endloop
+  endfacet
+  facet normal -0.255203 0.751885 -0.607898
+    outer loop
+      vertex -48.5754 4.38922 -59.3187
+      vertex -48.6364 4.53636 -59.1111
+      vertex -48.4304 4.60628 -59.1111
+    endloop
+  endfacet
+  facet normal -0.269492 0.546699 -0.792776
+    outer loop
+      vertex -48.5556 3.96228 -59.6629
+      vertex -48.6593 4.14202 -59.5037
+      vertex -48.4252 4.02656 -59.6629
+    endloop
+  endfacet
+  facet normal -0.195958 0.577094 -0.79282
+    outer loop
+      vertex -48.4252 4.02656 -59.6629
+      vertex -48.5046 4.21831 -59.5037
+      vertex -48.3413 4.27376 -59.5037
+    endloop
+  endfacet
+  facet normal -0.57127 0.651403 -0.499325
+    outer loop
+      vertex -49.1759 4.17587 -59.1111
+      vertex -49.2684 4.26837 -58.8846
+      vertex -49.092 4.42307 -58.8846
+    endloop
+  endfacet
+  facet normal -0.651433 0.571209 -0.499356
+    outer loop
+      vertex -49.3193 4.01233 -59.1111
+      vertex -49.4231 4.09196 -58.8846
+      vertex -49.1759 4.17587 -59.1111
+    endloop
+  endfacet
+  facet normal -0.694913 0.609284 -0.381928
+    outer loop
+      vertex -49.4231 4.09196 -58.8846
+      vertex -49.5025 4.15291 -58.6429
+      vertex -49.3392 4.33916 -58.6429
+    endloop
+  endfacet
+  facet normal -0.768496 0.513376 -0.381915
+    outer loop
+      vertex -49.4231 4.09196 -58.8846
+      vertex -49.6401 3.94693 -58.6429
+      vertex -49.5025 4.15291 -58.6429
+    endloop
+  endfacet
+  facet normal -0.383104 0.777137 -0.499289
+    outer loop
+      vertex -48.8315 4.44015 -59.1111
+      vertex -48.8969 4.55343 -58.8846
+      vertex -48.6864 4.6572 -58.8846
+    endloop
+  endfacet
+  facet normal -0.408649 0.828955 -0.38189
+    outer loop
+      vertex -48.8969 4.55343 -58.8846
+      vertex -48.9469 4.64013 -58.6429
+      vertex -48.6864 4.6572 -58.8846
+    endloop
+  endfacet
+  facet normal -0.972391 0.19359 -0.130302
+    outer loop
+      vertex -49.8947 3.50769 -58.3902
+      vertex -49.9448 3.25604 -58.3902
+      vertex -49.9277 3.51653 -58.1308
+    endloop
+  endfacet
+  facet normal -0.947452 0.188734 -0.25829
+    outer loop
+      vertex -49.8777 3.2472 -58.6429
+      vertex -49.8947 3.50769 -58.3902
+      vertex -49.8293 3.49017 -58.6429
+    endloop
+  endfacet
+  facet normal -0.866341 0.42736 -0.25849
+    outer loop
+      vertex -49.6401 3.94693 -58.6429
+      vertex -49.7497 3.72475 -58.6429
+      vertex -49.6988 3.98078 -58.3902
+    endloop
+  endfacet
+  facet normal -0.97248 0.193326 -0.130031
+    outer loop
+      vertex -49.9448 3.25604 -58.3902
+      vertex -49.9786 3.26049 -58.1308
+      vertex -49.9277 3.51653 -58.1308
+    endloop
+  endfacet
+  facet normal -0.71194 0.351426 -0.607981
+    outer loop
+      vertex -49.3892 3.57543 -59.3187
+      vertex -49.5364 3.63638 -59.1111
+      vertex -49.4401 3.83147 -59.1111
+    endloop
+  endfacet
+  facet normal -0.778811 0.154784 -0.607862
+    outer loop
+      vertex -49.4908 3.19627 -59.3187
+      vertex -49.6487 3.21706 -59.1111
+      vertex -49.6063 3.4304 -59.1111
+    endloop
+  endfacet
+  facet normal -0.864562 0.0565594 -0.499334
+    outer loop
+      vertex -49.6629 3 -59.1111
+      vertex -49.7784 3.23413 -58.8846
+      vertex -49.6487 3.21706 -59.1111
+    endloop
+  endfacet
+  facet normal -0.820543 0.278463 -0.499167
+    outer loop
+      vertex -49.5364 3.63638 -59.1111
+      vertex -49.7326 3.46426 -58.8846
+      vertex -49.6572 3.68644 -58.8846
+    endloop
+  endfacet
+  facet normal -0.706344 0.046425 -0.706344
+    outer loop
+      vertex -49.3187 3 -59.5037
+      vertex -49.5037 3 -59.3187
+      vertex -49.4908 3.19627 -59.3187
+    endloop
+  endfacet
+  facet normal -0.416355 0.278374 -0.865538
+    outer loop
+      vertex -48.7018 3.5385 -59.7937
+      vertex -48.9623 3.55557 -59.6629
+      vertex -48.8815 3.67642 -59.6629
+    endloop
+  endfacet
+  facet normal -0.474141 0.160884 -0.865625
+    outer loop
+      vertex -48.8544 3.22894 -59.7937
+      vertex -49.0733 3.28758 -59.6629
+      vertex -49.0266 3.42521 -59.6629
+    endloop
+  endfacet
+  facet normal -0.108679 0.0724696 -0.991432
+    outer loop
+      vertex -48.1133 3.0654 -59.9957
+      vertex -48.3379 3.19509 -59.9616
+      vertex -48.3096 3.23753 -59.9616
+    endloop
+  endfacet
+  facet normal -0.213009 0.319148 -0.923456
+    outer loop
+      vertex -48.3914 3.51003 -59.8939
+      vertex -48.5385 3.70178 -59.7937
+      vertex -48.3214 3.55675 -59.8939
+    endloop
+  endfacet
+  facet normal -0.245476 0.0835415 -0.965796
+    outer loop
+      vertex -48.3769 3.10099 -59.9616
+      vertex -48.621 3.16639 -59.8939
+      vertex -48.5939 3.24602 -59.8939
+    endloop
+  endfacet
+  facet normal -0.254312 0.0505664 -0.965799
+    outer loop
+      vertex -48.3769 3.10099 -59.9616
+      vertex -48.6374 3.08391 -59.8939
+      vertex -48.621 3.16639 -59.8939
+    endloop
+  endfacet
+  facet normal -0.123523 0.0426729 -0.991424
+    outer loop
+      vertex -48.1264 3.03385 -59.9957
+      vertex -48.3769 3.10099 -59.9616
+      vertex -48.1208 3.05006 -59.9957
+    endloop
+  endfacet
+  facet normal -0.117135 0.0578253 -0.991431
+    outer loop
+      vertex -48.1133 3.0654 -59.9957
+      vertex -48.3605 3.14931 -59.9616
+      vertex -48.3379 3.19509 -59.9616
+    endloop
+  endfacet
+  facet normal -0.0579371 0.117099 -0.991429
+    outer loop
+      vertex -48.0654 3.11328 -59.9957
+      vertex -48.1493 3.36048 -59.9616
+      vertex -48.0501 3.12085 -59.9957
+    endloop
+  endfacet
+  facet normal -0.776999 -0.383541 -0.499168
+    outer loop
+      vertex -49.4401 1.16853 -59.1111
+      vertex -49.6572 1.31356 -58.8846
+      vertex -49.5364 1.36362 -59.1111
+    endloop
+  endfacet
+  facet normal -0.71194 -0.351426 -0.607981
+    outer loop
+      vertex -49.4401 1.16853 -59.1111
+      vertex -49.5364 1.36362 -59.1111
+      vertex -49.3892 1.42457 -59.3187
+    endloop
+  endfacet
+  facet normal -0.513462 0.76846 0.381872
+    outer loop
+      vertex -48.9469 4.64013 48.6429
+      vertex -49.092 4.42307 48.8846
+      vertex -48.8969 4.55343 48.8846
+    endloop
+  endfacet
+  facet normal -0.18845 0.947514 0.258272
+    outer loop
+      vertex -48.2472 4.87766 48.6429
+      vertex -48.5077 4.89473 48.3902
+      vertex -48.4902 4.82933 48.6429
+    endloop
+  endfacet
+  facet normal -0.168966 0.849812 0.49927
+    outer loop
+      vertex -48.2341 4.7784 48.8846
+      vertex -48.4643 4.73263 48.8846
+      vertex -48.2171 4.64871 49.1111
+    endloop
+  endfacet
+  facet normal -0.0566694 0.864577 0.499295
+    outer loop
+      vertex -48 4.66294 49.1111
+      vertex -48.2341 4.7784 48.8846
+      vertex -48.2171 4.64871 49.1111
+    endloop
+  endfacet
+  facet normal -0.221423 0.449163 0.865577
+    outer loop
+      vertex -48.3385 3.81724 49.7937
+      vertex -48.5556 3.96228 49.6629
+      vertex -48.4423 3.76607 49.7937
+    endloop
+  endfacet
+  facet normal -0.278247 0.416353 0.86558
+    outer loop
+      vertex -48.4423 3.76607 49.7937
+      vertex -48.5556 3.96228 49.6629
+      vertex -48.5385 3.70178 49.7937
+    endloop
+  endfacet
+  facet normal -0.0833786 0.24554 0.965794
+    outer loop
+      vertex -48.1664 3.62097 49.8939
+      vertex -48.246 3.59394 49.8939
+      vertex -48.101 3.37689 49.9616
+    endloop
+  endfacet
+  facet normal -0.0505877 0.254326 0.965795
+    outer loop
+      vertex -48.0839 3.63738 49.8939
+      vertex -48.1664 3.62097 49.8939
+      vertex -48.101 3.37689 49.9616
+    endloop
+  endfacet
+  facet normal -0.123311 0.363304 0.923474
+    outer loop
+      vertex -48.2289 3.85444 49.7937
+      vertex -48.3385 3.81724 49.7937
+      vertex -48.246 3.59394 49.8939
+    endloop
+  endfacet
+  facet normal -0.123368 0.363305 0.923466
+    outer loop
+      vertex -48.2289 3.85444 49.7937
+      vertex -48.246 3.59394 49.8939
+      vertex -48.1664 3.62097 49.8939
+    endloop
+  endfacet
+  facet normal -0.195943 0.577093 0.792824
+    outer loop
+      vertex -48.3413 4.27376 49.5037
+      vertex -48.4252 4.02656 49.6629
+      vertex -48.2876 4.07328 49.6629
+    endloop
+  endfacet
+  facet normal -0.118837 0.597748 0.792827
+    outer loop
+      vertex -48.145 4.10163 49.6629
+      vertex -48.3413 4.27376 49.5037
+      vertex -48.2876 4.07328 49.6629
+    endloop
+  endfacet
+  facet normal -0.466722 0.53226 0.706307
+    outer loop
+      vertex -48.8028 4.04619 49.5037
+      vertex -49.0633 4.06326 49.3187
+      vertex -48.9325 3.93246 49.5037
+    endloop
+  endfacet
+  facet normal -0.401763 0.458179 0.79288
+    outer loop
+      vertex -48.8028 4.04619 49.5037
+      vertex -48.9325 3.93246 49.5037
+      vertex -48.6764 3.88153 49.6629
+    endloop
+  endfacet
+  facet normal -0.481361 0.720416 0.499292
+    outer loop
+      vertex -48.8969 4.55343 48.8846
+      vertex -49.092 4.42307 48.8846
+      vertex -48.8315 4.44015 49.1111
+    endloop
+  endfacet
+  facet normal -0.523481 0.597097 0.607818
+    outer loop
+      vertex -49.0123 4.3193 49.1111
+      vertex -49.1759 4.17587 49.1111
+      vertex -49.0633 4.06326 49.3187
+    endloop
+  endfacet
+  facet normal -0.310633 0.914773 0.25826
+    outer loop
+      vertex -48.5077 4.89473 48.3902
+      vertex -48.7247 4.7497 48.6429
+      vertex -48.4902 4.82933 48.6429
+    endloop
+  endfacet
+  facet normal -0.297195 0.875076 0.381991
+    outer loop
+      vertex -48.4643 4.73263 48.8846
+      vertex -48.7247 4.7497 48.6429
+      vertex -48.6864 4.6572 48.8846
+    endloop
+  endfacet
+  facet normal -0.776999 -0.383541 0.499168
+    outer loop
+      vertex -49.5364 1.36362 49.1111
+      vertex -49.6572 1.31356 48.8846
+      vertex -49.4401 1.16853 49.1111
+    endloop
+  endfacet
+  facet normal -0.777012 -0.383281 0.499347
+    outer loop
+      vertex -49.4401 1.16853 49.1111
+      vertex -49.6572 1.31356 48.8846
+      vertex -49.5534 1.10313 48.8846
+    endloop
+  endfacet
+  facet normal -0.778811 -0.154784 0.607862
+    outer loop
+      vertex -49.4908 1.80373 49.3187
+      vertex -49.6487 1.78294 49.1111
+      vertex -49.6063 1.5696 49.1111
+    endloop
+  endfacet
+  facet normal -0.849887 -0.16891 0.499161
+    outer loop
+      vertex -49.6487 1.78294 49.1111
+      vertex -49.7326 1.53574 48.8846
+      vertex -49.6063 1.5696 49.1111
+    endloop
+  endfacet
+  facet normal -0.376381 -0.0748381 0.923437
+    outer loop
+      vertex -48.6374 1.91609 49.8939
+      vertex -48.8544 1.77106 49.7937
+      vertex -48.621 1.83361 49.8939
+    endloop
+  endfacet
+  facet normal -0.376317 -0.0749451 0.923455
+    outer loop
+      vertex -48.6374 1.91609 49.8939
+      vertex -48.877 1.88454 49.7937
+      vertex -48.8544 1.77106 49.7937
+    endloop
+  endfacet
+  facet normal -0.344087 0.169717 0.923472
+    outer loop
+      vertex -48.5567 3.32144 49.8939
+      vertex -48.8172 3.33851 49.7937
+      vertex -48.5939 3.24602 49.8939
+    endloop
+  endfacet
+  facet normal -0.232583 0.114719 0.965787
+    outer loop
+      vertex -48.5567 3.32144 49.8939
+      vertex -48.5939 3.24602 49.8939
+      vertex -48.3379 3.19509 49.9616
+    endloop
+  endfacet
+  facet normal -0.171006 0.194906 0.965799
+    outer loop
+      vertex -48.3914 3.51003 49.8939
+      vertex -48.4546 3.45458 49.8939
+      vertex -48.2759 3.2759 49.9616
+    endloop
+  endfacet
+  facet normal -0.253029 0.288394 0.923474
+    outer loop
+      vertex -48.3914 3.51003 49.8939
+      vertex -48.6255 3.62549 49.7937
+      vertex -48.4546 3.45458 49.8939
+    endloop
+  endfacet
+  facet normal -0.57111 -0.651455 0.499439
+    outer loop
+      vertex -49.0123 0.680702 49.1111
+      vertex -49.1759 0.824125 49.1111
+      vertex -49.092 0.576926 48.8846
+    endloop
+  endfacet
+  facet normal -0.768522 -0.513285 0.381985
+    outer loop
+      vertex -49.5534 1.10313 48.8846
+      vertex -49.6401 1.05307 48.6429
+      vertex -49.4231 0.908037 48.8846
+    endloop
+  endfacet
+  facet normal -0.408726 -0.828882 0.381965
+    outer loop
+      vertex -48.6864 0.342795 48.8846
+      vertex -48.9469 0.359869 48.6429
+      vertex -48.7247 0.250301 48.6429
+    endloop
+  endfacet
+  facet normal -0.297162 -0.875096 0.381971
+    outer loop
+      vertex -48.6864 0.342795 48.8846
+      vertex -48.7247 0.250301 48.6429
+      vertex -48.4643 0.267375 48.8846
+    endloop
+  endfacet
+  facet normal -0.269563 -0.546609 0.792814
+    outer loop
+      vertex -48.4252 0.97344 49.6629
+      vertex -48.6593 0.85798 49.5037
+      vertex -48.5046 0.781689 49.5037
+    endloop
+  endfacet
+  facet normal -0.227596 -0.670291 0.706336
+    outer loop
+      vertex -48.3413 0.726242 49.5037
+      vertex -48.5754 0.610782 49.3187
+      vertex -48.3892 0.547558 49.3187
+    endloop
+  endfacet
+  facet normal -0.597118 -0.523299 0.607954
+    outer loop
+      vertex -49.1929 1.08462 49.3187
+      vertex -49.3193 0.987667 49.1111
+      vertex -49.0633 0.936738 49.3187
+    endloop
+  endfacet
+  facet normal -0.571285 -0.651399 0.499313
+    outer loop
+      vertex -49.1759 0.824125 49.1111
+      vertex -49.2684 0.731631 48.8846
+      vertex -49.092 0.576926 48.8846
+    endloop
+  endfacet
+  facet normal -0.376568 -0.330147 0.865563
+    outer loop
+      vertex -48.6255 1.37451 49.7937
+      vertex -48.8815 1.32358 49.6629
+      vertex -48.7857 1.21431 49.6629
+    endloop
+  endfacet
+  facet normal -0.458211 -0.401726 0.792881
+    outer loop
+      vertex -48.8815 1.32358 49.6629
+      vertex -48.9325 1.06754 49.5037
+      vertex -48.7857 1.21431 49.6629
+    endloop
+  endfacet
+  facet normal -0.416355 -0.278374 0.865538
+    outer loop
+      vertex -48.7018 1.4615 49.7937
+      vertex -48.9623 1.44443 49.6629
+      vertex -48.8815 1.32358 49.6629
+    endloop
+  endfacet
+  facet normal -0.474078 -0.160954 0.865647
+    outer loop
+      vertex -48.8544 1.77106 49.7937
+      vertex -49.0266 1.57479 49.6629
+      vertex -48.8172 1.66149 49.7937
+    endloop
+  endfacet
+  facet normal -0.466715 -0.532264 0.706309
+    outer loop
+      vertex -48.8028 0.953812 49.5037
+      vertex -49.0633 0.936738 49.3187
+      vertex -48.9154 0.807052 49.3187
+    endloop
+  endfacet
+  facet normal -0.523551 -0.597082 0.607772
+    outer loop
+      vertex -48.9154 0.807052 49.3187
+      vertex -49.0633 0.936738 49.3187
+      vertex -49.0123 0.680702 49.1111
+    endloop
+  endfacet
+  facet normal -0.458218 -0.401723 0.792878
+    outer loop
+      vertex -48.8815 1.32358 49.6629
+      vertex -49.0462 1.19723 49.5037
+      vertex -48.9325 1.06754 49.5037
+    endloop
+  endfacet
+  facet normal -0.546628 -0.269624 0.79278
+    outer loop
+      vertex -49.0266 1.57479 49.6629
+      vertex -49.142 1.34065 49.5037
+      vertex -48.9623 1.44443 49.6629
+    endloop
+  endfacet
+  facet normal -0.245596 -0.0833562 0.965782
+    outer loop
+      vertex -48.3769 1.89901 49.9616
+      vertex -48.5939 1.75398 49.8939
+      vertex -48.3605 1.85069 49.9616
+    endloop
+  endfacet
+  facet normal -0.108632 0.0725231 0.991433
+    outer loop
+      vertex -48.1038 3.07963 49.9957
+      vertex -48.3096 3.23753 49.9616
+      vertex -48.1133 3.0654 49.9957
+    endloop
+  endfacet
+  facet normal -0.0981411 0.0861964 0.991433
+    outer loop
+      vertex -48.2759 3.2759 49.9616
+      vertex -48.3096 3.23753 49.9616
+      vertex -48.1038 3.07963 49.9957
+    endloop
+  endfacet
+  facet normal -0.254299 0.0502908 0.965817
+    outer loop
+      vertex -48.3769 3.10099 49.9616
+      vertex -48.6374 3.08391 49.8939
+      vertex -48.3868 3.05093 49.9616
+    endloop
+  endfacet
+  facet normal -0.128159 0.025345 0.99143
+    outer loop
+      vertex -48.3769 3.10099 49.9616
+      vertex -48.3868 3.05093 49.9616
+      vertex -48.1297 3.01707 49.9957
+    endloop
+  endfacet
+  facet normal 0.0604353 0.922198 0.381966
+    outer loop
+      vertex 48 4.89386 48.6429
+      vertex 48 4.79375 48.8846
+      vertex 48.2472 4.87766 48.6429
+    endloop
+  endfacet
+  facet normal 0.18022 0.906416 0.38201
+    outer loop
+      vertex 48.2472 4.87766 48.6429
+      vertex 48.2341 4.7784 48.8846
+      vertex 48.4643 4.73263 48.8846
+    endloop
+  endfacet
+  facet normal 0.18845 0.947514 0.258272
+    outer loop
+      vertex 48.5077 4.89473 48.3902
+      vertex 48.2472 4.87766 48.6429
+      vertex 48.4902 4.82933 48.6429
+    endloop
+  endfacet
+  facet normal 0.180278 0.906424 0.381963
+    outer loop
+      vertex 48.4902 4.82933 48.6429
+      vertex 48.2472 4.87766 48.6429
+      vertex 48.4643 4.73263 48.8846
+    endloop
+  endfacet
+  facet normal 0.651433 0.571209 0.499356
+    outer loop
+      vertex 49.4231 4.09196 48.8846
+      vertex 49.1759 4.17587 49.1111
+      vertex 49.3193 4.01233 49.1111
+    endloop
+  endfacet
+  facet normal 0.776999 0.383541 0.499168
+    outer loop
+      vertex 49.6572 3.68644 48.8846
+      vertex 49.4401 3.83147 49.1111
+      vertex 49.5364 3.63638 49.1111
+    endloop
+  endfacet
+  facet normal 0.71194 0.351426 0.607981
+    outer loop
+      vertex 49.4401 3.83147 49.1111
+      vertex 49.3892 3.57543 49.3187
+      vertex 49.5364 3.63638 49.1111
+    endloop
+  endfacet
+  facet normal 0.634888 0.313107 0.706315
+    outer loop
+      vertex 49.3022 3.75184 49.3187
+      vertex 49.142 3.65935 49.5037
+      vertex 49.3892 3.57543 49.3187
+    endloop
+  endfacet
+  facet normal 0.536682 0.803288 0.258266
+    outer loop
+      vertex 49.1941 4.55622 48.3902
+      vertex 48.9469 4.64013 48.6429
+      vertex 49.1529 4.5025 48.6429
+    endloop
+  endfacet
+  facet normal 0.536775 0.803185 0.258391
+    outer loop
+      vertex 48.9808 4.69877 48.3902
+      vertex 48.9469 4.64013 48.6429
+      vertex 49.1941 4.55622 48.3902
+    endloop
+  endfacet
+  facet normal 0.255203 0.751885 0.607898
+    outer loop
+      vertex 48.6364 4.53636 49.1111
+      vertex 48.4304 4.60628 49.1111
+      vertex 48.5754 4.38922 49.3187
+    endloop
+  endfacet
+  facet normal 0.523481 0.597097 0.607818
+    outer loop
+      vertex 49.1759 4.17587 49.1111
+      vertex 49.0123 4.3193 49.1111
+      vertex 49.0633 4.06326 49.3187
+    endloop
+  endfacet
+  facet normal 0.481448 0.72028 0.499404
+    outer loop
+      vertex 49.092 4.42307 48.8846
+      vertex 48.8315 4.44015 49.1111
+      vertex 49.0123 4.3193 49.1111
+    endloop
+  endfacet
+  facet normal 0.58865 0.3932 0.706318
+    outer loop
+      vertex 49.3022 3.75184 49.3187
+      vertex 49.0462 3.80277 49.5037
+      vertex 49.142 3.65935 49.5037
+    endloop
+  endfacet
+  facet normal 0.330185 0.376539 0.865561
+    outer loop
+      vertex 48.6764 3.88153 49.6629
+      vertex 48.5385 3.70178 49.7937
+      vertex 48.6255 3.62549 49.7937
+    endloop
+  endfacet
+  facet normal 0.330173 0.376543 0.865564
+    outer loop
+      vertex 48.6764 3.88153 49.6629
+      vertex 48.6255 3.62549 49.7937
+      vertex 48.7857 3.78569 49.6629
+    endloop
+  endfacet
+  facet normal 0.313086 0.634873 0.706338
+    outer loop
+      vertex 48.5754 4.38922 49.3187
+      vertex 48.5046 4.21831 49.5037
+      vertex 48.6593 4.14202 49.5037
+    endloop
+  endfacet
+  facet normal 0.227602 0.670286 0.706339
+    outer loop
+      vertex 48.5754 4.38922 49.3187
+      vertex 48.3413 4.27376 49.5037
+      vertex 48.5046 4.21831 49.5037
+    endloop
+  endfacet
+  facet normal 0.154949 0.77878 0.607859
+    outer loop
+      vertex 48.4304 4.60628 49.1111
+      vertex 48.1963 4.49082 49.3187
+      vertex 48.3892 4.45244 49.3187
+    endloop
+  endfacet
+  facet normal 0.138136 0.694278 0.706326
+    outer loop
+      vertex 48.3892 4.45244 49.3187
+      vertex 48.1963 4.49082 49.3187
+      vertex 48.3413 4.27376 49.5037
+    endloop
+  endfacet
+  facet normal 0.00853748 -0.130349 0.991431
+    outer loop
+      vertex 48.0171 1.87031 49.9957
+      vertex 48 1.86919 49.9957
+      vertex 48.0509 1.61316 49.9616
+    endloop
+  endfacet
+  facet normal 0.0254463 -0.128126 0.991431
+    outer loop
+      vertex 48.101 1.62311 49.9616
+      vertex 48.0171 1.87031 49.9957
+      vertex 48.0509 1.61316 49.9616
+    endloop
+  endfacet
+  facet normal 0.0981186 -0.0862162 0.991433
+    outer loop
+      vertex 48.1038 1.92037 49.9957
+      vertex 48.0925 1.90751 49.9957
+      vertex 48.2759 1.7241 49.9616
+    endloop
+  endfacet
+  facet normal 0.194878 -0.17116 0.965778
+    outer loop
+      vertex 48.3096 1.76247 49.9616
+      vertex 48.2759 1.7241 49.9616
+      vertex 48.51 1.60864 49.8939
+    endloop
+  endfacet
+  facet normal 0.253029 -0.288394 0.923474
+    outer loop
+      vertex 48.4546 1.54542 49.8939
+      vertex 48.3914 1.48997 49.8939
+      vertex 48.6255 1.37451 49.7937
+    endloop
+  endfacet
+  facet normal 0.288558 -0.252864 0.923469
+    outer loop
+      vertex 48.51 1.60864 49.8939
+      vertex 48.4546 1.54542 49.8939
+      vertex 48.6255 1.37451 49.7937
+    endloop
+  endfacet
+  facet normal 0.114712 -0.232571 0.965791
+    outer loop
+      vertex 48.3214 1.44325 49.8939
+      vertex 48.1951 1.66209 49.9616
+      vertex 48.246 1.40606 49.8939
+    endloop
+  endfacet
+  facet normal 0.143959 -0.215692 0.965791
+    outer loop
+      vertex 48.3914 1.48997 49.8939
+      vertex 48.1951 1.66209 49.9616
+      vertex 48.3214 1.44325 49.8939
+    endloop
+  endfacet
+  facet normal 0.0860872 -0.0982392 0.991432
+    outer loop
+      vertex 48.2759 1.7241 49.9616
+      vertex 48.0796 1.89622 49.9957
+      vertex 48.2375 1.69045 49.9616
+    endloop
+  endfacet
+  facet normal 0.0860326 -0.0983012 0.991431
+    outer loop
+      vertex 48.0925 1.90751 49.9957
+      vertex 48.0796 1.89622 49.9957
+      vertex 48.2759 1.7241 49.9616
+    endloop
+  endfacet
+  facet normal -0.269492 -0.546699 0.792776
+    outer loop
+      vertex -48.5556 1.03772 49.6629
+      vertex -48.6593 0.85798 49.5037
+      vertex -48.4252 0.97344 49.6629
+    endloop
+  endfacet
+  facet normal -0.169714 -0.344082 0.923474
+    outer loop
+      vertex -48.3214 1.44325 49.8939
+      vertex -48.3385 1.18276 49.7937
+      vertex -48.246 1.40606 49.8939
+    endloop
+  endfacet
+  facet normal -0.0250966 -0.382837 0.923475
+    outer loop
+      vertex -48.0839 1.36262 49.8939
+      vertex -48.1155 1.12299 49.7937
+      vertex -48 1.35712 49.8939
+    endloop
+  endfacet
+  facet normal -0.0169617 -0.258743 0.965797
+    outer loop
+      vertex -48 1.60982 49.9616
+      vertex -48.0839 1.36262 49.8939
+      vertex -48 1.35712 49.8939
+    endloop
+  endfacet
+  facet normal 0 -0.865966 0.500104
+    outer loop
+      vertex -48 0.206255 48.8846
+      vertex 48 0.337061 49.1111
+      vertex -48 0.337061 49.1111
+    endloop
+  endfacet
+  facet normal 0 -0.865966 0.500104
+    outer loop
+      vertex 48 0.337061 49.1111
+      vertex -48 0.206255 48.8846
+      vertex 48 0.206255 48.8846
+    endloop
+  endfacet
+  facet normal -0.0519247 -0.792351 0.607851
+    outer loop
+      vertex -48 0.496321 49.3187
+      vertex -48.1963 0.509185 49.3187
+      vertex -48 0.337061 49.1111
+    endloop
+  endfacet
+  facet normal -0.0834146 -0.245516 0.965797
+    outer loop
+      vertex -48.1493 1.63952 49.9616
+      vertex -48.246 1.40606 49.8939
+      vertex -48.101 1.62311 49.9616
+    endloop
+  endfacet
+  facet normal -0.0981186 -0.0862162 0.991433
+    outer loop
+      vertex -48.1038 1.92037 49.9957
+      vertex -48.2759 1.7241 49.9616
+      vertex -48.0925 1.90751 49.9957
+    endloop
+  endfacet
+  facet normal -0.0860326 -0.0983012 0.991431
+    outer loop
+      vertex -48.0925 1.90751 49.9957
+      vertex -48.2759 1.7241 49.9616
+      vertex -48.0796 1.89622 49.9957
+    endloop
+  endfacet
+  facet normal -0.171006 -0.194906 0.965799
+    outer loop
+      vertex -48.2759 1.7241 49.9616
+      vertex -48.4546 1.54542 49.8939
+      vertex -48.3914 1.48997 49.8939
+    endloop
+  endfacet
+  facet normal -0.195016 -0.170893 0.965797
+    outer loop
+      vertex -48.2759 1.7241 49.9616
+      vertex -48.51 1.60864 49.8939
+      vertex -48.4546 1.54542 49.8939
+    endloop
+  endfacet
+  facet normal -0.144138 -0.215495 0.965809
+    outer loop
+      vertex -48.2375 1.69045 49.9616
+      vertex -48.3914 1.48997 49.8939
+      vertex -48.1951 1.66209 49.9616
+    endloop
+  endfacet
+  facet normal -0.0726213 -0.108573 0.991432
+    outer loop
+      vertex -48.0654 1.88672 49.9957
+      vertex -48.2375 1.69045 49.9616
+      vertex -48.1951 1.66209 49.9616
+    endloop
+  endfacet
+  facet normal -0.221423 -0.449163 0.865577
+    outer loop
+      vertex -48.4423 1.23393 49.7937
+      vertex -48.5556 1.03772 49.6629
+      vertex -48.3385 1.18276 49.7937
+    endloop
+  endfacet
+  facet normal -0.169626 -0.344093 0.923486
+    outer loop
+      vertex -48.3214 1.44325 49.8939
+      vertex -48.4423 1.23393 49.7937
+      vertex -48.3385 1.18276 49.7937
+    endloop
+  endfacet
+  facet normal -0.0254711 -0.128118 0.991432
+    outer loop
+      vertex -48.0339 1.87365 49.9957
+      vertex -48.101 1.62311 49.9616
+      vertex -48.0171 1.87031 49.9957
+    endloop
+  endfacet
+  facet normal -0.0579371 0.117099 0.991429
+    outer loop
+      vertex -48.0501 3.12085 49.9957
+      vertex -48.1493 3.36048 49.9616
+      vertex -48.0654 3.11328 49.9957
+    endloop
+  endfacet
+  facet normal -0.057739 0.117166 0.991432
+    outer loop
+      vertex -48.1493 3.36048 49.9616
+      vertex -48.1951 3.33791 49.9616
+      vertex -48.0654 3.11328 49.9957
+    endloop
+  endfacet
+  facet normal -0.0254711 0.128118 0.991432
+    outer loop
+      vertex -48.0171 3.12969 49.9957
+      vertex -48.101 3.37689 49.9616
+      vertex -48.0339 3.12635 49.9957
+    endloop
+  endfacet
+  facet normal 0.11462 0.232591 0.965797
+    outer loop
+      vertex 48.246 3.59394 49.8939
+      vertex 48.1493 3.36048 49.9616
+      vertex 48.1951 3.33791 49.9616
+    endloop
+  endfacet
+  facet normal 0.057739 0.117166 0.991432
+    outer loop
+      vertex 48.1493 3.36048 49.9616
+      vertex 48.0654 3.11328 49.9957
+      vertex 48.1951 3.33791 49.9616
+    endloop
+  endfacet
+  facet normal 0.0254463 0.128126 0.991431
+    outer loop
+      vertex 48.0509 3.38684 49.9616
+      vertex 48.0171 3.12969 49.9957
+      vertex 48.101 3.37689 49.9616
+    endloop
+  endfacet
+  facet normal 0.0505091 0.254322 0.9658
+    outer loop
+      vertex 48.0839 3.63738 49.8939
+      vertex 48.0509 3.38684 49.9616
+      vertex 48.101 3.37689 49.9616
+    endloop
+  endfacet
+  facet normal 0.0834146 0.245516 0.965797
+    outer loop
+      vertex 48.246 3.59394 49.8939
+      vertex 48.101 3.37689 49.9616
+      vertex 48.1493 3.36048 49.9616
+    endloop
+  endfacet
+  facet normal 0.0420229 0.123687 0.991431
+    outer loop
+      vertex 48.101 3.37689 49.9616
+      vertex 48.0501 3.12085 49.9957
+      vertex 48.1493 3.36048 49.9616
+    endloop
+  endfacet
+  facet normal 0.0169781 0.258738 0.965798
+    outer loop
+      vertex 48.0839 3.63738 49.8939
+      vertex 48 3.39018 49.9616
+      vertex 48.0509 3.38684 49.9616
+    endloop
+  endfacet
+  facet normal 0.00855315 0.130346 0.991432
+    outer loop
+      vertex 48 3.39018 49.9616
+      vertex 48 3.13081 49.9957
+      vertex 48.0509 3.38684 49.9616
+    endloop
+  endfacet
+  facet normal 0.0505877 0.254326 0.965795
+    outer loop
+      vertex 48.1664 3.62097 49.8939
+      vertex 48.0839 3.63738 49.8939
+      vertex 48.101 3.37689 49.9616
+    endloop
+  endfacet
+  facet normal 0.0833786 0.24554 0.965794
+    outer loop
+      vertex 48.1664 3.62097 49.8939
+      vertex 48.101 3.37689 49.9616
+      vertex 48.246 3.59394 49.8939
+    endloop
+  endfacet
+  facet normal 0.13039 0.00840238 0.991427
+    outer loop
+      vertex 48.3868 3.05093 49.9616
+      vertex 48.1297 3.01707 49.9957
+      vertex 48.1308 3 49.9957
+    endloop
+  endfacet
+  facet normal 0.123523 0.0426729 0.991424
+    outer loop
+      vertex 48.3769 3.10099 49.9616
+      vertex 48.1208 3.05006 49.9957
+      vertex 48.1264 3.03385 49.9957
+    endloop
+  endfacet
+  facet normal 0.123664 0.041972 0.991436
+    outer loop
+      vertex 48.3605 3.14931 49.9616
+      vertex 48.1208 3.05006 49.9957
+      vertex 48.3769 3.10099 49.9616
+    endloop
+  endfacet
+  facet normal 0.338431 0.506781 -0.792866
+    outer loop
+      vertex 48.6764 3.88153 -59.6629
+      vertex 48.6593 4.14202 -59.5037
+      vertex 48.8028 4.04619 -59.5037
+    endloop
+  endfacet
+  facet normal 0.393126 0.588684 -0.706331
+    outer loop
+      vertex 48.8028 4.04619 -59.5037
+      vertex 48.6593 4.14202 -59.5037
+      vertex 48.7518 4.30222 -59.3187
+    endloop
+  endfacet
+  facet normal 0.26956 0.546612 -0.792813
+    outer loop
+      vertex 48.6593 4.14202 -59.5037
+      vertex 48.4252 4.02656 -59.6629
+      vertex 48.5046 4.21831 -59.5037
+    endloop
+  endfacet
+  facet normal 0.338735 0.506739 -0.792764
+    outer loop
+      vertex 48.6764 3.88153 -59.6629
+      vertex 48.5556 3.96228 -59.6629
+      vertex 48.6593 4.14202 -59.5037
+    endloop
+  endfacet
+  facet normal 0.0169617 0.258743 -0.965797
+    outer loop
+      vertex 48.0839 3.63738 -59.8939
+      vertex 48 3.39018 -59.9616
+      vertex 48 3.64288 -59.8939
+    endloop
+  endfacet
+  facet normal 0.0977607 0.491186 -0.865551
+    outer loop
+      vertex 48.2289 3.85444 -59.7937
+      vertex 48.1155 3.87701 -59.7937
+      vertex 48.145 4.10163 -59.6629
+    endloop
+  endfacet
+  facet normal 0.344087 0.169717 -0.923472
+    outer loop
+      vertex 48.5939 3.24602 -59.8939
+      vertex 48.5567 3.32144 -59.8939
+      vertex 48.8172 3.33851 -59.7937
+    endloop
+  endfacet
+  facet normal 0.232583 0.114719 -0.965787
+    outer loop
+      vertex 48.5939 3.24602 -59.8939
+      vertex 48.3379 3.19509 -59.9616
+      vertex 48.5567 3.32144 -59.8939
+    endloop
+  endfacet
+  facet normal 0.318905 0.213134 -0.923512
+    outer loop
+      vertex 48.7661 3.44229 -59.7937
+      vertex 48.5567 3.32144 -59.8939
+      vertex 48.7018 3.5385 -59.7937
+    endloop
+  endfacet
+  facet normal 0.252976 0.28849 -0.923459
+    outer loop
+      vertex 48.6255 3.62549 -59.7937
+      vertex 48.3914 3.51003 -59.8939
+      vertex 48.5385 3.70178 -59.7937
+    endloop
+  endfacet
+  facet normal 0.169036 0.849763 -0.499329
+    outer loop
+      vertex 48.4304 4.60628 -59.1111
+      vertex 48.2171 4.64871 -59.1111
+      vertex 48.4643 4.73263 -58.8846
+    endloop
+  endfacet
+  facet normal 0.278469 0.820432 -0.499345
+    outer loop
+      vertex 48.6364 4.53636 -59.1111
+      vertex 48.4304 4.60628 -59.1111
+      vertex 48.4643 4.73263 -58.8846
+    endloop
+  endfacet
+  facet normal 0.0519361 0.792363 -0.607835
+    outer loop
+      vertex 48.1963 4.49082 -59.3187
+      vertex 48 4.66294 -59.1111
+      vertex 48.2171 4.64871 -59.1111
+    endloop
+  endfacet
+  facet normal 0.154921 0.778801 -0.607839
+    outer loop
+      vertex 48.4304 4.60628 -59.1111
+      vertex 48.1963 4.49082 -59.3187
+      vertex 48.2171 4.64871 -59.1111
+    endloop
+  endfacet
+  facet normal -0.118873 0.597721 -0.792842
+    outer loop
+      vertex -48.145 4.10163 -59.6629
+      vertex -48.3413 4.27376 -59.5037
+      vertex -48.1721 4.30741 -59.5037
+    endloop
+  endfacet
+  facet normal -0.0462756 0.706368 -0.70633
+    outer loop
+      vertex -48 4.31869 -59.5037
+      vertex -48.1963 4.49082 -59.3187
+      vertex -48 4.50368 -59.3187
+    endloop
+  endfacet
+  facet normal -0.118837 0.597748 -0.792827
+    outer loop
+      vertex -48.2876 4.07328 -59.6629
+      vertex -48.3413 4.27376 -59.5037
+      vertex -48.145 4.10163 -59.6629
+    endloop
+  endfacet
+  facet normal -0.0398585 0.608125 -0.79284
+    outer loop
+      vertex -48.145 4.10163 -59.6629
+      vertex -48.1721 4.30741 -59.5037
+      vertex -48 4.31869 -59.5037
+    endloop
+  endfacet
+  facet normal 0.660113 -0.441179 0.607957
+    outer loop
+      vertex 49.3022 1.24816 49.3187
+      vertex 49.1929 1.08462 49.3187
+      vertex 49.3193 0.987667 49.1111
+    endloop
+  endfacet
+  facet normal 0.53244 -0.466617 0.706241
+    outer loop
+      vertex 49.1929 1.08462 49.3187
+      vertex 49.0462 1.19723 49.5037
+      vertex 49.0633 0.936738 49.3187
+    endloop
+  endfacet
+  facet normal 0.726411 -0.636892 0.258255
+    outer loop
+      vertex 49.5025 0.847092 48.6429
+      vertex 49.3392 0.660839 48.6429
+      vertex 49.5562 0.805872 48.3902
+    endloop
+  endfacet
+  facet normal 0.80332 -0.536644 0.258246
+    outer loop
+      vertex 49.6401 1.05307 48.6429
+      vertex 49.5025 0.847092 48.6429
+      vertex 49.5562 0.805872 48.3902
+    endloop
+  endfacet
+  facet normal 0.383215 -0.77712 0.49923
+    outer loop
+      vertex 48.8315 0.559853 49.1111
+      vertex 48.6364 0.463645 49.1111
+      vertex 48.6864 0.342795 48.8846
+    endloop
+  endfacet
+  facet normal 0.383121 -0.777125 0.499295
+    outer loop
+      vertex 48.8315 0.559853 49.1111
+      vertex 48.6864 0.342795 48.8846
+      vertex 48.8969 0.446571 48.8846
+    endloop
+  endfacet
+  facet normal 0.227596 -0.670291 0.706336
+    outer loop
+      vertex 48.5754 0.610782 49.3187
+      vertex 48.3413 0.726242 49.5037
+      vertex 48.3892 0.547558 49.3187
+    endloop
+  endfacet
+  facet normal 0.13811 -0.694276 0.706333
+    outer loop
+      vertex 48.3413 0.726242 49.5037
+      vertex 48.1963 0.509185 49.3187
+      vertex 48.3892 0.547558 49.3187
+    endloop
+  endfacet
+  facet normal 0.768518 0.513291 0.381985
+    outer loop
+      vertex 49.6401 3.94693 48.6429
+      vertex 49.4231 4.09196 48.8846
+      vertex 49.5534 3.89687 48.8846
+    endloop
+  endfacet
+  facet normal 0.768496 0.513376 0.381915
+    outer loop
+      vertex 49.5025 4.15291 48.6429
+      vertex 49.4231 4.09196 48.8846
+      vertex 49.6401 3.94693 48.6429
+    endloop
+  endfacet
+  facet normal 0.195016 0.170893 0.965797
+    outer loop
+      vertex 48.4546 3.45458 49.8939
+      vertex 48.2759 3.2759 49.9616
+      vertex 48.51 3.39136 49.8939
+    endloop
+  endfacet
+  facet normal 0.288558 0.252864 0.923469
+    outer loop
+      vertex 48.6255 3.62549 49.7937
+      vertex 48.4546 3.45458 49.8939
+      vertex 48.51 3.39136 49.8939
+    endloop
+  endfacet
+  facet normal 0.376381 0.0748381 0.923437
+    outer loop
+      vertex 48.8544 3.22894 49.7937
+      vertex 48.621 3.16639 49.8939
+      vertex 48.6374 3.08391 49.8939
+    endloop
+  endfacet
+  facet normal 0.376317 0.0749451 0.923455
+    outer loop
+      vertex 48.8544 3.22894 49.7937
+      vertex 48.6374 3.08391 49.8939
+      vertex 48.877 3.11546 49.7937
+    endloop
+  endfacet
+  facet normal 0.532304 0.466674 0.706305
+    outer loop
+      vertex 49.0633 4.06326 49.3187
+      vertex 48.9325 3.93246 49.5037
+      vertex 49.0462 3.80277 49.5037
+    endloop
+  endfacet
+  facet normal 0.458218 0.401723 0.792878
+    outer loop
+      vertex 48.9325 3.93246 49.5037
+      vertex 48.8815 3.67642 49.6629
+      vertex 49.0462 3.80277 49.5037
+    endloop
+  endfacet
+  facet normal 0.820543 0.278463 0.499167
+    outer loop
+      vertex 49.6572 3.68644 48.8846
+      vertex 49.5364 3.63638 49.1111
+      vertex 49.7326 3.46426 48.8846
+    endloop
+  endfacet
+  facet normal 0.875143 0.296992 0.381996
+    outer loop
+      vertex 49.7497 3.72475 48.6429
+      vertex 49.6572 3.68644 48.8846
+      vertex 49.7326 3.46426 48.8846
+    endloop
+  endfacet
+  facet normal 0.90634 0.180378 0.382115
+    outer loop
+      vertex 49.8777 3.2472 48.6429
+      vertex 49.7326 3.46426 48.8846
+      vertex 49.7784 3.23413 48.8846
+    endloop
+  endfacet
+  facet normal 0.849746 0.169115 0.499332
+    outer loop
+      vertex 49.7326 3.46426 48.8846
+      vertex 49.6487 3.21706 49.1111
+      vertex 49.7784 3.23413 48.8846
+    endloop
+  endfacet
+  facet normal 0.947452 0.188734 0.25829
+    outer loop
+      vertex 49.8947 3.50769 48.3902
+      vertex 49.8293 3.49017 48.6429
+      vertex 49.8777 3.2472 48.6429
+    endloop
+  endfacet
+  facet normal 0.914834 0.31043 0.258286
+    outer loop
+      vertex 49.8947 3.50769 48.3902
+      vertex 49.7497 3.72475 48.6429
+      vertex 49.8293 3.49017 48.6429
+    endloop
+  endfacet
+  facet normal 0.382882 -0.0250965 0.923456
+    outer loop
+      vertex 48.6429 2 49.8939
+      vertex 48.6374 1.91609 49.8939
+      vertex 48.877 1.88454 49.7937
+    endloop
+  endfacet
+  facet normal 0.258743 -0.0169597 0.965797
+    outer loop
+      vertex 48.6429 2 49.8939
+      vertex 48.3902 2 49.9616
+      vertex 48.6374 1.91609 49.8939
+    endloop
+  endfacet
+  facet normal 0.532303 -0.466673 0.706308
+    outer loop
+      vertex 49.0462 1.19723 49.5037
+      vertex 48.9325 1.06754 49.5037
+      vertex 49.0633 0.936738 49.3187
+    endloop
+  endfacet
+  facet normal 0.458218 -0.401723 0.792878
+    outer loop
+      vertex 49.0462 1.19723 49.5037
+      vertex 48.8815 1.32358 49.6629
+      vertex 48.9325 1.06754 49.5037
+    endloop
+  endfacet
+  facet normal 0.694418 -0.138228 0.70617
+    outer loop
+      vertex 49.4908 1.80373 49.3187
+      vertex 49.2738 1.6587 49.5037
+      vertex 49.4524 1.61082 49.3187
+    endloop
+  endfacet
+  facet normal 0.670487 -0.227516 0.706175
+    outer loop
+      vertex 49.4524 1.61082 49.3187
+      vertex 49.2738 1.6587 49.5037
+      vertex 49.3892 1.42457 49.3187
+    endloop
+  endfacet
+  facet normal 0.577116 -0.196094 0.79277
+    outer loop
+      vertex 49.2738 1.6587 49.5037
+      vertex 49.0266 1.57479 49.6629
+      vertex 49.2183 1.49536 49.5037
+    endloop
+  endfacet
+  facet normal 0.546657 -0.269601 0.792768
+    outer loop
+      vertex 49.2183 1.49536 49.5037
+      vertex 49.0266 1.57479 49.6629
+      vertex 49.142 1.34065 49.5037
+    endloop
+  endfacet
+  facet normal 0.123523 -0.0426729 0.991424
+    outer loop
+      vertex 48.1264 1.96615 49.9957
+      vertex 48.1208 1.94994 49.9957
+      vertex 48.3769 1.89901 49.9616
+    endloop
+  endfacet
+  facet normal 0.523551 -0.597082 -0.607772
+    outer loop
+      vertex 49.0123 0.680702 -59.1111
+      vertex 48.9154 0.807052 -59.3187
+      vertex 49.0633 0.936738 -59.3187
+    endloop
+  endfacet
+  facet normal 0.441076 -0.660346 -0.607779
+    outer loop
+      vertex 49.0123 0.680702 -59.1111
+      vertex 48.7518 0.697776 -59.3187
+      vertex 48.9154 0.807052 -59.3187
+    endloop
+  endfacet
+  facet normal 0.793533 0 -0.608528
+    outer loop
+      vertex 49.6629 2 -59.1111
+      vertex 49.5037 3 -59.3187
+      vertex 49.6629 3 -59.1111
+    endloop
+  endfacet
+  facet normal 0.793533 0 -0.608528
+    outer loop
+      vertex 49.5037 3 -59.3187
+      vertex 49.6629 2 -59.1111
+      vertex 49.5037 2 -59.3187
+    endloop
+  endfacet
+  facet normal 0.792455 -0.0520848 -0.607702
+    outer loop
+      vertex 49.6629 2 -59.1111
+      vertex 49.4908 1.80373 -59.3187
+      vertex 49.5037 2 -59.3187
+    endloop
+  endfacet
+  facet normal 0.670487 -0.227516 -0.706175
+    outer loop
+      vertex 49.3892 1.42457 -59.3187
+      vertex 49.2738 1.6587 -59.5037
+      vertex 49.4524 1.61082 -59.3187
+    endloop
+  endfacet
+  facet normal 0.694418 -0.138228 -0.70617
+    outer loop
+      vertex 49.4524 1.61082 -59.3187
+      vertex 49.2738 1.6587 -59.5037
+      vertex 49.4908 1.80373 -59.3187
+    endloop
+  endfacet
+  facet normal 0.330173 -0.376543 -0.865564
+    outer loop
+      vertex 48.6764 1.11847 -59.6629
+      vertex 48.6255 1.37451 -59.7937
+      vertex 48.7857 1.21431 -59.6629
+    endloop
+  endfacet
+  facet normal 0.376568 -0.330147 -0.865563
+    outer loop
+      vertex 48.7857 1.21431 -59.6629
+      vertex 48.6255 1.37451 -59.7937
+      vertex 48.8815 1.32358 -59.6629
+    endloop
+  endfacet
+  facet normal 0.416373 -0.278275 -0.865561
+    outer loop
+      vertex 48.9623 1.44443 -59.6629
+      vertex 48.7018 1.4615 -59.7937
+      vertex 48.7661 1.55771 -59.7937
+    endloop
+  endfacet
+  facet normal 0.416355 -0.278374 -0.865538
+    outer loop
+      vertex 48.8815 1.32358 -59.6629
+      vertex 48.7018 1.4615 -59.7937
+      vertex 48.9623 1.44443 -59.6629
+    endloop
+  endfacet
+  facet normal -0.427298 -0.866388 0.258435
+    outer loop
+      vertex -48.7247 0.250301 48.6429
+      vertex -48.9808 0.30123 48.3902
+      vertex -48.7507 0.187746 48.3902
+    endloop
+  endfacet
+  facet normal -0.310491 -0.914782 0.258397
+    outer loop
+      vertex -48.7247 0.250301 48.6429
+      vertex -48.7507 0.187746 48.3902
+      vertex -48.5077 0.105268 48.3902
+    endloop
+  endfacet
+  facet normal -0.154924 -0.778797 -0.607844
+    outer loop
+      vertex -48.1963 0.509185 -59.3187
+      vertex -48.4304 0.393724 -59.1111
+      vertex -48.3892 0.547558 -59.3187
+    endloop
+  endfacet
+  facet normal -0.154939 -0.778785 -0.607855
+    outer loop
+      vertex -48.2171 0.351288 -59.1111
+      vertex -48.4304 0.393724 -59.1111
+      vertex -48.1963 0.509185 -59.3187
+    endloop
+  endfacet
+  facet normal -0.180235 -0.906414 -0.382006
+    outer loop
+      vertex -48.2472 0.122342 -58.6429
+      vertex -48.4643 0.267375 -58.8846
+      vertex -48.2341 0.221601 -58.8846
+    endloop
+  endfacet
+  facet normal -0.168981 -0.849814 -0.499261
+    outer loop
+      vertex -48.2341 0.221601 -58.8846
+      vertex -48.4643 0.267375 -58.8846
+      vertex -48.2171 0.351288 -59.1111
+    endloop
+  endfacet
+  facet normal -0.269563 -0.546609 -0.792814
+    outer loop
+      vertex -48.5046 0.781689 -59.5037
+      vertex -48.6593 0.85798 -59.5037
+      vertex -48.4252 0.97344 -59.6629
+    endloop
+  endfacet
+  facet normal -0.160955 -0.474212 -0.865573
+    outer loop
+      vertex -48.2289 1.14556 -59.7937
+      vertex -48.4252 0.97344 -59.6629
+      vertex -48.3385 1.18276 -59.7937
+    endloop
+  endfacet
+  facet normal -0.255208 -0.751889 -0.607892
+    outer loop
+      vertex -48.4304 0.393724 -59.1111
+      vertex -48.6364 0.463645 -59.1111
+      vertex -48.5754 0.610782 -59.3187
+    endloop
+  endfacet
+  facet normal -0.351167 -0.71213 -0.607909
+    outer loop
+      vertex -48.6364 0.463645 -59.1111
+      vertex -48.8315 0.559853 -59.1111
+      vertex -48.5754 0.610782 -59.3187
+    endloop
+  endfacet
+  facet normal -0.427243 -0.866434 -0.258371
+    outer loop
+      vertex -48.7247 0.250301 -58.6429
+      vertex -48.9808 0.30123 -58.3902
+      vertex -48.9469 0.359869 -58.6429
+    endloop
+  endfacet
+  facet normal -0.536781 -0.803183 -0.258388
+    outer loop
+      vertex -48.9808 0.30123 -58.3902
+      vertex -49.1941 0.443782 -58.3902
+      vertex -48.9469 0.359869 -58.6429
+    endloop
+  endfacet
+  facet normal -0.188449 -0.94751 -0.258286
+    outer loop
+      vertex -48.2472 0.122342 -58.6429
+      vertex -48.5077 0.105268 -58.3902
+      vertex -48.4902 0.170672 -58.6429
+    endloop
+  endfacet
+  facet normal -0.310628 -0.914771 -0.258273
+    outer loop
+      vertex -48.5077 0.105268 -58.3902
+      vertex -48.7247 0.250301 -58.6429
+      vertex -48.4902 0.170672 -58.6429
+    endloop
+  endfacet
+  facet normal -0.169626 -0.344093 -0.923486
+    outer loop
+      vertex -48.3385 1.18276 -59.7937
+      vertex -48.4423 1.23393 -59.7937
+      vertex -48.3214 1.44325 -59.8939
+    endloop
+  endfacet
+  facet normal -0.376531 -0.33026 -0.865536
+    outer loop
+      vertex -48.6255 1.37451 -59.7937
+      vertex -48.8815 1.32358 -59.6629
+      vertex -48.7018 1.4615 -59.7937
+    endloop
+  endfacet
+  facet normal -0.0981411 -0.0861964 -0.991433
+    outer loop
+      vertex -48.2759 1.7241 -59.9616
+      vertex -48.3096 1.76247 -59.9616
+      vertex -48.1038 1.92037 -59.9957
+    endloop
+  endfacet
+  facet normal -0.215801 -0.143902 -0.965775
+    outer loop
+      vertex -48.3096 1.76247 -59.9616
+      vertex -48.51 1.60864 -59.8939
+      vertex -48.3379 1.80491 -59.9616
+    endloop
+  endfacet
+  facet normal -0.00853748 -0.130349 -0.991431
+    outer loop
+      vertex -48 1.86919 -59.9957
+      vertex -48.0509 1.61316 -59.9616
+      vertex -48.0171 1.87031 -59.9957
+    endloop
+  endfacet
+  facet normal -0.0419945 -0.123693 -0.991432
+    outer loop
+      vertex -48.0339 1.87365 -59.9957
+      vertex -48.101 1.62311 -59.9616
+      vertex -48.0501 1.87915 -59.9957
+    endloop
+  endfacet
+  facet normal -0.0420229 -0.123687 -0.991431
+    outer loop
+      vertex -48.101 1.62311 -59.9616
+      vertex -48.1493 1.63952 -59.9616
+      vertex -48.0501 1.87915 -59.9957
+    endloop
+  endfacet
+  facet normal -0.318905 -0.213134 -0.923512
+    outer loop
+      vertex -48.7018 1.4615 -59.7937
+      vertex -48.7661 1.55771 -59.7937
+      vertex -48.5567 1.67856 -59.8939
+    endloop
+  endfacet
+  facet normal -0.34412 -0.169441 -0.92351
+    outer loop
+      vertex -48.7661 1.55771 -59.7937
+      vertex -48.8172 1.66149 -59.7937
+      vertex -48.5567 1.67856 -59.8939
+    endloop
+  endfacet
+  facet normal -0.215653 -0.144036 -0.965788
+    outer loop
+      vertex -48.51 1.60864 -59.8939
+      vertex -48.5567 1.67856 -59.8939
+      vertex -48.3379 1.80491 -59.9616
+    endloop
+  endfacet
+  facet normal -0.288396 -0.252955 -0.923494
+    outer loop
+      vertex -48.6255 1.37451 -59.7937
+      vertex -48.7018 1.4615 -59.7937
+      vertex -48.51 1.60864 -59.8939
+    endloop
+  endfacet
+  facet normal -0.588625 -0.3934 -0.706227
+    outer loop
+      vertex -49.1929 1.08462 -59.3187
+      vertex -49.3022 1.24816 -59.3187
+      vertex -49.0462 1.19723 -59.5037
+    endloop
+  endfacet
+  facet normal -0.53244 -0.466617 -0.706241
+    outer loop
+      vertex -49.0633 0.936738 -59.3187
+      vertex -49.1929 1.08462 -59.3187
+      vertex -49.0462 1.19723 -59.5037
+    endloop
+  endfacet
+  facet normal -0.0860872 -0.0982392 -0.991432
+    outer loop
+      vertex -48.2375 1.69045 -59.9616
+      vertex -48.2759 1.7241 -59.9616
+      vertex -48.0796 1.89622 -59.9957
+    endloop
+  endfacet
+  facet normal -0.117298 -0.0573489 -0.99144
+    outer loop
+      vertex -48.1133 1.9346 -59.9957
+      vertex -48.3605 1.85069 -59.9616
+      vertex -48.1208 1.94994 -59.9957
+    endloop
+  endfacet
+  facet normal -0.376317 -0.0749451 -0.923455
+    outer loop
+      vertex -48.8544 1.77106 -59.7937
+      vertex -48.877 1.88454 -59.7937
+      vertex -48.6374 1.91609 -59.8939
+    endloop
+  endfacet
+  facet normal -0.376381 -0.0748381 -0.923437
+    outer loop
+      vertex -48.621 1.83361 -59.8939
+      vertex -48.8544 1.77106 -59.7937
+      vertex -48.6374 1.91609 -59.8939
+    endloop
+  endfacet
+  facet normal -0.792455 0.0520848 -0.607702
+    outer loop
+      vertex -49.5037 3 -59.3187
+      vertex -49.6629 3 -59.1111
+      vertex -49.4908 3.19627 -59.3187
+    endloop
+  endfacet
+  facet normal -0.947499 -0.188634 -0.25819
+    outer loop
+      vertex -49.8947 1.49231 -58.3902
+      vertex -49.9448 1.74396 -58.3902
+      vertex -49.8777 1.7528 -58.6429
+    endloop
+  endfacet
+  facet normal -0.914834 -0.31043 -0.258286
+    outer loop
+      vertex -49.7497 1.27525 -58.6429
+      vertex -49.8947 1.49231 -58.3902
+      vertex -49.8293 1.50983 -58.6429
+    endloop
+  endfacet
+  facet normal -0.865975 0 -0.500086
+    outer loop
+      vertex -49.6629 2 -59.1111
+      vertex -49.7937 3 -58.8846
+      vertex -49.6629 3 -59.1111
+    endloop
+  endfacet
+  facet normal -0.865975 -0 -0.500086
+    outer loop
+      vertex -49.7937 3 -58.8846
+      vertex -49.6629 2 -59.1111
+      vertex -49.7937 2 -58.8846
+    endloop
+  endfacet
+  facet normal 0.118837 0.597748 -0.792827
+    outer loop
+      vertex 48.2876 4.07328 -59.6629
+      vertex 48.145 4.10163 -59.6629
+      vertex 48.3413 4.27376 -59.5037
+    endloop
+  endfacet
+  facet normal 0.221423 0.449163 -0.865577
+    outer loop
+      vertex 48.4423 3.76607 -59.7937
+      vertex 48.3385 3.81724 -59.7937
+      vertex 48.5556 3.96228 -59.6629
+    endloop
+  endfacet
+  facet normal 0.0726213 0.108573 -0.991432
+    outer loop
+      vertex 48.2375 3.30955 -59.9616
+      vertex 48.0654 3.11328 -59.9957
+      vertex 48.1951 3.33791 -59.9616
+    endloop
+  endfacet
+  facet normal 0.117298 0.0573489 -0.99144
+    outer loop
+      vertex 48.1208 3.05006 -59.9957
+      vertex 48.1133 3.0654 -59.9957
+      vertex 48.3605 3.14931 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0860326 0.0983012 -0.991431
+    outer loop
+      vertex 48.0925 3.09249 -59.9957
+      vertex 48.0796 3.10378 -59.9957
+      vertex 48.2759 3.2759 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0981186 0.0862162 -0.991433
+    outer loop
+      vertex 48.1038 3.07963 -59.9957
+      vertex 48.0925 3.09249 -59.9957
+      vertex 48.2759 3.2759 -59.9616
+    endloop
+  endfacet
+  facet normal 0.245476 -0.0835415 -0.965796
+    outer loop
+      vertex 48.5939 1.75398 -59.8939
+      vertex 48.3769 1.89901 -59.9616
+      vertex 48.621 1.83361 -59.8939
+    endloop
+  endfacet
+  facet normal 0.245596 -0.0833562 -0.965782
+    outer loop
+      vertex 48.5939 1.75398 -59.8939
+      vertex 48.3605 1.85069 -59.9616
+      vertex 48.3769 1.89901 -59.9616
+    endloop
+  endfacet
+  facet normal 0.195016 -0.170893 -0.965797
+    outer loop
+      vertex 48.4546 1.54542 -59.8939
+      vertex 48.2759 1.7241 -59.9616
+      vertex 48.51 1.60864 -59.8939
+    endloop
+  endfacet
+  facet normal 0.108679 -0.0724696 -0.991432
+    outer loop
+      vertex 48.3096 1.76247 -59.9616
+      vertex 48.1133 1.9346 -59.9957
+      vertex 48.3379 1.80491 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0833786 -0.24554 -0.965794
+    outer loop
+      vertex 48.1664 1.37903 -59.8939
+      vertex 48.101 1.62311 -59.9616
+      vertex 48.246 1.40606 -59.8939
+    endloop
+  endfacet
+  facet normal 0.0505877 -0.254326 -0.965795
+    outer loop
+      vertex 48.1664 1.37903 -59.8939
+      vertex 48.0839 1.36262 -59.8939
+      vertex 48.101 1.62311 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0834146 -0.245516 -0.965797
+    outer loop
+      vertex 48.246 1.40606 -59.8939
+      vertex 48.101 1.62311 -59.9616
+      vertex 48.1493 1.63952 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0254711 -0.128118 -0.991432
+    outer loop
+      vertex 48.101 1.62311 -59.9616
+      vertex 48.0171 1.87031 -59.9957
+      vertex 48.0339 1.87365 -59.9957
+    endloop
+  endfacet
+  facet normal 0.491187 -0.0978218 -0.865544
+    outer loop
+      vertex 49.1016 1.85497 -59.6629
+      vertex 48.8544 1.77106 -59.7937
+      vertex 48.877 1.88454 -59.7937
+    endloop
+  endfacet
+  facet normal 0.376317 -0.0749451 -0.923455
+    outer loop
+      vertex 48.8544 1.77106 -59.7937
+      vertex 48.6374 1.91609 -59.8939
+      vertex 48.877 1.88454 -59.7937
+    endloop
+  endfacet
+  facet normal 0.376317 0.0749451 -0.923455
+    outer loop
+      vertex 48.877 3.11546 -59.7937
+      vertex 48.6374 3.08391 -59.8939
+      vertex 48.8544 3.22894 -59.7937
+    endloop
+  endfacet
+  facet normal 0.376381 0.0748381 -0.923437
+    outer loop
+      vertex 48.6374 3.08391 -59.8939
+      vertex 48.621 3.16639 -59.8939
+      vertex 48.8544 3.22894 -59.7937
+    endloop
+  endfacet
+  facet normal 0.171006 -0.194906 -0.965799
+    outer loop
+      vertex 48.3914 1.48997 -59.8939
+      vertex 48.2759 1.7241 -59.9616
+      vertex 48.4546 1.54542 -59.8939
+    endloop
+  endfacet
+  facet normal 0.213009 -0.319148 -0.923456
+    outer loop
+      vertex 48.5385 1.29822 -59.7937
+      vertex 48.3214 1.44325 -59.8939
+      vertex 48.3914 1.48997 -59.8939
+    endloop
+  endfacet
+  facet normal -0.651433 0.571209 0.499356
+    outer loop
+      vertex -49.1759 4.17587 49.1111
+      vertex -49.4231 4.09196 48.8846
+      vertex -49.3193 4.01233 49.1111
+    endloop
+  endfacet
+  facet normal -0.720469 0.481216 0.499355
+    outer loop
+      vertex -49.4231 4.09196 48.8846
+      vertex -49.4401 3.83147 49.1111
+      vertex -49.3193 4.01233 49.1111
+    endloop
+  endfacet
+  facet normal -0.536682 0.803288 -0.258266
+    outer loop
+      vertex -49.1529 4.5025 -58.6429
+      vertex -49.1941 4.55622 -58.3902
+      vertex -48.9469 4.64013 -58.6429
+    endloop
+  endfacet
+  facet normal -0.536775 0.803185 -0.258391
+    outer loop
+      vertex -48.9469 4.64013 -58.6429
+      vertex -49.1941 4.55622 -58.3902
+      vertex -48.9808 4.69877 -58.3902
+    endloop
+  endfacet
+  facet normal -0.26956 0.546612 -0.792813
+    outer loop
+      vertex -48.4252 4.02656 -59.6629
+      vertex -48.6593 4.14202 -59.5037
+      vertex -48.5046 4.21831 -59.5037
+    endloop
+  endfacet
+  facet normal -0.313086 0.634873 -0.706338
+    outer loop
+      vertex -48.5046 4.21831 -59.5037
+      vertex -48.6593 4.14202 -59.5037
+      vertex -48.5754 4.38922 -59.3187
+    endloop
+  endfacet
+  facet normal -0.441059 0.660358 -0.607778
+    outer loop
+      vertex -48.9154 4.19295 -59.3187
+      vertex -49.0123 4.3193 -59.1111
+      vertex -48.7518 4.30222 -59.3187
+    endloop
+  endfacet
+  facet normal -0.523561 0.597075 -0.607772
+    outer loop
+      vertex -48.9154 4.19295 -59.3187
+      vertex -49.0633 4.06326 -59.3187
+      vertex -49.0123 4.3193 -59.1111
+    endloop
+  endfacet
+  facet normal -0.653742 0.7454 -0.130385
+    outer loop
+      vertex -49.387 4.38704 -58.3902
+      vertex -49.4112 4.41119 -58.1308
+      vertex -49.1941 4.55622 -58.3902
+    endloop
+  endfacet
+  facet normal -0.637026 0.726341 -0.258121
+    outer loop
+      vertex -49.3392 4.33916 -58.6429
+      vertex -49.387 4.38704 -58.3902
+      vertex -49.1941 4.55622 -58.3902
+    endloop
+  endfacet
+  facet normal -0.803322 0.53664 -0.258246
+    outer loop
+      vertex -49.5025 4.15291 -58.6429
+      vertex -49.6401 3.94693 -58.6429
+      vertex -49.5562 4.19413 -58.3902
+    endloop
+  endfacet
+  facet normal -0.726406 0.636897 -0.258255
+    outer loop
+      vertex -49.5025 4.15291 -58.6429
+      vertex -49.5562 4.19413 -58.3902
+      vertex -49.3392 4.33916 -58.6429
+    endloop
+  endfacet
+  facet normal -0.906365 0.180549 -0.381976
+    outer loop
+      vertex -49.7326 3.46426 -58.8846
+      vertex -49.8777 3.2472 -58.6429
+      vertex -49.8293 3.49017 -58.6429
+    endloop
+  endfacet
+  facet normal -0.964002 0.0632527 -0.258262
+    outer loop
+      vertex -49.8939 3 -58.6429
+      vertex -49.9616 3 -58.3902
+      vertex -49.9448 3.25604 -58.3902
+    endloop
+  endfacet
+  facet normal -0.875143 0.296992 -0.381996
+    outer loop
+      vertex -49.7326 3.46426 -58.8846
+      vertex -49.7497 3.72475 -58.6429
+      vertex -49.6572 3.68644 -58.8846
+    endloop
+  endfacet
+  facet normal -0.866378 0.427316 -0.258437
+    outer loop
+      vertex -49.7497 3.72475 -58.6429
+      vertex -49.8123 3.75066 -58.3902
+      vertex -49.6988 3.98078 -58.3902
+    endloop
+  endfacet
+  facet normal -0.776999 0.383541 -0.499168
+    outer loop
+      vertex -49.5364 3.63638 -59.1111
+      vertex -49.6572 3.68644 -58.8846
+      vertex -49.4401 3.83147 -59.1111
+    endloop
+  endfacet
+  facet normal -0.82882 0.408837 -0.381982
+    outer loop
+      vertex -49.5534 3.89687 -58.8846
+      vertex -49.6572 3.68644 -58.8846
+      vertex -49.6401 3.94693 -58.6429
+    endloop
+  endfacet
+  facet normal -0.90634 0.180378 -0.382115
+    outer loop
+      vertex -49.7784 3.23413 -58.8846
+      vertex -49.8777 3.2472 -58.6429
+      vertex -49.7326 3.46426 -58.8846
+    endloop
+  endfacet
+  facet normal -0.922077 0.0604274 -0.38226
+    outer loop
+      vertex -49.7937 3 -58.8846
+      vertex -49.8939 3 -58.6429
+      vertex -49.8777 3.2472 -58.6429
+    endloop
+  endfacet
+  facet normal -0.768518 0.513291 -0.381985
+    outer loop
+      vertex -49.5534 3.89687 -58.8846
+      vertex -49.6401 3.94693 -58.6429
+      vertex -49.4231 4.09196 -58.8846
+    endloop
+  endfacet
+  facet normal -0.777012 0.383281 -0.499347
+    outer loop
+      vertex -49.4401 3.83147 -59.1111
+      vertex -49.6572 3.68644 -58.8846
+      vertex -49.5534 3.89687 -58.8846
+    endloop
+  endfacet
+  facet normal -0.608082 0.0399217 -0.79287
+    outer loop
+      vertex -49.1016 3.14503 -59.6629
+      vertex -49.3187 3 -59.5037
+      vertex -49.3074 3.17212 -59.5037
+    endloop
+  endfacet
+  facet normal -0.706374 0.0463748 -0.706318
+    outer loop
+      vertex -49.3187 3 -59.5037
+      vertex -49.4908 3.19627 -59.3187
+      vertex -49.3074 3.17212 -59.5037
+    endloop
+  endfacet
+  facet normal -0.466722 0.53226 -0.706307
+    outer loop
+      vertex -48.9325 3.93246 -59.5037
+      vertex -49.0633 4.06326 -59.3187
+      vertex -48.8028 4.04619 -59.5037
+    endloop
+  endfacet
+  facet normal -0.393183 0.588676 -0.706306
+    outer loop
+      vertex -48.8028 4.04619 -59.5037
+      vertex -48.9154 4.19295 -59.3187
+      vertex -48.7518 4.30222 -59.3187
+    endloop
+  endfacet
+  facet normal -0.778651 0.154996 -0.608012
+    outer loop
+      vertex -49.4908 3.19627 -59.3187
+      vertex -49.6063 3.4304 -59.1111
+      vertex -49.4524 3.38918 -59.3187
+    endloop
+  endfacet
+  facet normal -0.474078 0.160954 -0.865647
+    outer loop
+      vertex -48.8544 3.22894 -59.7937
+      vertex -49.0266 3.42521 -59.6629
+      vertex -48.8172 3.33851 -59.7937
+    endloop
+  endfacet
+  facet normal -0.0169617 0.258743 -0.965797
+    outer loop
+      vertex -48 3.39018 -59.9616
+      vertex -48.0839 3.63738 -59.8939
+      vertex -48 3.64288 -59.8939
+    endloop
+  endfacet
+  facet normal -0.0420229 0.123687 -0.991431
+    outer loop
+      vertex -48.0501 3.12085 -59.9957
+      vertex -48.1493 3.36048 -59.9616
+      vertex -48.101 3.37689 -59.9616
+    endloop
+  endfacet
+  facet normal -0.232563 0.114808 -0.965781
+    outer loop
+      vertex -48.3605 3.14931 -59.9616
+      vertex -48.5939 3.24602 -59.8939
+      vertex -48.3379 3.19509 -59.9616
+    endloop
+  endfacet
+  facet normal -0.0726213 0.108573 -0.991432
+    outer loop
+      vertex -48.0654 3.11328 -59.9957
+      vertex -48.2375 3.30955 -59.9616
+      vertex -48.1951 3.33791 -59.9616
+    endloop
+  endfacet
+  facet normal -0.0860872 0.0982392 -0.991432
+    outer loop
+      vertex -48.0796 3.10378 -59.9957
+      vertex -48.2759 3.2759 -59.9616
+      vertex -48.2375 3.30955 -59.9616
+    endloop
+  endfacet
+  facet normal -0.215653 0.144036 -0.965788
+    outer loop
+      vertex -48.3379 3.19509 -59.9616
+      vertex -48.5567 3.32144 -59.8939
+      vertex -48.51 3.39136 -59.8939
+    endloop
+  endfacet
+  facet normal -0.108632 0.0725231 -0.991433
+    outer loop
+      vertex -48.1133 3.0654 -59.9957
+      vertex -48.3096 3.23753 -59.9616
+      vertex -48.1038 3.07963 -59.9957
+    endloop
+  endfacet
+  facet normal -0.143959 0.215692 -0.965791
+    outer loop
+      vertex -48.1951 3.33791 -59.9616
+      vertex -48.3914 3.51003 -59.8939
+      vertex -48.3214 3.55675 -59.8939
+    endloop
+  endfacet
+  facet normal -0.114712 0.232571 -0.965791
+    outer loop
+      vertex -48.1951 3.33791 -59.9616
+      vertex -48.3214 3.55675 -59.8939
+      vertex -48.246 3.59394 -59.8939
+    endloop
+  endfacet
+  facet normal -0.427287 0.866398 0.25842
+    outer loop
+      vertex -48.7507 4.81225 48.3902
+      vertex -48.9808 4.69877 48.3902
+      vertex -48.7247 4.7497 48.6429
+    endloop
+  endfacet
+  facet normal -0.427249 0.86643 0.258374
+    outer loop
+      vertex -48.7247 4.7497 48.6429
+      vertex -48.9808 4.69877 48.3902
+      vertex -48.9469 4.64013 48.6429
+    endloop
+  endfacet
+  facet normal -0.609286 0.69493 0.381894
+    outer loop
+      vertex -49.1529 4.5025 48.6429
+      vertex -49.3392 4.33916 48.6429
+      vertex -49.092 4.42307 48.8846
+    endloop
+  endfacet
+  facet normal -0.51342 0.76847 0.381907
+    outer loop
+      vertex -48.9469 4.64013 48.6429
+      vertex -49.1529 4.5025 48.6429
+      vertex -49.092 4.42307 48.8846
+    endloop
+  endfacet
+  facet normal -0.383104 0.777137 0.499289
+    outer loop
+      vertex -48.6864 4.6572 48.8846
+      vertex -48.8969 4.55343 48.8846
+      vertex -48.8315 4.44015 49.1111
+    endloop
+  endfacet
+  facet normal -0.408649 0.828955 0.38189
+    outer loop
+      vertex -48.6864 4.6572 48.8846
+      vertex -48.9469 4.64013 48.6429
+      vertex -48.8969 4.55343 48.8846
+    endloop
+  endfacet
+  facet normal -0.269492 0.546699 0.792776
+    outer loop
+      vertex -48.4252 4.02656 49.6629
+      vertex -48.6593 4.14202 49.5037
+      vertex -48.5556 3.96228 49.6629
+    endloop
+  endfacet
+  facet normal -0.338735 0.506739 0.792764
+    outer loop
+      vertex -48.6593 4.14202 49.5037
+      vertex -48.6764 3.88153 49.6629
+      vertex -48.5556 3.96228 49.6629
+    endloop
+  endfacet
+  facet normal -0.138136 0.694278 0.706326
+    outer loop
+      vertex -48.1963 4.49082 49.3187
+      vertex -48.3892 4.45244 49.3187
+      vertex -48.3413 4.27376 49.5037
+    endloop
+  endfacet
+  facet normal -0.154949 0.77878 0.607859
+    outer loop
+      vertex -48.1963 4.49082 49.3187
+      vertex -48.4304 4.60628 49.1111
+      vertex -48.3892 4.45244 49.3187
+    endloop
+  endfacet
+  facet normal -0.26956 0.546612 0.792813
+    outer loop
+      vertex -48.5046 4.21831 49.5037
+      vertex -48.6593 4.14202 49.5037
+      vertex -48.4252 4.02656 49.6629
+    endloop
+  endfacet
+  facet normal -0.195958 0.577094 0.79282
+    outer loop
+      vertex -48.3413 4.27376 49.5037
+      vertex -48.5046 4.21831 49.5037
+      vertex -48.4252 4.02656 49.6629
+    endloop
+  endfacet
+  facet normal -0.441059 0.660358 0.607778
+    outer loop
+      vertex -48.7518 4.30222 49.3187
+      vertex -49.0123 4.3193 49.1111
+      vertex -48.9154 4.19295 49.3187
+    endloop
+  endfacet
+  facet normal -0.441217 0.660091 0.607954
+    outer loop
+      vertex -48.8315 4.44015 49.1111
+      vertex -49.0123 4.3193 49.1111
+      vertex -48.7518 4.30222 49.3187
+    endloop
+  endfacet
+  facet normal -0.278641 0.820446 0.499226
+    outer loop
+      vertex -48.4643 4.73263 48.8846
+      vertex -48.6864 4.6572 48.8846
+      vertex -48.6364 4.53636 49.1111
+    endloop
+  endfacet
+  facet normal -0.383228 0.77713 0.499204
+    outer loop
+      vertex -48.6864 4.6572 48.8846
+      vertex -48.8315 4.44015 49.1111
+      vertex -48.6364 4.53636 49.1111
+    endloop
+  endfacet
+  facet normal -0.634888 -0.313107 0.706315
+    outer loop
+      vertex -49.142 1.34065 49.5037
+      vertex -49.3892 1.42457 49.3187
+      vertex -49.3022 1.24816 49.3187
+    endloop
+  endfacet
+  facet normal -0.71219 -0.35123 0.607801
+    outer loop
+      vertex -49.3892 1.42457 49.3187
+      vertex -49.4401 1.16853 49.1111
+      vertex -49.3022 1.24816 49.3187
+    endloop
+  endfacet
+  facet normal -0.319 0.213062 0.923495
+    outer loop
+      vertex -48.51 3.39136 49.8939
+      vertex -48.7018 3.5385 49.7937
+      vertex -48.5567 3.32144 49.8939
+    endloop
+  endfacet
+  facet normal -0.318905 0.213134 0.923512
+    outer loop
+      vertex -48.7018 3.5385 49.7937
+      vertex -48.7661 3.44229 49.7937
+      vertex -48.5567 3.32144 49.8939
+    endloop
+  endfacet
+  facet normal -0.288558 0.252864 0.923469
+    outer loop
+      vertex -48.4546 3.45458 49.8939
+      vertex -48.6255 3.62549 49.7937
+      vertex -48.51 3.39136 49.8939
+    endloop
+  endfacet
+  facet normal -0.195016 0.170893 0.965797
+    outer loop
+      vertex -48.4546 3.45458 49.8939
+      vertex -48.51 3.39136 49.8939
+      vertex -48.2759 3.2759 49.9616
+    endloop
+  endfacet
+  facet normal -0.523465 -0.597106 0.607823
+    outer loop
+      vertex -49.0633 0.936738 49.3187
+      vertex -49.1759 0.824125 49.1111
+      vertex -49.0123 0.680702 49.1111
+    endloop
+  endfacet
+  facet normal -0.720473 -0.48121 0.499355
+    outer loop
+      vertex -49.3193 0.987667 49.1111
+      vertex -49.4401 1.16853 49.1111
+      vertex -49.4231 0.908037 48.8846
+    endloop
+  endfacet
+  facet normal -0.536781 -0.803183 0.258388
+    outer loop
+      vertex -48.9469 0.359869 48.6429
+      vertex -49.1941 0.443782 48.3902
+      vertex -48.9808 0.30123 48.3902
+    endloop
+  endfacet
+  facet normal -0.609357 -0.69481 0.382
+    outer loop
+      vertex -49.2684 0.731631 48.8846
+      vertex -49.3392 0.660839 48.6429
+      vertex -49.092 0.576926 48.8846
+    endloop
+  endfacet
+  facet normal -0.427243 -0.866434 0.258371
+    outer loop
+      vertex -48.9469 0.359869 48.6429
+      vertex -48.9808 0.30123 48.3902
+      vertex -48.7247 0.250301 48.6429
+    endloop
+  endfacet
+  facet normal -0.408667 -0.828943 0.381896
+    outer loop
+      vertex -48.8969 0.446571 48.8846
+      vertex -48.9469 0.359869 48.6429
+      vertex -48.6864 0.342795 48.8846
+    endloop
+  endfacet
+  facet normal -0.651436 -0.571205 0.499356
+    outer loop
+      vertex -49.3193 0.987667 49.1111
+      vertex -49.4231 0.908037 48.8846
+      vertex -49.1759 0.824125 49.1111
+    endloop
+  endfacet
+  facet normal -0.651417 -0.571263 0.499314
+    outer loop
+      vertex -49.1759 0.824125 49.1111
+      vertex -49.4231 0.908037 48.8846
+      vertex -49.2684 0.731631 48.8846
+    endloop
+  endfacet
+  facet normal -0.441076 -0.660346 0.607779
+    outer loop
+      vertex -48.9154 0.807052 49.3187
+      vertex -49.0123 0.680702 49.1111
+      vertex -48.7518 0.697776 49.3187
+    endloop
+  endfacet
+  facet normal -0.393197 -0.588666 0.706306
+    outer loop
+      vertex -48.8028 0.953812 49.5037
+      vertex -48.9154 0.807052 49.3187
+      vertex -48.7518 0.697776 49.3187
+    endloop
+  endfacet
+  facet normal -0.634888 -0.313115 0.706312
+    outer loop
+      vertex -49.2183 1.49536 49.5037
+      vertex -49.3892 1.42457 49.3187
+      vertex -49.142 1.34065 49.5037
+    endloop
+  endfacet
+  facet normal -0.546657 -0.269601 0.792768
+    outer loop
+      vertex -49.0266 1.57479 49.6629
+      vertex -49.2183 1.49536 49.5037
+      vertex -49.142 1.34065 49.5037
+    endloop
+  endfacet
+  facet normal -0.588625 -0.3934 0.706227
+    outer loop
+      vertex -49.0462 1.19723 49.5037
+      vertex -49.3022 1.24816 49.3187
+      vertex -49.1929 1.08462 49.3187
+    endloop
+  endfacet
+  facet normal -0.53244 -0.466617 0.706241
+    outer loop
+      vertex -49.0462 1.19723 49.5037
+      vertex -49.1929 1.08462 49.3187
+      vertex -49.0633 0.936738 49.3187
+    endloop
+  endfacet
+  facet normal -0.449303 -0.221231 0.865554
+    outer loop
+      vertex -48.8172 1.66149 49.7937
+      vertex -48.9623 1.44443 49.6629
+      vertex -48.7661 1.55771 49.7937
+    endloop
+  endfacet
+  facet normal -0.449015 -0.221476 0.865641
+    outer loop
+      vertex -48.8172 1.66149 49.7937
+      vertex -49.0266 1.57479 49.6629
+      vertex -48.9623 1.44443 49.6629
+    endloop
+  endfacet
+  facet normal -0.123523 -0.0426729 0.991424
+    outer loop
+      vertex -48.1264 1.96615 49.9957
+      vertex -48.3769 1.89901 49.9616
+      vertex -48.1208 1.94994 49.9957
+    endloop
+  endfacet
+  facet normal -0.123664 -0.041972 0.991436
+    outer loop
+      vertex -48.1208 1.94994 49.9957
+      vertex -48.3769 1.89901 49.9616
+      vertex -48.3605 1.85069 49.9616
+    endloop
+  endfacet
+  facet normal -0.232563 0.114808 0.965781
+    outer loop
+      vertex -48.3379 3.19509 49.9616
+      vertex -48.5939 3.24602 49.8939
+      vertex -48.3605 3.14931 49.9616
+    endloop
+  endfacet
+  facet normal -0.245596 0.0833562 0.965782
+    outer loop
+      vertex -48.3605 3.14931 49.9616
+      vertex -48.5939 3.24602 49.8939
+      vertex -48.3769 3.10099 49.9616
+    endloop
+  endfacet
+  facet normal 0.188449 0.947514 0.258271
+    outer loop
+      vertex 48.256 4.94479 48.3902
+      vertex 48.2472 4.87766 48.6429
+      vertex 48.5077 4.89473 48.3902
+    endloop
+  endfacet
+  facet normal 0.0631748 0.964 0.258288
+    outer loop
+      vertex 48.256 4.94479 48.3902
+      vertex 48 4.89386 48.6429
+      vertex 48.2472 4.87766 48.6429
+    endloop
+  endfacet
+  facet normal 0.720482 0.481208 0.499345
+    outer loop
+      vertex 49.5534 3.89687 48.8846
+      vertex 49.4231 4.09196 48.8846
+      vertex 49.4401 3.83147 49.1111
+    endloop
+  endfacet
+  facet normal 0.720469 0.481216 0.499355
+    outer loop
+      vertex 49.4231 4.09196 48.8846
+      vertex 49.3193 4.01233 49.1111
+      vertex 49.4401 3.83147 49.1111
+    endloop
+  endfacet
+  facet normal 0.571131 0.651447 0.499425
+    outer loop
+      vertex 49.092 4.42307 48.8846
+      vertex 49.0123 4.3193 49.1111
+      vertex 49.1759 4.17587 49.1111
+    endloop
+  endfacet
+  facet normal 0.513462 0.76846 0.381872
+    outer loop
+      vertex 48.9469 4.64013 48.6429
+      vertex 48.8969 4.55343 48.8846
+      vertex 49.092 4.42307 48.8846
+    endloop
+  endfacet
+  facet normal 0.383104 0.777137 0.499289
+    outer loop
+      vertex 48.8969 4.55343 48.8846
+      vertex 48.6864 4.6572 48.8846
+      vertex 48.8315 4.44015 49.1111
+    endloop
+  endfacet
+  facet normal 0.383228 0.77713 0.499204
+    outer loop
+      vertex 48.6864 4.6572 48.8846
+      vertex 48.6364 4.53636 49.1111
+      vertex 48.8315 4.44015 49.1111
+    endloop
+  endfacet
+  facet normal 0.0981411 -0.0861964 0.991433
+    outer loop
+      vertex 48.3096 1.76247 49.9616
+      vertex 48.1038 1.92037 49.9957
+      vertex 48.2759 1.7241 49.9616
+    endloop
+  endfacet
+  facet normal 0.108632 -0.0725231 0.991433
+    outer loop
+      vertex 48.1133 1.9346 49.9957
+      vertex 48.1038 1.92037 49.9957
+      vertex 48.3096 1.76247 49.9616
+    endloop
+  endfacet
+  facet normal -0.255307 -0.751901 0.607835
+    outer loop
+      vertex -48.3892 0.547558 49.3187
+      vertex -48.5754 0.610782 49.3187
+      vertex -48.4304 0.393724 49.1111
+    endloop
+  endfacet
+  facet normal -0.0519244 -0.792351 0.607851
+    outer loop
+      vertex -48.1963 0.509185 49.3187
+      vertex -48.2171 0.351288 49.1111
+      vertex -48 0.337061 49.1111
+    endloop
+  endfacet
+  facet normal -0.0566756 -0.864574 0.4993
+    outer loop
+      vertex -48 0.337061 49.1111
+      vertex -48.2341 0.221601 48.8846
+      vertex -48 0.206255 48.8846
+    endloop
+  endfacet
+  facet normal -0.0977595 -0.49118 0.865555
+    outer loop
+      vertex -48.1155 1.12299 49.7937
+      vertex -48.2289 1.14556 49.7937
+      vertex -48.145 0.898366 49.6629
+    endloop
+  endfacet
+  facet normal -0.0748893 -0.376272 0.923478
+    outer loop
+      vertex -48.0839 1.36262 49.8939
+      vertex -48.2289 1.14556 49.7937
+      vertex -48.1155 1.12299 49.7937
+    endloop
+  endfacet
+  facet normal -0.213155 -0.318953 0.92349
+    outer loop
+      vertex -48.3214 1.44325 49.8939
+      vertex -48.5385 1.29822 49.7937
+      vertex -48.4423 1.23393 49.7937
+    endloop
+  endfacet
+  facet normal -0.278247 -0.416353 0.86558
+    outer loop
+      vertex -48.5385 1.29822 49.7937
+      vertex -48.5556 1.03772 49.6629
+      vertex -48.4423 1.23393 49.7937
+    endloop
+  endfacet
+  facet normal -0.0833786 -0.24554 0.965794
+    outer loop
+      vertex -48.101 1.62311 49.9616
+      vertex -48.246 1.40606 49.8939
+      vertex -48.1664 1.37903 49.8939
+    endloop
+  endfacet
+  facet normal -0.0505877 -0.254326 0.965795
+    outer loop
+      vertex -48.101 1.62311 49.9616
+      vertex -48.1664 1.37903 49.8939
+      vertex -48.0839 1.36262 49.8939
+    endloop
+  endfacet
+  facet normal -0.0254463 -0.128126 0.991431
+    outer loop
+      vertex -48.0171 1.87031 49.9957
+      vertex -48.101 1.62311 49.9616
+      vertex -48.0509 1.61316 49.9616
+    endloop
+  endfacet
+  facet normal -0.00853748 -0.130349 0.991431
+    outer loop
+      vertex -48.0171 1.87031 49.9957
+      vertex -48.0509 1.61316 49.9616
+      vertex -48 1.86919 49.9957
+    endloop
+  endfacet
+  facet normal 0.40176 0.458185 -0.792878
+    outer loop
+      vertex 48.7857 3.78569 -59.6629
+      vertex 48.6764 3.88153 -59.6629
+      vertex 48.9325 3.93246 -59.5037
+    endloop
+  endfacet
+  facet normal 0.401763 0.458179 -0.79288
+    outer loop
+      vertex 48.9325 3.93246 -59.5037
+      vertex 48.6764 3.88153 -59.6629
+      vertex 48.8028 4.04619 -59.5037
+    endloop
+  endfacet
+  facet normal 0.278247 0.416353 -0.86558
+    outer loop
+      vertex 48.5385 3.70178 -59.7937
+      vertex 48.4423 3.76607 -59.7937
+      vertex 48.5556 3.96228 -59.6629
+    endloop
+  endfacet
+  facet normal 0.0327752 0.499727 -0.865563
+    outer loop
+      vertex 48.1155 3.87701 -59.7937
+      vertex 48 4.11114 -59.6629
+      vertex 48.145 4.10163 -59.6629
+    endloop
+  endfacet
+  facet normal 0.213009 0.319148 -0.923456
+    outer loop
+      vertex 48.3914 3.51003 -59.8939
+      vertex 48.3214 3.55675 -59.8939
+      vertex 48.5385 3.70178 -59.7937
+    endloop
+  endfacet
+  facet normal 0.0833786 0.24554 -0.965794
+    outer loop
+      vertex 48.246 3.59394 -59.8939
+      vertex 48.101 3.37689 -59.9616
+      vertex 48.1664 3.62097 -59.8939
+    endloop
+  endfacet
+  facet normal 0.0726313 0.108565 -0.991432
+    outer loop
+      vertex 48.0796 3.10378 -59.9957
+      vertex 48.0654 3.11328 -59.9957
+      vertex 48.2375 3.30955 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0505877 0.254326 -0.965795
+    outer loop
+      vertex 48.101 3.37689 -59.9616
+      vertex 48.0839 3.63738 -59.8939
+      vertex 48.1664 3.62097 -59.8939
+    endloop
+  endfacet
+  facet normal 0.114712 0.232571 -0.965791
+    outer loop
+      vertex 48.3214 3.55675 -59.8939
+      vertex 48.1951 3.33791 -59.9616
+      vertex 48.246 3.59394 -59.8939
+    endloop
+  endfacet
+  facet normal 0.0169781 0.258738 -0.965798
+    outer loop
+      vertex 48.0509 3.38684 -59.9616
+      vertex 48 3.39018 -59.9616
+      vertex 48.0839 3.63738 -59.8939
+    endloop
+  endfacet
+  facet normal 0.170862 0.194981 -0.96581
+    outer loop
+      vertex 48.2759 3.2759 -59.9616
+      vertex 48.2375 3.30955 -59.9616
+      vertex 48.3914 3.51003 -59.8939
+    endloop
+  endfacet
+  facet normal 0.169626 0.344093 -0.923486
+    outer loop
+      vertex 48.4423 3.76607 -59.7937
+      vertex 48.3214 3.55675 -59.8939
+      vertex 48.3385 3.81724 -59.7937
+    endloop
+  endfacet
+  facet normal 0.376531 0.33026 -0.865536
+    outer loop
+      vertex 48.7018 3.5385 -59.7937
+      vertex 48.6255 3.62549 -59.7937
+      vertex 48.8815 3.67642 -59.6629
+    endloop
+  endfacet
+  facet normal 0.416355 0.278374 -0.865538
+    outer loop
+      vertex 48.9623 3.55557 -59.6629
+      vertex 48.7018 3.5385 -59.7937
+      vertex 48.8815 3.67642 -59.6629
+    endloop
+  endfacet
+  facet normal -0.0748893 0.376272 -0.923478
+    outer loop
+      vertex -48.0839 3.63738 -59.8939
+      vertex -48.2289 3.85444 -59.7937
+      vertex -48.1155 3.87701 -59.7937
+    endloop
+  endfacet
+  facet normal -0.0977607 0.491186 -0.865551
+    outer loop
+      vertex -48.1155 3.87701 -59.7937
+      vertex -48.2289 3.85444 -59.7937
+      vertex -48.145 4.10163 -59.6629
+    endloop
+  endfacet
+  facet normal -0.138073 0.694261 -0.706355
+    outer loop
+      vertex -48.1721 4.30741 -59.5037
+      vertex -48.3413 4.27376 -59.5037
+      vertex -48.1963 4.49082 -59.3187
+    endloop
+  endfacet
+  facet normal -0.0462969 0.706356 -0.706341
+    outer loop
+      vertex -48.1721 4.30741 -59.5037
+      vertex -48.1963 4.49082 -59.3187
+      vertex -48 4.31869 -59.5037
+    endloop
+  endfacet
+  facet normal 0.694921 -0.609282 0.381917
+    outer loop
+      vertex 49.4231 0.908037 48.8846
+      vertex 49.3392 0.660839 48.6429
+      vertex 49.5025 0.847092 48.6429
+    endloop
+  endfacet
+  facet normal 0.768497 -0.513381 0.381906
+    outer loop
+      vertex 49.6401 1.05307 48.6429
+      vertex 49.4231 0.908037 48.8846
+      vertex 49.5025 0.847092 48.6429
+    endloop
+  endfacet
+  facet normal 0.401763 0.458179 0.79288
+    outer loop
+      vertex 48.8028 4.04619 49.5037
+      vertex 48.6764 3.88153 49.6629
+      vertex 48.9325 3.93246 49.5037
+    endloop
+  endfacet
+  facet normal 0.40176 0.458185 0.792878
+    outer loop
+      vertex 48.9325 3.93246 49.5037
+      vertex 48.6764 3.88153 49.6629
+      vertex 48.7857 3.78569 49.6629
+    endloop
+  endfacet
+  facet normal 0.254312 -0.0505664 0.965799
+    outer loop
+      vertex 48.6374 1.91609 49.8939
+      vertex 48.3769 1.89901 49.9616
+      vertex 48.621 1.83361 49.8939
+    endloop
+  endfacet
+  facet normal 0.254299 -0.0502908 0.965817
+    outer loop
+      vertex 48.3868 1.94907 49.9616
+      vertex 48.3769 1.89901 49.9616
+      vertex 48.6374 1.91609 49.8939
+    endloop
+  endfacet
+  facet normal 0.588625 -0.3934 0.706227
+    outer loop
+      vertex 49.3022 1.24816 49.3187
+      vertex 49.0462 1.19723 49.5037
+      vertex 49.1929 1.08462 49.3187
+    endloop
+  endfacet
+  facet normal 0.58865 -0.3932 0.706318
+    outer loop
+      vertex 49.142 1.34065 49.5037
+      vertex 49.0462 1.19723 49.5037
+      vertex 49.3022 1.24816 49.3187
+    endloop
+  endfacet
+  facet normal 0.393128 -0.588675 0.706337
+    outer loop
+      vertex 48.8028 0.953812 49.5037
+      vertex 48.6593 0.85798 49.5037
+      vertex 48.7518 0.697776 49.3187
+    endloop
+  endfacet
+  facet normal 0.393197 -0.588666 0.706306
+    outer loop
+      vertex 48.8028 0.953812 49.5037
+      vertex 48.7518 0.697776 49.3187
+      vertex 48.9154 0.807052 49.3187
+    endloop
+  endfacet
+  facet normal -0.278603 -0.820443 0.499253
+    outer loop
+      vertex -48.6364 0.463645 49.1111
+      vertex -48.6864 0.342795 48.8846
+      vertex -48.4643 0.267375 48.8846
+    endloop
+  endfacet
+  facet normal -0.383215 -0.77712 0.49923
+    outer loop
+      vertex -48.6364 0.463645 49.1111
+      vertex -48.8315 0.559853 49.1111
+      vertex -48.6864 0.342795 48.8846
+    endloop
+  endfacet
+  facet normal -0.269492 -0.546699 -0.792776
+    outer loop
+      vertex -48.4252 0.97344 -59.6629
+      vertex -48.6593 0.85798 -59.5037
+      vertex -48.5556 1.03772 -59.6629
+    endloop
+  endfacet
+  facet normal -0.338735 -0.506739 -0.792764
+    outer loop
+      vertex -48.6593 0.85798 -59.5037
+      vertex -48.6764 1.11847 -59.6629
+      vertex -48.5556 1.03772 -59.6629
+    endloop
+  endfacet
+  facet normal -0.213155 -0.318953 -0.92349
+    outer loop
+      vertex -48.4423 1.23393 -59.7937
+      vertex -48.5385 1.29822 -59.7937
+      vertex -48.3214 1.44325 -59.8939
+    endloop
+  endfacet
+  facet normal -0.213009 -0.319148 -0.923456
+    outer loop
+      vertex -48.3214 1.44325 -59.8939
+      vertex -48.5385 1.29822 -59.7937
+      vertex -48.3914 1.48997 -59.8939
+    endloop
+  endfacet
+  facet normal -0.143959 -0.215692 -0.965791
+    outer loop
+      vertex -48.3214 1.44325 -59.8939
+      vertex -48.3914 1.48997 -59.8939
+      vertex -48.1951 1.66209 -59.9616
+    endloop
+  endfacet
+  facet normal -0.114712 -0.232571 -0.965791
+    outer loop
+      vertex -48.246 1.40606 -59.8939
+      vertex -48.3214 1.44325 -59.8939
+      vertex -48.1951 1.66209 -59.9616
+    endloop
+  endfacet
+  facet normal -0.252976 -0.28849 -0.923459
+    outer loop
+      vertex -48.5385 1.29822 -59.7937
+      vertex -48.6255 1.37451 -59.7937
+      vertex -48.3914 1.48997 -59.8939
+    endloop
+  endfacet
+  facet normal -0.330185 -0.376539 -0.865561
+    outer loop
+      vertex -48.5385 1.29822 -59.7937
+      vertex -48.6764 1.11847 -59.6629
+      vertex -48.6255 1.37451 -59.7937
+    endloop
+  endfacet
+  facet normal -0.194878 -0.17116 -0.965778
+    outer loop
+      vertex -48.2759 1.7241 -59.9616
+      vertex -48.51 1.60864 -59.8939
+      vertex -48.3096 1.76247 -59.9616
+    endloop
+  endfacet
+  facet normal -0.195016 -0.170893 -0.965797
+    outer loop
+      vertex -48.4546 1.54542 -59.8939
+      vertex -48.51 1.60864 -59.8939
+      vertex -48.2759 1.7241 -59.9616
+    endloop
+  endfacet
+  facet normal -0.0860326 -0.0983012 -0.991431
+    outer loop
+      vertex -48.0796 1.89622 -59.9957
+      vertex -48.2759 1.7241 -59.9616
+      vertex -48.0925 1.90751 -59.9957
+    endloop
+  endfacet
+  facet normal -0.0981186 -0.0862162 -0.991433
+    outer loop
+      vertex -48.0925 1.90751 -59.9957
+      vertex -48.2759 1.7241 -59.9616
+      vertex -48.1038 1.92037 -59.9957
+    endloop
+  endfacet
+  facet normal -0.474141 -0.160884 -0.865625
+    outer loop
+      vertex -49.0266 1.57479 -59.6629
+      vertex -49.0733 1.71242 -59.6629
+      vertex -48.8544 1.77106 -59.7937
+    endloop
+  endfacet
+  facet normal -0.577082 -0.195813 -0.792864
+    outer loop
+      vertex -49.0266 1.57479 -59.6629
+      vertex -49.2738 1.6587 -59.5037
+      vertex -49.0733 1.71242 -59.6629
+    endloop
+  endfacet
+  facet normal -0.820542 0.278454 -0.499174
+    outer loop
+      vertex -49.6063 3.4304 -59.1111
+      vertex -49.7326 3.46426 -58.8846
+      vertex -49.5364 3.63638 -59.1111
+    endloop
+  endfacet
+  facet normal -0.849887 0.16891 -0.499161
+    outer loop
+      vertex -49.6487 3.21706 -59.1111
+      vertex -49.7326 3.46426 -58.8846
+      vertex -49.6063 3.4304 -59.1111
+    endloop
+  endfacet
+  facet normal -0.906365 -0.180549 -0.381976
+    outer loop
+      vertex -49.8293 1.50983 -58.6429
+      vertex -49.8777 1.7528 -58.6429
+      vertex -49.7326 1.53574 -58.8846
+    endloop
+  endfacet
+  facet normal -0.875161 -0.296968 -0.381972
+    outer loop
+      vertex -49.7497 1.27525 -58.6429
+      vertex -49.8293 1.50983 -58.6429
+      vertex -49.7326 1.53574 -58.8846
+    endloop
+  endfacet
+  facet normal -0.922148 0.0602608 -0.382114
+    outer loop
+      vertex -49.7937 3 -58.8846
+      vertex -49.8777 3.2472 -58.6429
+      vertex -49.7784 3.23413 -58.8846
+    endloop
+  endfacet
+  facet normal 0.0579371 0.117099 -0.991429
+    outer loop
+      vertex 48.0654 3.11328 -59.9957
+      vertex 48.0501 3.12085 -59.9957
+      vertex 48.1493 3.36048 -59.9616
+    endloop
+  endfacet
+  facet normal 0.123523 0.0426729 -0.991424
+    outer loop
+      vertex 48.1264 3.03385 -59.9957
+      vertex 48.1208 3.05006 -59.9957
+      vertex 48.3769 3.10099 -59.9616
+    endloop
+  endfacet
+  facet normal 0.128203 0.0252128 -0.991427
+    outer loop
+      vertex 48.1297 3.01707 -59.9957
+      vertex 48.1264 3.03385 -59.9957
+      vertex 48.3769 3.10099 -59.9616
+    endloop
+  endfacet
+  facet normal 0.108679 0.0724696 -0.991432
+    outer loop
+      vertex 48.3379 3.19509 -59.9616
+      vertex 48.1133 3.0654 -59.9957
+      vertex 48.3096 3.23753 -59.9616
+    endloop
+  endfacet
+  facet normal 0.117135 0.0578253 -0.991431
+    outer loop
+      vertex 48.3605 3.14931 -59.9616
+      vertex 48.1133 3.0654 -59.9957
+      vertex 48.3379 3.19509 -59.9616
+    endloop
+  endfacet
+  facet normal 0.123664 -0.041972 -0.991436
+    outer loop
+      vertex 48.3605 1.85069 -59.9616
+      vertex 48.1208 1.94994 -59.9957
+      vertex 48.3769 1.89901 -59.9616
+    endloop
+  endfacet
+  facet normal 0.254299 -0.0502908 -0.965817
+    outer loop
+      vertex 48.6374 1.91609 -59.8939
+      vertex 48.3769 1.89901 -59.9616
+      vertex 48.3868 1.94907 -59.9616
+    endloop
+  endfacet
+  facet normal 0.254312 -0.0505664 -0.965799
+    outer loop
+      vertex 48.621 1.83361 -59.8939
+      vertex 48.3769 1.89901 -59.9616
+      vertex 48.6374 1.91609 -59.8939
+    endloop
+  endfacet
+  facet normal 0.169714 -0.344082 -0.923474
+    outer loop
+      vertex 48.3385 1.18276 -59.7937
+      vertex 48.246 1.40606 -59.8939
+      vertex 48.3214 1.44325 -59.8939
+    endloop
+  endfacet
+  facet normal 0.143959 -0.215692 -0.965791
+    outer loop
+      vertex 48.3214 1.44325 -59.8939
+      vertex 48.1951 1.66209 -59.9616
+      vertex 48.3914 1.48997 -59.8939
+    endloop
+  endfacet
+  facet normal 0.123368 -0.363305 -0.923466
+    outer loop
+      vertex 48.2289 1.14556 -59.7937
+      vertex 48.1664 1.37903 -59.8939
+      vertex 48.246 1.40606 -59.8939
+    endloop
+  endfacet
+  facet normal 0.0748487 -0.376296 -0.923471
+    outer loop
+      vertex 48.2289 1.14556 -59.7937
+      vertex 48.0839 1.36262 -59.8939
+      vertex 48.1664 1.37903 -59.8939
+    endloop
+  endfacet
+  facet normal 0.0419945 -0.123693 -0.991432
+    outer loop
+      vertex 48.101 1.62311 -59.9616
+      vertex 48.0339 1.87365 -59.9957
+      vertex 48.0501 1.87915 -59.9957
+    endloop
+  endfacet
+  facet normal 0.0505091 -0.254322 -0.9658
+    outer loop
+      vertex 48.0839 1.36262 -59.8939
+      vertex 48.0509 1.61316 -59.9616
+      vertex 48.101 1.62311 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0169781 -0.258738 -0.965798
+    outer loop
+      vertex 48.0839 1.36262 -59.8939
+      vertex 48 1.60982 -59.9616
+      vertex 48.0509 1.61316 -59.9616
+    endloop
+  endfacet
+  facet normal 0.00855315 -0.130346 -0.991432
+    outer loop
+      vertex 48.0509 1.61316 -59.9616
+      vertex 48 1.60982 -59.9616
+      vertex 48 1.86919 -59.9957
+    endloop
+  endfacet
+  facet normal 0.608045 0.0398292 -0.792903
+    outer loop
+      vertex 49.1111 3 -59.6629
+      vertex 49.1016 3.14503 -59.6629
+      vertex 49.3187 3 -59.5037
+    endloop
+  endfacet
+  facet normal 0.382882 0.0250965 -0.923456
+    outer loop
+      vertex 48.6429 3 -59.8939
+      vertex 48.6374 3.08391 -59.8939
+      vertex 48.877 3.11546 -59.7937
+    endloop
+  endfacet
+  facet normal 0.114712 -0.232571 -0.965791
+    outer loop
+      vertex 48.246 1.40606 -59.8939
+      vertex 48.1951 1.66209 -59.9616
+      vertex 48.3214 1.44325 -59.8939
+    endloop
+  endfacet
+  facet normal 0.11462 -0.232591 -0.965797
+    outer loop
+      vertex 48.246 1.40606 -59.8939
+      vertex 48.1493 1.63952 -59.9616
+      vertex 48.1951 1.66209 -59.9616
+    endloop
+  endfacet
+  facet normal 0.194878 -0.17116 -0.965778
+    outer loop
+      vertex 48.51 1.60864 -59.8939
+      vertex 48.2759 1.7241 -59.9616
+      vertex 48.3096 1.76247 -59.9616
+    endloop
+  endfacet
+  facet normal 0.108632 -0.0725231 -0.991433
+    outer loop
+      vertex 48.3096 1.76247 -59.9616
+      vertex 48.1038 1.92037 -59.9957
+      vertex 48.1133 1.9346 -59.9957
+    endloop
+  endfacet
+  facet normal -0.597118 0.523306 0.607949
+    outer loop
+      vertex -49.0633 4.06326 49.3187
+      vertex -49.3193 4.01233 49.1111
+      vertex -49.1929 3.91538 49.3187
+    endloop
+  endfacet
+  facet normal -0.660116 0.44118 0.607953
+    outer loop
+      vertex -49.1929 3.91538 49.3187
+      vertex -49.3193 4.01233 49.1111
+      vertex -49.3022 3.75184 49.3187
+    endloop
+  endfacet
+  facet normal -0.51342 0.76847 -0.381907
+    outer loop
+      vertex -49.092 4.42307 -58.8846
+      vertex -49.1529 4.5025 -58.6429
+      vertex -48.9469 4.64013 -58.6429
+    endloop
+  endfacet
+  facet normal -0.609286 0.69493 -0.381894
+    outer loop
+      vertex -49.092 4.42307 -58.8846
+      vertex -49.3392 4.33916 -58.6429
+      vertex -49.1529 4.5025 -58.6429
+    endloop
+  endfacet
+  facet normal -0.160998 0.474173 -0.865586
+    outer loop
+      vertex -48.2289 3.85444 -59.7937
+      vertex -48.4252 4.02656 -59.6629
+      vertex -48.2876 4.07328 -59.6629
+    endloop
+  endfacet
+  facet normal -0.160955 0.474212 -0.865573
+    outer loop
+      vertex -48.3385 3.81724 -59.7937
+      vertex -48.4252 4.02656 -59.6629
+      vertex -48.2289 3.85444 -59.7937
+    endloop
+  endfacet
+  facet normal -0.466723 0.532257 -0.706309
+    outer loop
+      vertex -48.8028 4.04619 -59.5037
+      vertex -49.0633 4.06326 -59.3187
+      vertex -48.9154 4.19295 -59.3187
+    endloop
+  endfacet
+  facet normal -0.351199 0.712086 -0.607941
+    outer loop
+      vertex -48.7518 4.30222 -59.3187
+      vertex -48.8315 4.44015 -59.1111
+      vertex -48.5754 4.38922 -59.3187
+    endloop
+  endfacet
+  facet normal -0.393126 0.588684 -0.706331
+    outer loop
+      vertex -48.6593 4.14202 -59.5037
+      vertex -48.8028 4.04619 -59.5037
+      vertex -48.7518 4.30222 -59.3187
+    endloop
+  endfacet
+  facet normal -0.532304 0.466674 -0.706305
+    outer loop
+      vertex -49.0462 3.80277 -59.5037
+      vertex -49.0633 4.06326 -59.3187
+      vertex -48.9325 3.93246 -59.5037
+    endloop
+  endfacet
+  facet normal -0.401763 0.458179 -0.79288
+    outer loop
+      vertex -48.6764 3.88153 -59.6629
+      vertex -48.9325 3.93246 -59.5037
+      vertex -48.8028 4.04619 -59.5037
+    endloop
+  endfacet
+  facet normal -0.40176 0.458185 -0.792878
+    outer loop
+      vertex -48.7857 3.78569 -59.6629
+      vertex -48.9325 3.93246 -59.5037
+      vertex -48.6764 3.88153 -59.6629
+    endloop
+  endfacet
+  facet normal -0.875161 0.296968 -0.381972
+    outer loop
+      vertex -49.7326 3.46426 -58.8846
+      vertex -49.8293 3.49017 -58.6429
+      vertex -49.7497 3.72475 -58.6429
+    endloop
+  endfacet
+  facet normal -0.914834 0.31043 -0.258286
+    outer loop
+      vertex -49.8293 3.49017 -58.6429
+      vertex -49.8947 3.50769 -58.3902
+      vertex -49.7497 3.72475 -58.6429
+    endloop
+  endfacet
+  facet normal -0.670487 0.227516 -0.706175
+    outer loop
+      vertex -49.2738 3.3413 -59.5037
+      vertex -49.4524 3.38918 -59.3187
+      vertex -49.3892 3.57543 -59.3187
+    endloop
+  endfacet
+  facet normal -0.660335 0.441051 -0.607809
+    outer loop
+      vertex -49.3022 3.75184 -59.3187
+      vertex -49.4401 3.83147 -59.1111
+      vertex -49.3193 4.01233 -59.1111
+    endloop
+  endfacet
+  facet normal -0.751827 0.255117 -0.608006
+    outer loop
+      vertex -49.4524 3.38918 -59.3187
+      vertex -49.6063 3.4304 -59.1111
+      vertex -49.3892 3.57543 -59.3187
+    endloop
+  endfacet
+  facet normal -0.751829 0.255136 -0.607995
+    outer loop
+      vertex -49.3892 3.57543 -59.3187
+      vertex -49.6063 3.4304 -59.1111
+      vertex -49.5364 3.63638 -59.1111
+    endloop
+  endfacet
+  facet normal -0.964026 0.0631765 -0.25819
+    outer loop
+      vertex -49.8939 3 -58.6429
+      vertex -49.9448 3.25604 -58.3902
+      vertex -49.8777 3.2472 -58.6429
+    endloop
+  endfacet
+  facet normal -0.947499 0.188634 -0.25819
+    outer loop
+      vertex -49.8777 3.2472 -58.6429
+      vertex -49.9448 3.25604 -58.3902
+      vertex -49.8947 3.50769 -58.3902
+    endloop
+  endfacet
+  facet normal -0.338431 0.506781 -0.792866
+    outer loop
+      vertex -48.6764 3.88153 -59.6629
+      vertex -48.8028 4.04619 -59.5037
+      vertex -48.6593 4.14202 -59.5037
+    endloop
+  endfacet
+  facet normal -0.338735 0.506739 -0.792764
+    outer loop
+      vertex -48.5556 3.96228 -59.6629
+      vertex -48.6764 3.88153 -59.6629
+      vertex -48.6593 4.14202 -59.5037
+    endloop
+  endfacet
+  facet normal -0.416373 0.278275 -0.865561
+    outer loop
+      vertex -48.7661 3.44229 -59.7937
+      vertex -48.9623 3.55557 -59.6629
+      vertex -48.7018 3.5385 -59.7937
+    endloop
+  endfacet
+  facet normal -0.449015 0.221476 -0.865641
+    outer loop
+      vertex -48.8172 3.33851 -59.7937
+      vertex -49.0266 3.42521 -59.6629
+      vertex -48.9623 3.55557 -59.6629
+    endloop
+  endfacet
+  facet normal -0.634888 0.313107 -0.706315
+    outer loop
+      vertex -49.142 3.65935 -59.5037
+      vertex -49.3892 3.57543 -59.3187
+      vertex -49.3022 3.75184 -59.3187
+    endloop
+  endfacet
+  facet normal -0.58865 0.3932 -0.706318
+    outer loop
+      vertex -49.142 3.65935 -59.5037
+      vertex -49.3022 3.75184 -59.3187
+      vertex -49.0462 3.80277 -59.5037
+    endloop
+  endfacet
+  facet normal -0.71219 0.35123 -0.607801
+    outer loop
+      vertex -49.3892 3.57543 -59.3187
+      vertex -49.4401 3.83147 -59.1111
+      vertex -49.3022 3.75184 -59.3187
+    endloop
+  endfacet
+  facet normal -0.694418 0.138228 -0.70617
+    outer loop
+      vertex -49.2738 3.3413 -59.5037
+      vertex -49.4908 3.19627 -59.3187
+      vertex -49.4524 3.38918 -59.3187
+    endloop
+  endfacet
+  facet normal -0.0505877 0.254326 -0.965795
+    outer loop
+      vertex -48.101 3.37689 -59.9616
+      vertex -48.1664 3.62097 -59.8939
+      vertex -48.0839 3.63738 -59.8939
+    endloop
+  endfacet
+  facet normal -0.0833786 0.24554 -0.965794
+    outer loop
+      vertex -48.101 3.37689 -59.9616
+      vertex -48.246 3.59394 -59.8939
+      vertex -48.1664 3.62097 -59.8939
+    endloop
+  endfacet
+  facet normal -0.0505091 0.254322 -0.9658
+    outer loop
+      vertex -48.0509 3.38684 -59.9616
+      vertex -48.101 3.37689 -59.9616
+      vertex -48.0839 3.63738 -59.8939
+    endloop
+  endfacet
+  facet normal -0.0169781 0.258738 -0.965798
+    outer loop
+      vertex -48.0509 3.38684 -59.9616
+      vertex -48.0839 3.63738 -59.8939
+      vertex -48 3.39018 -59.9616
+    endloop
+  endfacet
+  facet normal -0.144138 0.215495 -0.965809
+    outer loop
+      vertex -48.2375 3.30955 -59.9616
+      vertex -48.3914 3.51003 -59.8939
+      vertex -48.1951 3.33791 -59.9616
+    endloop
+  endfacet
+  facet normal -0.169714 0.344082 -0.923474
+    outer loop
+      vertex -48.3214 3.55675 -59.8939
+      vertex -48.3385 3.81724 -59.7937
+      vertex -48.246 3.59394 -59.8939
+    endloop
+  endfacet
+  facet normal -0.0254711 0.128118 -0.991432
+    outer loop
+      vertex -48.0339 3.12635 -59.9957
+      vertex -48.101 3.37689 -59.9616
+      vertex -48.0171 3.12969 -59.9957
+    endloop
+  endfacet
+  facet normal -0.0981411 0.0861964 -0.991433
+    outer loop
+      vertex -48.1038 3.07963 -59.9957
+      vertex -48.3096 3.23753 -59.9616
+      vertex -48.2759 3.2759 -59.9616
+    endloop
+  endfacet
+  facet normal -0.0860326 0.0983012 -0.991431
+    outer loop
+      vertex -48.0925 3.09249 -59.9957
+      vertex -48.2759 3.2759 -59.9616
+      vertex -48.0796 3.10378 -59.9957
+    endloop
+  endfacet
+  facet normal -0.117298 0.0573489 -0.99144
+    outer loop
+      vertex -48.1208 3.05006 -59.9957
+      vertex -48.3605 3.14931 -59.9616
+      vertex -48.1133 3.0654 -59.9957
+    endloop
+  endfacet
+  facet normal -0.123664 0.041972 -0.991436
+    outer loop
+      vertex -48.1208 3.05006 -59.9957
+      vertex -48.3769 3.10099 -59.9616
+      vertex -48.3605 3.14931 -59.9616
+    endloop
+  endfacet
+  facet normal -0.330173 0.376543 -0.865564
+    outer loop
+      vertex -48.6255 3.62549 -59.7937
+      vertex -48.7857 3.78569 -59.6629
+      vertex -48.6764 3.88153 -59.6629
+    endloop
+  endfacet
+  facet normal -0.195016 0.170893 -0.965797
+    outer loop
+      vertex -48.2759 3.2759 -59.9616
+      vertex -48.51 3.39136 -59.8939
+      vertex -48.4546 3.45458 -59.8939
+    endloop
+  endfacet
+  facet normal -0.255289 0.751895 0.607849
+    outer loop
+      vertex -48.4304 4.60628 49.1111
+      vertex -48.5754 4.38922 49.3187
+      vertex -48.3892 4.45244 49.3187
+    endloop
+  endfacet
+  facet normal -0.227586 0.670302 0.706329
+    outer loop
+      vertex -48.3892 4.45244 49.3187
+      vertex -48.5754 4.38922 49.3187
+      vertex -48.3413 4.27376 49.5037
+    endloop
+  endfacet
+  facet normal -0.609286 -0.694935 0.381884
+    outer loop
+      vertex -49.092 0.576926 48.8846
+      vertex -49.3392 0.660839 48.6429
+      vertex -49.1529 0.4975 48.6429
+    endloop
+  endfacet
+  facet normal -0.636887 -0.726415 0.258256
+    outer loop
+      vertex -49.1529 0.4975 48.6429
+      vertex -49.3392 0.660839 48.6429
+      vertex -49.1941 0.443782 48.3902
+    endloop
+  endfacet
+  facet normal -0.117298 0.0573489 0.99144
+    outer loop
+      vertex -48.1133 3.0654 49.9957
+      vertex -48.3605 3.14931 49.9616
+      vertex -48.1208 3.05006 49.9957
+    endloop
+  endfacet
+  facet normal -0.123664 0.041972 0.991436
+    outer loop
+      vertex -48.3605 3.14931 49.9616
+      vertex -48.3769 3.10099 49.9616
+      vertex -48.1208 3.05006 49.9957
+    endloop
+  endfacet
+  facet normal 0.393126 0.588684 0.706331
+    outer loop
+      vertex 48.7518 4.30222 49.3187
+      vertex 48.6593 4.14202 49.5037
+      vertex 48.8028 4.04619 49.5037
+    endloop
+  endfacet
+  facet normal 0.441059 0.660358 0.607778
+    outer loop
+      vertex 49.0123 4.3193 49.1111
+      vertex 48.7518 4.30222 49.3187
+      vertex 48.9154 4.19295 49.3187
+    endloop
+  endfacet
+  facet normal -0.227592 -0.670295 0.706333
+    outer loop
+      vertex -48.5046 0.781689 49.5037
+      vertex -48.5754 0.610782 49.3187
+      vertex -48.3413 0.726242 49.5037
+    endloop
+  endfacet
+  facet normal -0.278473 -0.820433 0.499343
+    outer loop
+      vertex -48.4304 0.393724 49.1111
+      vertex -48.6364 0.463645 49.1111
+      vertex -48.4643 0.267375 48.8846
+    endloop
+  endfacet
+  facet normal -0.313097 -0.634876 0.706331
+    outer loop
+      vertex -48.6593 0.85798 49.5037
+      vertex -48.7518 0.697776 49.3187
+      vertex -48.5754 0.610782 49.3187
+    endloop
+  endfacet
+  facet normal -0.351185 -0.712107 0.607925
+    outer loop
+      vertex -48.7518 0.697776 49.3187
+      vertex -48.8315 0.559853 49.1111
+      vertex -48.5754 0.610782 49.3187
+    endloop
+  endfacet
+  facet normal 0 -0.793422 0.608672
+    outer loop
+      vertex -48 0.337061 49.1111
+      vertex 48 0.496321 49.3187
+      vertex -48 0.496321 49.3187
+    endloop
+  endfacet
+  facet normal 0 -0.793422 0.608672
+    outer loop
+      vertex 48 0.496321 49.3187
+      vertex -48 0.337061 49.1111
+      vertex 48 0.337061 49.1111
+    endloop
+  endfacet
+  facet normal 0 -0.70713 0.707084
+    outer loop
+      vertex -48 0.681309 49.5037
+      vertex 48 0.496321 49.3187
+      vertex 48 0.681309 49.5037
+    endloop
+  endfacet
+  facet normal 0 -0.70713 0.707084
+    outer loop
+      vertex 48 0.496321 49.3187
+      vertex -48 0.681309 49.5037
+      vertex -48 0.496321 49.3187
+    endloop
+  endfacet
+  facet normal -0.0604423 -0.922191 0.381982
+    outer loop
+      vertex -48 0.206255 48.8846
+      vertex -48.2472 0.122342 48.6429
+      vertex -48 0.10614 48.6429
+    endloop
+  endfacet
+  facet normal 0 -0.92388 0.382682
+    outer loop
+      vertex -48 0.10614 48.6429
+      vertex 48 0.206255 48.8846
+      vertex -48 0.206255 48.8846
+    endloop
+  endfacet
+  facet normal 0 -0.92388 0.382682
+    outer loop
+      vertex 48 0.206255 48.8846
+      vertex -48 0.10614 48.6429
+      vertex 48 0.10614 48.6429
+    endloop
+  endfacet
+  facet normal -0.0420229 -0.123687 0.991431
+    outer loop
+      vertex -48.0501 1.87915 49.9957
+      vertex -48.1493 1.63952 49.9616
+      vertex -48.101 1.62311 49.9616
+    endloop
+  endfacet
+  facet normal -0.0579371 -0.117099 0.991429
+    outer loop
+      vertex -48.0654 1.88672 49.9957
+      vertex -48.1493 1.63952 49.9616
+      vertex -48.0501 1.87915 49.9957
+    endloop
+  endfacet
+  facet normal 0.0250966 0.382837 -0.923475
+    outer loop
+      vertex 48.0839 3.63738 -59.8939
+      vertex 48 3.64288 -59.8939
+      vertex 48.1155 3.87701 -59.7937
+    endloop
+  endfacet
+  facet normal 0.0250917 0.382839 -0.923474
+    outer loop
+      vertex 48.1155 3.87701 -59.7937
+      vertex 48 3.64288 -59.8939
+      vertex 48 3.88458 -59.7937
+    endloop
+  endfacet
+  facet normal 0.0420229 0.123687 -0.991431
+    outer loop
+      vertex 48.1493 3.36048 -59.9616
+      vertex 48.0501 3.12085 -59.9957
+      vertex 48.101 3.37689 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0834146 0.245516 -0.965797
+    outer loop
+      vertex 48.1493 3.36048 -59.9616
+      vertex 48.101 3.37689 -59.9616
+      vertex 48.246 3.59394 -59.8939
+    endloop
+  endfacet
+  facet normal 0.143959 0.215692 -0.965791
+    outer loop
+      vertex 48.3914 3.51003 -59.8939
+      vertex 48.1951 3.33791 -59.9616
+      vertex 48.3214 3.55675 -59.8939
+    endloop
+  endfacet
+  facet normal 0.144138 0.215495 -0.965809
+    outer loop
+      vertex 48.2375 3.30955 -59.9616
+      vertex 48.1951 3.33791 -59.9616
+      vertex 48.3914 3.51003 -59.8939
+    endloop
+  endfacet
+  facet normal 0.278308 0.416342 -0.865566
+    outer loop
+      vertex 48.6764 3.88153 -59.6629
+      vertex 48.5385 3.70178 -59.7937
+      vertex 48.5556 3.96228 -59.6629
+    endloop
+  endfacet
+  facet normal 0.330185 0.376539 -0.865561
+    outer loop
+      vertex 48.6255 3.62549 -59.7937
+      vertex 48.5385 3.70178 -59.7937
+      vertex 48.6764 3.88153 -59.6629
+    endloop
+  endfacet
+  facet normal 0.171006 0.194906 -0.965799
+    outer loop
+      vertex 48.4546 3.45458 -59.8939
+      vertex 48.2759 3.2759 -59.9616
+      vertex 48.3914 3.51003 -59.8939
+    endloop
+  endfacet
+  facet normal 0.253029 0.288394 -0.923474
+    outer loop
+      vertex 48.4546 3.45458 -59.8939
+      vertex 48.3914 3.51003 -59.8939
+      vertex 48.6255 3.62549 -59.7937
+    endloop
+  endfacet
+  facet normal 0.123664 -0.041972 0.991436
+    outer loop
+      vertex 48.3769 1.89901 49.9616
+      vertex 48.1208 1.94994 49.9957
+      vertex 48.3605 1.85069 49.9616
+    endloop
+  endfacet
+  facet normal 0.245596 -0.0833562 0.965782
+    outer loop
+      vertex 48.3769 1.89901 49.9616
+      vertex 48.3605 1.85069 49.9616
+      vertex 48.5939 1.75398 49.8939
+    endloop
+  endfacet
+  facet normal -0.221423 -0.449163 -0.865577
+    outer loop
+      vertex -48.3385 1.18276 -59.7937
+      vertex -48.5556 1.03772 -59.6629
+      vertex -48.4423 1.23393 -59.7937
+    endloop
+  endfacet
+  facet normal -0.278247 -0.416353 -0.86558
+    outer loop
+      vertex -48.4423 1.23393 -59.7937
+      vertex -48.5556 1.03772 -59.6629
+      vertex -48.5385 1.29822 -59.7937
+    endloop
+  endfacet
+  facet normal 0.00853748 0.130349 -0.991431
+    outer loop
+      vertex 48.0171 3.12969 -59.9957
+      vertex 48 3.13081 -59.9957
+      vertex 48.0509 3.38684 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0254463 -0.128126 -0.991431
+    outer loop
+      vertex 48.0509 1.61316 -59.9616
+      vertex 48.0171 1.87031 -59.9957
+      vertex 48.101 1.62311 -59.9616
+    endloop
+  endfacet
+  facet normal 0.00853748 -0.130349 -0.991431
+    outer loop
+      vertex 48.0509 1.61316 -59.9616
+      vertex 48 1.86919 -59.9957
+      vertex 48.0171 1.87031 -59.9957
+    endloop
+  endfacet
+  facet normal 0.499757 0.0327359 -0.865547
+    outer loop
+      vertex 49.1111 3 -59.6629
+      vertex 48.877 3.11546 -59.7937
+      vertex 49.1016 3.14503 -59.6629
+    endloop
+  endfacet
+  facet normal 0.499816 0.0328997 -0.865507
+    outer loop
+      vertex 48.8846 3 -59.7937
+      vertex 48.877 3.11546 -59.7937
+      vertex 49.1111 3 -59.6629
+    endloop
+  endfacet
+  facet normal 0.170862 -0.194981 -0.96581
+    outer loop
+      vertex 48.3914 1.48997 -59.8939
+      vertex 48.2375 1.69045 -59.9616
+      vertex 48.2759 1.7241 -59.9616
+    endloop
+  endfacet
+  facet normal 0.057739 -0.117166 -0.991432
+    outer loop
+      vertex 48.1493 1.63952 -59.9616
+      vertex 48.0654 1.88672 -59.9957
+      vertex 48.1951 1.66209 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0981411 -0.0861964 -0.991433
+    outer loop
+      vertex 48.2759 1.7241 -59.9616
+      vertex 48.1038 1.92037 -59.9957
+      vertex 48.3096 1.76247 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0981186 -0.0862162 -0.991433
+    outer loop
+      vertex 48.2759 1.7241 -59.9616
+      vertex 48.0925 1.90751 -59.9957
+      vertex 48.1038 1.92037 -59.9957
+    endloop
+  endfacet
+  facet normal 0.232563 -0.114808 -0.965781
+    outer loop
+      vertex 48.5939 1.75398 -59.8939
+      vertex 48.3379 1.80491 -59.9616
+      vertex 48.3605 1.85069 -59.9616
+    endloop
+  endfacet
+  facet normal 0.232583 -0.114719 -0.965787
+    outer loop
+      vertex 48.5567 1.67856 -59.8939
+      vertex 48.3379 1.80491 -59.9616
+      vertex 48.5939 1.75398 -59.8939
+    endloop
+  endfacet
+  facet normal -0.376531 0.33026 -0.865536
+    outer loop
+      vertex -48.7018 3.5385 -59.7937
+      vertex -48.8815 3.67642 -59.6629
+      vertex -48.6255 3.62549 -59.7937
+    endloop
+  endfacet
+  facet normal -0.523481 0.597097 -0.607818
+    outer loop
+      vertex -49.0633 4.06326 -59.3187
+      vertex -49.1759 4.17587 -59.1111
+      vertex -49.0123 4.3193 -59.1111
+    endloop
+  endfacet
+  facet normal -0.571131 0.651447 -0.499425
+    outer loop
+      vertex -49.0123 4.3193 -59.1111
+      vertex -49.1759 4.17587 -59.1111
+      vertex -49.092 4.42307 -58.8846
+    endloop
+  endfacet
+  facet normal -0.481448 0.72028 -0.499404
+    outer loop
+      vertex -49.0123 4.3193 -59.1111
+      vertex -49.092 4.42307 -58.8846
+      vertex -48.8315 4.44015 -59.1111
+    endloop
+  endfacet
+  facet normal -0.588625 0.3934 -0.706227
+    outer loop
+      vertex -49.0462 3.80277 -59.5037
+      vertex -49.3022 3.75184 -59.3187
+      vertex -49.1929 3.91538 -59.3187
+    endloop
+  endfacet
+  facet normal -0.660116 0.44118 -0.607953
+    outer loop
+      vertex -49.3022 3.75184 -59.3187
+      vertex -49.3193 4.01233 -59.1111
+      vertex -49.1929 3.91538 -59.3187
+    endloop
+  endfacet
+  facet normal -0.720482 0.481208 -0.499345
+    outer loop
+      vertex -49.4401 3.83147 -59.1111
+      vertex -49.5534 3.89687 -58.8846
+      vertex -49.4231 4.09196 -58.8846
+    endloop
+  endfacet
+  facet normal -0.720469 0.481216 -0.499355
+    outer loop
+      vertex -49.3193 4.01233 -59.1111
+      vertex -49.4401 3.83147 -59.1111
+      vertex -49.4231 4.09196 -58.8846
+    endloop
+  endfacet
+  facet normal -0.252976 0.28849 -0.923459
+    outer loop
+      vertex -48.3914 3.51003 -59.8939
+      vertex -48.6255 3.62549 -59.7937
+      vertex -48.5385 3.70178 -59.7937
+    endloop
+  endfacet
+  facet normal -0.278308 0.416342 -0.865566
+    outer loop
+      vertex -48.5385 3.70178 -59.7937
+      vertex -48.6764 3.88153 -59.6629
+      vertex -48.5556 3.96228 -59.6629
+    endloop
+  endfacet
+  facet normal -0.546657 0.269601 -0.792768
+    outer loop
+      vertex -49.0266 3.42521 -59.6629
+      vertex -49.2183 3.50464 -59.5037
+      vertex -49.142 3.65935 -59.5037
+    endloop
+  endfacet
+  facet normal -0.376568 0.330147 -0.865563
+    outer loop
+      vertex -48.6255 3.62549 -59.7937
+      vertex -48.8815 3.67642 -59.6629
+      vertex -48.7857 3.78569 -59.6629
+    endloop
+  endfacet
+  facet normal -0.634888 0.313115 -0.706312
+    outer loop
+      vertex -49.2183 3.50464 -59.5037
+      vertex -49.3892 3.57543 -59.3187
+      vertex -49.142 3.65935 -59.5037
+    endloop
+  endfacet
+  facet normal -0.670259 0.227742 -0.706319
+    outer loop
+      vertex -49.2738 3.3413 -59.5037
+      vertex -49.3892 3.57543 -59.3187
+      vertex -49.2183 3.50464 -59.5037
+    endloop
+  endfacet
+  facet normal -0.057739 0.117166 -0.991432
+    outer loop
+      vertex -48.0654 3.11328 -59.9957
+      vertex -48.1951 3.33791 -59.9616
+      vertex -48.1493 3.36048 -59.9616
+    endloop
+  endfacet
+  facet normal -0.11462 0.232591 -0.965797
+    outer loop
+      vertex -48.1951 3.33791 -59.9616
+      vertex -48.246 3.59394 -59.8939
+      vertex -48.1493 3.36048 -59.9616
+    endloop
+  endfacet
+  facet normal -0.213155 0.318953 -0.92349
+    outer loop
+      vertex -48.3214 3.55675 -59.8939
+      vertex -48.5385 3.70178 -59.7937
+      vertex -48.4423 3.76607 -59.7937
+    endloop
+  endfacet
+  facet normal -0.169626 0.344093 -0.923486
+    outer loop
+      vertex -48.3214 3.55675 -59.8939
+      vertex -48.4423 3.76607 -59.7937
+      vertex -48.3385 3.81724 -59.7937
+    endloop
+  endfacet
+  facet normal -0.0726313 0.108565 -0.991432
+    outer loop
+      vertex -48.0796 3.10378 -59.9957
+      vertex -48.2375 3.30955 -59.9616
+      vertex -48.0654 3.11328 -59.9957
+    endloop
+  endfacet
+  facet normal -0.0254463 0.128126 -0.991431
+    outer loop
+      vertex -48.0171 3.12969 -59.9957
+      vertex -48.101 3.37689 -59.9616
+      vertex -48.0509 3.38684 -59.9616
+    endloop
+  endfacet
+  facet normal -0.00853748 0.130349 -0.991431
+    outer loop
+      vertex -48.0171 3.12969 -59.9957
+      vertex -48.0509 3.38684 -59.9616
+      vertex -48 3.13081 -59.9957
+    endloop
+  endfacet
+  facet normal -0.171006 0.194906 -0.965799
+    outer loop
+      vertex -48.2759 3.2759 -59.9616
+      vertex -48.4546 3.45458 -59.8939
+      vertex -48.3914 3.51003 -59.8939
+    endloop
+  endfacet
+  facet normal -0.170862 0.194981 -0.96581
+    outer loop
+      vertex -48.2759 3.2759 -59.9616
+      vertex -48.3914 3.51003 -59.8939
+      vertex -48.2375 3.30955 -59.9616
+    endloop
+  endfacet
+  facet normal -0.215801 0.143902 -0.965775
+    outer loop
+      vertex -48.3379 3.19509 -59.9616
+      vertex -48.51 3.39136 -59.8939
+      vertex -48.3096 3.23753 -59.9616
+    endloop
+  endfacet
+  facet normal -0.194878 0.17116 -0.965778
+    outer loop
+      vertex -48.3096 3.23753 -59.9616
+      vertex -48.51 3.39136 -59.8939
+      vertex -48.2759 3.2759 -59.9616
+    endloop
+  endfacet
+  facet normal 0.441217 0.660091 0.607954
+    outer loop
+      vertex 48.8315 4.44015 49.1111
+      vertex 48.7518 4.30222 49.3187
+      vertex 49.0123 4.3193 49.1111
+    endloop
+  endfacet
+  facet normal 0.523561 0.597075 0.607772
+    outer loop
+      vertex 49.0123 4.3193 49.1111
+      vertex 48.9154 4.19295 49.3187
+      vertex 49.0633 4.06326 49.3187
+    endloop
+  endfacet
+  facet normal -0.168981 -0.849814 0.499261
+    outer loop
+      vertex -48.2171 0.351288 49.1111
+      vertex -48.4643 0.267375 48.8846
+      vertex -48.2341 0.221601 48.8846
+    endloop
+  endfacet
+  facet normal -0.0566578 -0.864583 0.499286
+    outer loop
+      vertex -48.2171 0.351288 49.1111
+      vertex -48.2341 0.221601 48.8846
+      vertex -48 0.337061 49.1111
+    endloop
+  endfacet
+  facet normal 0.0976467 0.491161 -0.865578
+    outer loop
+      vertex 48.2289 3.85444 -59.7937
+      vertex 48.145 4.10163 -59.6629
+      vertex 48.2876 4.07328 -59.6629
+    endloop
+  endfacet
+  facet normal 0.160998 0.474173 -0.865586
+    outer loop
+      vertex 48.4252 4.02656 -59.6629
+      vertex 48.2289 3.85444 -59.7937
+      vertex 48.2876 4.07328 -59.6629
+    endloop
+  endfacet
+  facet normal 0.0254711 0.128118 -0.991432
+    outer loop
+      vertex 48.0339 3.12635 -59.9957
+      vertex 48.0171 3.12969 -59.9957
+      vertex 48.101 3.37689 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0254463 0.128126 -0.991431
+    outer loop
+      vertex 48.101 3.37689 -59.9616
+      vertex 48.0171 3.12969 -59.9957
+      vertex 48.0509 3.38684 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0419945 0.123693 -0.991432
+    outer loop
+      vertex 48.0501 3.12085 -59.9957
+      vertex 48.0339 3.12635 -59.9957
+      vertex 48.101 3.37689 -59.9616
+    endloop
+  endfacet
+  facet normal 0.057739 0.117166 -0.991432
+    outer loop
+      vertex 48.1951 3.33791 -59.9616
+      vertex 48.0654 3.11328 -59.9957
+      vertex 48.1493 3.36048 -59.9616
+    endloop
+  endfacet
+  facet normal 0.11462 0.232591 -0.965797
+    outer loop
+      vertex 48.1951 3.33791 -59.9616
+      vertex 48.1493 3.36048 -59.9616
+      vertex 48.246 3.59394 -59.8939
+    endloop
+  endfacet
+  facet normal 0.0726213 -0.108573 -0.991432
+    outer loop
+      vertex 48.1951 1.66209 -59.9616
+      vertex 48.0654 1.88672 -59.9957
+      vertex 48.2375 1.69045 -59.9616
+    endloop
+  endfacet
+  facet normal 0.0860872 -0.0982392 -0.991432
+    outer loop
+      vertex 48.2375 1.69045 -59.9616
+      vertex 48.0796 1.89622 -59.9957
+      vertex 48.2759 1.7241 -59.9616
+    endloop
+  endfacet
+  facet normal -0.532437 0.46662 -0.706241
+    outer loop
+      vertex -49.0462 3.80277 -59.5037
+      vertex -49.1929 3.91538 -59.3187
+      vertex -49.0633 4.06326 -59.3187
+    endloop
+  endfacet
+  facet normal -0.597118 0.523306 -0.607949
+    outer loop
+      vertex -49.1929 3.91538 -59.3187
+      vertex -49.3193 4.01233 -59.1111
+      vertex -49.0633 4.06326 -59.3187
+    endloop
+  endfacet
+  facet normal -0.253029 0.288394 -0.923474
+    outer loop
+      vertex -48.4546 3.45458 -59.8939
+      vertex -48.6255 3.62549 -59.7937
+      vertex -48.3914 3.51003 -59.8939
+    endloop
+  endfacet
+  facet normal -0.288558 0.252864 -0.923469
+    outer loop
+      vertex -48.51 3.39136 -59.8939
+      vertex -48.6255 3.62549 -59.7937
+      vertex -48.4546 3.45458 -59.8939
+    endloop
+  endfacet
+  facet normal -0.449303 0.221231 -0.865554
+    outer loop
+      vertex -48.8172 3.33851 -59.7937
+      vertex -48.9623 3.55557 -59.6629
+      vertex -48.7661 3.44229 -59.7937
+    endloop
+  endfacet
+  facet normal -0.506732 0.338481 -0.792876
+    outer loop
+      vertex -48.8815 3.67642 -59.6629
+      vertex -49.142 3.65935 -59.5037
+      vertex -49.0462 3.80277 -59.5037
+    endloop
+  endfacet
+  facet normal -0.344087 0.169717 -0.923472
+    outer loop
+      vertex -48.5939 3.24602 -59.8939
+      vertex -48.8172 3.33851 -59.7937
+      vertex -48.5567 3.32144 -59.8939
+    endloop
+  endfacet
+  facet normal -0.363296 0.123342 -0.923473
+    outer loop
+      vertex -48.5939 3.24602 -59.8939
+      vertex -48.8544 3.22894 -59.7937
+      vertex -48.8172 3.33851 -59.7937
+    endloop
+  endfacet
+  facet normal -0.0419945 0.123693 -0.991432
+    outer loop
+      vertex -48.0501 3.12085 -59.9957
+      vertex -48.101 3.37689 -59.9616
+      vertex -48.0339 3.12635 -59.9957
+    endloop
+  endfacet
+  facet normal -0.0981186 0.0862162 -0.991433
+    outer loop
+      vertex -48.1038 3.07963 -59.9957
+      vertex -48.2759 3.2759 -59.9616
+      vertex -48.0925 3.09249 -59.9957
+    endloop
+  endfacet
+  facet normal 0.393183 0.588676 0.706306
+    outer loop
+      vertex 48.9154 4.19295 49.3187
+      vertex 48.7518 4.30222 49.3187
+      vertex 48.8028 4.04619 49.5037
+    endloop
+  endfacet
+  facet normal 0.466723 0.532257 0.706309
+    outer loop
+      vertex 48.9154 4.19295 49.3187
+      vertex 48.8028 4.04619 49.5037
+      vertex 49.0633 4.06326 49.3187
+    endloop
+  endfacet
+  facet normal -0.154939 -0.778785 0.607855
+    outer loop
+      vertex -48.1963 0.509185 49.3187
+      vertex -48.4304 0.393724 49.1111
+      vertex -48.2171 0.351288 49.1111
+    endloop
+  endfacet
+  facet normal -0.16906 -0.84976 0.499326
+    outer loop
+      vertex -48.4304 0.393724 49.1111
+      vertex -48.4643 0.267375 48.8846
+      vertex -48.2171 0.351288 49.1111
+    endloop
+  endfacet
+  facet normal 0.0748487 0.376296 -0.923471
+    outer loop
+      vertex 48.1664 3.62097 -59.8939
+      vertex 48.0839 3.63738 -59.8939
+      vertex 48.2289 3.85444 -59.7937
+    endloop
+  endfacet
+  facet normal 0.123368 0.363305 -0.923466
+    outer loop
+      vertex 48.246 3.59394 -59.8939
+      vertex 48.1664 3.62097 -59.8939
+      vertex 48.2289 3.85444 -59.7937
+    endloop
+  endfacet
+  facet normal 0.0726313 -0.108565 -0.991432
+    outer loop
+      vertex 48.2375 1.69045 -59.9616
+      vertex 48.0654 1.88672 -59.9957
+      vertex 48.0796 1.89622 -59.9957
+    endloop
+  endfacet
+  facet normal -0.546628 0.269624 -0.79278
+    outer loop
+      vertex -49.0266 3.42521 -59.6629
+      vertex -49.142 3.65935 -59.5037
+      vertex -48.9623 3.55557 -59.6629
+    endloop
+  endfacet
+  facet normal -0.506691 0.338773 -0.792778
+    outer loop
+      vertex -48.9623 3.55557 -59.6629
+      vertex -49.142 3.65935 -59.5037
+      vertex -48.8815 3.67642 -59.6629
+    endloop
+  endfacet
+  facet normal -0.318905 0.213134 -0.923512
+    outer loop
+      vertex -48.5567 3.32144 -59.8939
+      vertex -48.7661 3.44229 -59.7937
+      vertex -48.7018 3.5385 -59.7937
+    endloop
+  endfacet
+  facet normal -0.34412 0.169441 -0.92351
+    outer loop
+      vertex -48.5567 3.32144 -59.8939
+      vertex -48.8172 3.33851 -59.7937
+      vertex -48.7661 3.44229 -59.7937
     endloop
   endfacet
   facet normal -0.997858 0 0.0654196
     outer loop
-      vertex 2.08203 0 -41.9241
-      vertex 2.1 5 -41.65
-      vertex 2.08203 5 -41.9241
+      vertex 2.08203 0.00428295 -41.9241
+      vertex 2.1 2 -41.65
+      vertex 2.08203 2 -41.9241
     endloop
   endfacet
   facet normal -0.997858 0 0.0654196
     outer loop
-      vertex 2.1 5 -41.65
-      vertex 2.08203 0 -41.9241
-      vertex 2.1 0 -41.65
+      vertex 2.1 2 -41.65
+      vertex 2.08203 0.00428295 -41.9241
+      vertex 2.1 0.00428295 -41.65
     endloop
   endfacet
   facet normal 0.997858 -0 0.0654196
     outer loop
-      vertex -2.1 0 -41.65
-      vertex -2.08203 5 -41.9241
-      vertex -2.1 5 -41.65
+      vertex -2.1 0.00428295 -41.65
+      vertex -2.08203 2 -41.9241
+      vertex -2.1 2 -41.65
     endloop
   endfacet
   facet normal 0.997858 0 0.0654196
     outer loop
-      vertex -2.08203 5 -41.9241
-      vertex -2.1 0 -41.65
-      vertex -2.08203 0 -41.9241
+      vertex -2.08203 2 -41.9241
+      vertex -2.1 0.00428295 -41.65
+      vertex -2.08203 0.00428295 -41.9241
     endloop
   endfacet
-  facet normal -0.0655274 0 0.997851
+  facet normal 0.0655274 0 0.997851
     outer loop
-      vertex 0 5 -43.75
-      vertex 0.274104 0 -43.732
-      vertex 0.274104 5 -43.732
+      vertex -0.274104 2 -43.732
+      vertex 0 0.00428295 -43.75
+      vertex 0 2 -43.75
     endloop
   endfacet
-  facet normal -0.0655274 0 0.997851
+  facet normal 0.0655274 0 0.997851
     outer loop
-      vertex 0.274104 0 -43.732
-      vertex 0 5 -43.75
-      vertex 0 0 -43.75
+      vertex 0 0.00428295 -43.75
+      vertex -0.274104 2 -43.732
+      vertex -0.274104 0.00428295 -43.732
     endloop
   endfacet
-  facet normal 0.0655274 0 -0.997851
+  facet normal -0.0655274 0 -0.997851
     outer loop
-      vertex -0.274104 0 -39.568
-      vertex 0 5 -39.55
-      vertex 0 0 -39.55
+      vertex 0 0.00428295 -39.55
+      vertex 0.274104 2 -39.568
+      vertex 0.274104 0.00428295 -39.568
     endloop
   endfacet
-  facet normal 0.0655274 0 -0.997851
+  facet normal -0.0655274 0 -0.997851
     outer loop
-      vertex 0 5 -39.55
-      vertex -0.274104 0 -39.568
-      vertex -0.274104 5 -39.568
-    endloop
-  endfacet
-  facet normal 0.751796 0 -0.659396
-    outer loop
-      vertex -1.48492 0 -40.1651
-      vertex -1.66604 5 -40.3716
-      vertex -1.48492 5 -40.1651
-    endloop
-  endfacet
-  facet normal 0.751796 0 -0.659396
-    outer loop
-      vertex -1.66604 5 -40.3716
-      vertex -1.48492 0 -40.1651
-      vertex -1.66604 0 -40.3716
+      vertex 0.274104 2 -39.568
+      vertex 0 0.00428295 -39.55
+      vertex 0 2 -39.55
     endloop
   endfacet
   facet normal -0.659319 0 0.751864
     outer loop
-      vertex 1.2784 5 -43.316
-      vertex 1.48492 0 -43.1349
-      vertex 1.48492 5 -43.1349
+      vertex 1.2784 2 -43.316
+      vertex 1.48492 0.00428295 -43.1349
+      vertex 1.48492 2 -43.1349
     endloop
   endfacet
   facet normal -0.659319 0 0.751864
     outer loop
-      vertex 1.48492 0 -43.1349
-      vertex 1.2784 5 -43.316
-      vertex 1.2784 0 -43.316
-    endloop
-  endfacet
-  facet normal 0.659319 0 0.751864
-    outer loop
-      vertex -1.48492 5 -43.1349
-      vertex -1.2784 0 -43.316
-      vertex -1.2784 5 -43.316
-    endloop
-  endfacet
-  facet normal 0.659319 0 0.751864
-    outer loop
-      vertex -1.2784 0 -43.316
-      vertex -1.48492 5 -43.1349
-      vertex -1.48492 0 -43.1349
-    endloop
-  endfacet
-  facet normal 0.321449 0 0.946927
-    outer loop
-      vertex -0.803635 5 -43.5901
-      vertex -0.54352 0 -43.6784
-      vertex -0.54352 5 -43.6784
-    endloop
-  endfacet
-  facet normal 0.321449 0 0.946927
-    outer loop
-      vertex -0.54352 0 -43.6784
-      vertex -0.803635 5 -43.5901
-      vertex -0.803635 0 -43.5901
-    endloop
-  endfacet
-  facet normal -0.751796 0 -0.659396
-    outer loop
-      vertex 1.66604 0 -40.3716
-      vertex 1.48492 5 -40.1651
-      vertex 1.66604 5 -40.3716
-    endloop
-  endfacet
-  facet normal -0.751796 -0 -0.659396
-    outer loop
-      vertex 1.48492 5 -40.1651
-      vertex 1.66604 0 -40.3716
-      vertex 1.48492 0 -40.1651
-    endloop
-  endfacet
-  facet normal 0.946932 0 -0.321433
-    outer loop
-      vertex -1.94015 0 -40.8464
-      vertex -2.02844 5 -41.1065
-      vertex -1.94015 5 -40.8464
-    endloop
-  endfacet
-  facet normal 0.946932 0 -0.321433
-    outer loop
-      vertex -2.02844 5 -41.1065
-      vertex -1.94015 0 -40.8464
-      vertex -2.02844 0 -41.1065
-    endloop
-  endfacet
-  facet normal -0.896889 0 0.442256
-    outer loop
-      vertex 1.81865 0 -42.7
-      vertex 1.94015 5 -42.4536
-      vertex 1.81865 5 -42.7
-    endloop
-  endfacet
-  facet normal -0.896889 0 0.442256
-    outer loop
-      vertex 1.94015 5 -42.4536
-      vertex 1.81865 0 -42.7
-      vertex 1.94015 0 -42.4536
-    endloop
-  endfacet
-  facet normal -0.321449 0 0.946927
-    outer loop
-      vertex 0.54352 5 -43.6784
-      vertex 0.803635 0 -43.5901
-      vertex 0.803635 5 -43.5901
-    endloop
-  endfacet
-  facet normal -0.321449 0 0.946927
-    outer loop
-      vertex 0.803635 0 -43.5901
-      vertex 0.54352 5 -43.6784
-      vertex 0.54352 0 -43.6784
-    endloop
-  endfacet
-  facet normal -0.195125 0 0.980778
-    outer loop
-      vertex 0.274104 5 -43.732
-      vertex 0.54352 0 -43.6784
-      vertex 0.54352 5 -43.6784
-    endloop
-  endfacet
-  facet normal -0.195125 0 0.980778
-    outer loop
-      vertex 0.54352 0 -43.6784
-      vertex 0.274104 5 -43.732
-      vertex 0.274104 0 -43.732
-    endloop
-  endfacet
-  facet normal -0.555792 0 0.831322
-    outer loop
-      vertex 1.05 5 -43.4687
-      vertex 1.2784 0 -43.316
-      vertex 1.2784 5 -43.316
-    endloop
-  endfacet
-  facet normal -0.555792 0 0.831322
-    outer loop
-      vertex 1.2784 0 -43.316
-      vertex 1.05 5 -43.4687
-      vertex 1.05 0 -43.4687
-    endloop
-  endfacet
-  facet normal 0.896889 -0 0.442256
-    outer loop
-      vertex -1.94015 0 -42.4536
-      vertex -1.81865 5 -42.7
-      vertex -1.94015 5 -42.4536
-    endloop
-  endfacet
-  facet normal 0.896889 0 0.442256
-    outer loop
-      vertex -1.81865 5 -42.7
-      vertex -1.94015 0 -42.4536
-      vertex -1.81865 0 -42.7
-    endloop
-  endfacet
-  facet normal 0.195125 0 0.980778
-    outer loop
-      vertex -0.54352 5 -43.6784
-      vertex -0.274104 0 -43.732
-      vertex -0.274104 5 -43.732
-    endloop
-  endfacet
-  facet normal 0.195125 0 0.980778
-    outer loop
-      vertex -0.274104 0 -43.732
-      vertex -0.54352 5 -43.6784
-      vertex -0.54352 0 -43.6784
-    endloop
-  endfacet
-  facet normal -0.946932 0 -0.321433
-    outer loop
-      vertex 2.02844 0 -41.1065
-      vertex 1.94015 5 -40.8464
-      vertex 2.02844 5 -41.1065
-    endloop
-  endfacet
-  facet normal -0.946932 -0 -0.321433
-    outer loop
-      vertex 1.94015 5 -40.8464
-      vertex 2.02844 0 -41.1065
-      vertex 1.94015 0 -40.8464
-    endloop
-  endfacet
-  facet normal -0.831473 0 -0.555565
-    outer loop
-      vertex 1.81865 0 -40.6
-      vertex 1.66604 5 -40.3716
-      vertex 1.81865 5 -40.6
-    endloop
-  endfacet
-  facet normal -0.831473 -0 -0.555565
-    outer loop
-      vertex 1.66604 5 -40.3716
-      vertex 1.81865 0 -40.6
-      vertex 1.66604 0 -40.3716
-    endloop
-  endfacet
-  facet normal -0.980783 0 -0.195101
-    outer loop
-      vertex 2.08203 0 -41.3759
-      vertex 2.02844 5 -41.1065
-      vertex 2.08203 5 -41.3759
-    endloop
-  endfacet
-  facet normal -0.980783 -0 -0.195101
-    outer loop
-      vertex 2.02844 5 -41.1065
-      vertex 2.08203 0 -41.3759
-      vertex 2.02844 0 -41.1065
-    endloop
-  endfacet
-  facet normal 0.442014 0 -0.897008
-    outer loop
-      vertex -1.05 0 -39.8313
-      vertex -0.803635 5 -39.7099
-      vertex -0.803635 0 -39.7099
-    endloop
-  endfacet
-  facet normal 0.442014 0 -0.897008
-    outer loop
-      vertex -0.803635 5 -39.7099
-      vertex -1.05 0 -39.8313
-      vertex -1.05 5 -39.8313
-    endloop
-  endfacet
-  facet normal 0.659319 0 -0.751864
-    outer loop
-      vertex -1.48492 0 -40.1651
-      vertex -1.2784 5 -39.984
-      vertex -1.2784 0 -39.984
-    endloop
-  endfacet
-  facet normal 0.659319 0 -0.751864
-    outer loop
-      vertex -1.2784 5 -39.984
-      vertex -1.48492 0 -40.1651
-      vertex -1.48492 5 -40.1651
-    endloop
-  endfacet
-  facet normal 0.321449 0 -0.946927
-    outer loop
-      vertex -0.803635 0 -39.7099
-      vertex -0.54352 5 -39.6216
-      vertex -0.54352 0 -39.6216
-    endloop
-  endfacet
-  facet normal 0.321449 0 -0.946927
-    outer loop
-      vertex -0.54352 5 -39.6216
-      vertex -0.803635 0 -39.7099
-      vertex -0.803635 5 -39.7099
-    endloop
-  endfacet
-  facet normal 0.896889 0 -0.442256
-    outer loop
-      vertex -1.81865 0 -40.6
-      vertex -1.94015 5 -40.8464
-      vertex -1.81865 5 -40.6
-    endloop
-  endfacet
-  facet normal 0.896889 0 -0.442256
-    outer loop
-      vertex -1.94015 5 -40.8464
-      vertex -1.81865 0 -40.6
-      vertex -1.94015 0 -40.8464
-    endloop
-  endfacet
-  facet normal 0.997858 0 -0.0654196
-    outer loop
-      vertex -2.08203 0 -41.3759
-      vertex -2.1 5 -41.65
-      vertex -2.08203 5 -41.3759
-    endloop
-  endfacet
-  facet normal 0.997858 0 -0.0654196
-    outer loop
-      vertex -2.1 5 -41.65
-      vertex -2.08203 0 -41.3759
-      vertex -2.1 0 -41.65
-    endloop
-  endfacet
-  facet normal -0.946932 0 0.321433
-    outer loop
-      vertex 1.94015 0 -42.4536
-      vertex 2.02844 5 -42.1935
-      vertex 1.94015 5 -42.4536
-    endloop
-  endfacet
-  facet normal -0.946932 0 0.321433
-    outer loop
-      vertex 2.02844 5 -42.1935
-      vertex 1.94015 0 -42.4536
-      vertex 2.02844 0 -42.1935
-    endloop
-  endfacet
-  facet normal -0.980783 0 0.195101
-    outer loop
-      vertex 2.02844 0 -42.1935
-      vertex 2.08203 5 -41.9241
-      vertex 2.02844 5 -42.1935
-    endloop
-  endfacet
-  facet normal -0.980783 0 0.195101
-    outer loop
-      vertex 2.08203 5 -41.9241
-      vertex 2.02844 0 -42.1935
-      vertex 2.08203 0 -41.9241
-    endloop
-  endfacet
-  facet normal -0.751796 0 0.659396
-    outer loop
-      vertex 1.48492 0 -43.1349
-      vertex 1.66604 5 -42.9284
-      vertex 1.48492 5 -43.1349
-    endloop
-  endfacet
-  facet normal -0.751796 0 0.659396
-    outer loop
-      vertex 1.66604 5 -42.9284
-      vertex 1.48492 0 -43.1349
-      vertex 1.66604 0 -42.9284
-    endloop
-  endfacet
-  facet normal -0.831473 0 0.555565
-    outer loop
-      vertex 1.66604 0 -42.9284
-      vertex 1.81865 5 -42.7
-      vertex 1.66604 5 -42.9284
-    endloop
-  endfacet
-  facet normal -0.831473 0 0.555565
-    outer loop
-      vertex 1.81865 5 -42.7
-      vertex 1.66604 0 -42.9284
-      vertex 1.81865 0 -42.7
-    endloop
-  endfacet
-  facet normal -0.442014 0 0.897008
-    outer loop
-      vertex 0.803635 5 -43.5901
-      vertex 1.05 0 -43.4687
-      vertex 1.05 5 -43.4687
-    endloop
-  endfacet
-  facet normal -0.442014 0 0.897008
-    outer loop
-      vertex 1.05 0 -43.4687
-      vertex 0.803635 5 -43.5901
-      vertex 0.803635 0 -43.5901
-    endloop
-  endfacet
-  facet normal 0.831473 -0 0.555565
-    outer loop
-      vertex -1.81865 0 -42.7
-      vertex -1.66604 5 -42.9284
-      vertex -1.81865 5 -42.7
-    endloop
-  endfacet
-  facet normal 0.831473 0 0.555565
-    outer loop
-      vertex -1.66604 5 -42.9284
-      vertex -1.81865 0 -42.7
-      vertex -1.66604 0 -42.9284
+      vertex 1.48492 0.00428295 -43.1349
+      vertex 1.2784 2 -43.316
+      vertex 1.2784 0.00428295 -43.316
     endloop
   endfacet
   facet normal 0.751796 -0 0.659396
     outer loop
-      vertex -1.66604 0 -42.9284
-      vertex -1.48492 5 -43.1349
-      vertex -1.66604 5 -42.9284
+      vertex -1.66604 0.00428295 -42.9284
+      vertex -1.48492 2 -43.1349
+      vertex -1.66604 2 -42.9284
     endloop
   endfacet
   facet normal 0.751796 0 0.659396
     outer loop
-      vertex -1.48492 5 -43.1349
-      vertex -1.66604 0 -42.9284
-      vertex -1.48492 0 -43.1349
+      vertex -1.48492 2 -43.1349
+      vertex -1.66604 0.00428295 -42.9284
+      vertex -1.48492 0.00428295 -43.1349
+    endloop
+  endfacet
+  facet normal 0.442014 0 0.897008
+    outer loop
+      vertex -1.05 2 -43.4687
+      vertex -0.803635 0.00428295 -43.5901
+      vertex -0.803635 2 -43.5901
+    endloop
+  endfacet
+  facet normal 0.442014 0 0.897008
+    outer loop
+      vertex -0.803635 0.00428295 -43.5901
+      vertex -1.05 2 -43.4687
+      vertex -1.05 0.00428295 -43.4687
+    endloop
+  endfacet
+  facet normal -0.831473 0 -0.555565
+    outer loop
+      vertex 1.81865 0.00428295 -40.6
+      vertex 1.66604 2 -40.3716
+      vertex 1.81865 2 -40.6
+    endloop
+  endfacet
+  facet normal -0.831473 -0 -0.555565
+    outer loop
+      vertex 1.66604 2 -40.3716
+      vertex 1.81865 0.00428295 -40.6
+      vertex 1.66604 0.00428295 -40.3716
+    endloop
+  endfacet
+  facet normal -0.896889 0 0.442256
+    outer loop
+      vertex 1.81865 0.00428295 -42.7
+      vertex 1.94015 2 -42.4536
+      vertex 1.81865 2 -42.7
+    endloop
+  endfacet
+  facet normal -0.896889 0 0.442256
+    outer loop
+      vertex 1.94015 2 -42.4536
+      vertex 1.81865 0.00428295 -42.7
+      vertex 1.94015 0.00428295 -42.4536
+    endloop
+  endfacet
+  facet normal -0.831473 0 0.555565
+    outer loop
+      vertex 1.66604 0.00428295 -42.9284
+      vertex 1.81865 2 -42.7
+      vertex 1.66604 2 -42.9284
+    endloop
+  endfacet
+  facet normal -0.831473 0 0.555565
+    outer loop
+      vertex 1.81865 2 -42.7
+      vertex 1.66604 0.00428295 -42.9284
+      vertex 1.81865 0.00428295 -42.7
+    endloop
+  endfacet
+  facet normal -0.321449 0 0.946927
+    outer loop
+      vertex 0.54352 2 -43.6784
+      vertex 0.803635 0.00428295 -43.5901
+      vertex 0.803635 2 -43.5901
+    endloop
+  endfacet
+  facet normal -0.321449 0 0.946927
+    outer loop
+      vertex 0.803635 0.00428295 -43.5901
+      vertex 0.54352 2 -43.6784
+      vertex 0.54352 0.00428295 -43.6784
+    endloop
+  endfacet
+  facet normal -0.195125 0 0.980778
+    outer loop
+      vertex 0.274104 2 -43.732
+      vertex 0.54352 0.00428295 -43.6784
+      vertex 0.54352 2 -43.6784
+    endloop
+  endfacet
+  facet normal -0.195125 0 0.980778
+    outer loop
+      vertex 0.54352 0.00428295 -43.6784
+      vertex 0.274104 2 -43.732
+      vertex 0.274104 0.00428295 -43.732
+    endloop
+  endfacet
+  facet normal -0.555792 0 0.831322
+    outer loop
+      vertex 1.05 2 -43.4687
+      vertex 1.2784 0.00428295 -43.316
+      vertex 1.2784 2 -43.316
+    endloop
+  endfacet
+  facet normal -0.555792 0 0.831322
+    outer loop
+      vertex 1.2784 0.00428295 -43.316
+      vertex 1.05 2 -43.4687
+      vertex 1.05 0.00428295 -43.4687
+    endloop
+  endfacet
+  facet normal 0.896889 -0 0.442256
+    outer loop
+      vertex -1.94015 0.00428295 -42.4536
+      vertex -1.81865 2 -42.7
+      vertex -1.94015 2 -42.4536
+    endloop
+  endfacet
+  facet normal 0.896889 0 0.442256
+    outer loop
+      vertex -1.81865 2 -42.7
+      vertex -1.94015 0.00428295 -42.4536
+      vertex -1.81865 0.00428295 -42.7
+    endloop
+  endfacet
+  facet normal 0.831473 -0 0.555565
+    outer loop
+      vertex -1.81865 0.00428295 -42.7
+      vertex -1.66604 2 -42.9284
+      vertex -1.81865 2 -42.7
+    endloop
+  endfacet
+  facet normal 0.831473 0 0.555565
+    outer loop
+      vertex -1.66604 2 -42.9284
+      vertex -1.81865 0.00428295 -42.7
+      vertex -1.66604 0.00428295 -42.9284
+    endloop
+  endfacet
+  facet normal 0.555792 0 0.831322
+    outer loop
+      vertex -1.2784 2 -43.316
+      vertex -1.05 0.00428295 -43.4687
+      vertex -1.05 2 -43.4687
+    endloop
+  endfacet
+  facet normal 0.555792 0 0.831322
+    outer loop
+      vertex -1.05 0.00428295 -43.4687
+      vertex -1.2784 2 -43.316
+      vertex -1.2784 0.00428295 -43.316
+    endloop
+  endfacet
+  facet normal 0.321449 0 0.946927
+    outer loop
+      vertex -0.803635 2 -43.5901
+      vertex -0.54352 0.00428295 -43.6784
+      vertex -0.54352 2 -43.6784
+    endloop
+  endfacet
+  facet normal 0.321449 0 0.946927
+    outer loop
+      vertex -0.54352 0.00428295 -43.6784
+      vertex -0.803635 2 -43.5901
+      vertex -0.803635 0.00428295 -43.5901
+    endloop
+  endfacet
+  facet normal -0.980783 0 -0.195101
+    outer loop
+      vertex 2.08203 0.00428295 -41.3759
+      vertex 2.02844 2 -41.1065
+      vertex 2.08203 2 -41.3759
+    endloop
+  endfacet
+  facet normal -0.980783 -0 -0.195101
+    outer loop
+      vertex 2.02844 2 -41.1065
+      vertex 2.08203 0.00428295 -41.3759
+      vertex 2.02844 0.00428295 -41.1065
+    endloop
+  endfacet
+  facet normal -0.195125 0 -0.980778
+    outer loop
+      vertex 0.274104 0.00428295 -39.568
+      vertex 0.54352 2 -39.6216
+      vertex 0.54352 0.00428295 -39.6216
+    endloop
+  endfacet
+  facet normal -0.195125 0 -0.980778
+    outer loop
+      vertex 0.54352 2 -39.6216
+      vertex 0.274104 0.00428295 -39.568
+      vertex 0.274104 2 -39.568
+    endloop
+  endfacet
+  facet normal -0.442014 0 -0.897008
+    outer loop
+      vertex 0.803635 0.00428295 -39.7099
+      vertex 1.05 2 -39.8313
+      vertex 1.05 0.00428295 -39.8313
+    endloop
+  endfacet
+  facet normal -0.442014 0 -0.897008
+    outer loop
+      vertex 1.05 2 -39.8313
+      vertex 0.803635 0.00428295 -39.7099
+      vertex 0.803635 2 -39.7099
+    endloop
+  endfacet
+  facet normal -0.946932 0 0.321433
+    outer loop
+      vertex 1.94015 0.00428295 -42.4536
+      vertex 2.02844 2 -42.1935
+      vertex 1.94015 2 -42.4536
+    endloop
+  endfacet
+  facet normal -0.946932 0 0.321433
+    outer loop
+      vertex 2.02844 2 -42.1935
+      vertex 1.94015 0.00428295 -42.4536
+      vertex 2.02844 0.00428295 -42.1935
+    endloop
+  endfacet
+  facet normal -0.980783 0 0.195101
+    outer loop
+      vertex 2.02844 0.00428295 -42.1935
+      vertex 2.08203 2 -41.9241
+      vertex 2.02844 2 -42.1935
+    endloop
+  endfacet
+  facet normal -0.980783 0 0.195101
+    outer loop
+      vertex 2.08203 2 -41.9241
+      vertex 2.02844 0.00428295 -42.1935
+      vertex 2.08203 0.00428295 -41.9241
+    endloop
+  endfacet
+  facet normal -0.751796 0 0.659396
+    outer loop
+      vertex 1.48492 0.00428295 -43.1349
+      vertex 1.66604 2 -42.9284
+      vertex 1.48492 2 -43.1349
+    endloop
+  endfacet
+  facet normal -0.751796 0 0.659396
+    outer loop
+      vertex 1.66604 2 -42.9284
+      vertex 1.48492 0.00428295 -43.1349
+      vertex 1.66604 0.00428295 -42.9284
+    endloop
+  endfacet
+  facet normal -0.0655274 0 0.997851
+    outer loop
+      vertex 0 2 -43.75
+      vertex 0.274104 0.00428295 -43.732
+      vertex 0.274104 2 -43.732
+    endloop
+  endfacet
+  facet normal -0.0655274 0 0.997851
+    outer loop
+      vertex 0.274104 0.00428295 -43.732
+      vertex 0 2 -43.75
+      vertex 0 0.00428295 -43.75
+    endloop
+  endfacet
+  facet normal -0.442014 0 0.897008
+    outer loop
+      vertex 0.803635 2 -43.5901
+      vertex 1.05 0.00428295 -43.4687
+      vertex 1.05 2 -43.4687
+    endloop
+  endfacet
+  facet normal -0.442014 0 0.897008
+    outer loop
+      vertex 1.05 0.00428295 -43.4687
+      vertex 0.803635 2 -43.5901
+      vertex 0.803635 0.00428295 -43.5901
     endloop
   endfacet
   facet normal 0.946932 -0 0.321433
     outer loop
-      vertex -2.02844 0 -42.1935
-      vertex -1.94015 5 -42.4536
-      vertex -2.02844 5 -42.1935
+      vertex -2.02844 0.00428295 -42.1935
+      vertex -1.94015 2 -42.4536
+      vertex -2.02844 2 -42.1935
     endloop
   endfacet
   facet normal 0.946932 0 0.321433
     outer loop
-      vertex -1.94015 5 -42.4536
-      vertex -2.02844 0 -42.1935
-      vertex -1.94015 0 -42.4536
+      vertex -1.94015 2 -42.4536
+      vertex -2.02844 0.00428295 -42.1935
+      vertex -1.94015 0.00428295 -42.4536
     endloop
   endfacet
   facet normal 0.980783 -0 0.195101
     outer loop
-      vertex -2.08203 0 -41.9241
-      vertex -2.02844 5 -42.1935
-      vertex -2.08203 5 -41.9241
+      vertex -2.08203 0.00428295 -41.9241
+      vertex -2.02844 2 -42.1935
+      vertex -2.08203 2 -41.9241
     endloop
   endfacet
   facet normal 0.980783 0 0.195101
     outer loop
-      vertex -2.02844 5 -42.1935
-      vertex -2.08203 0 -41.9241
-      vertex -2.02844 0 -42.1935
+      vertex -2.02844 2 -42.1935
+      vertex -2.08203 0.00428295 -41.9241
+      vertex -2.02844 0.00428295 -42.1935
     endloop
   endfacet
-  facet normal 0.442014 0 0.897008
+  facet normal 0.659319 0 0.751864
     outer loop
-      vertex -1.05 5 -43.4687
-      vertex -0.803635 0 -43.5901
-      vertex -0.803635 5 -43.5901
+      vertex -1.48492 2 -43.1349
+      vertex -1.2784 0.00428295 -43.316
+      vertex -1.2784 2 -43.316
     endloop
   endfacet
-  facet normal 0.442014 0 0.897008
+  facet normal 0.659319 0 0.751864
     outer loop
-      vertex -0.803635 0 -43.5901
-      vertex -1.05 5 -43.4687
-      vertex -1.05 0 -43.4687
+      vertex -1.2784 0.00428295 -43.316
+      vertex -1.48492 2 -43.1349
+      vertex -1.48492 0.00428295 -43.1349
     endloop
   endfacet
-  facet normal 0.555792 0 0.831322
+  facet normal 0.195125 0 0.980778
     outer loop
-      vertex -1.2784 5 -43.316
-      vertex -1.05 0 -43.4687
-      vertex -1.05 5 -43.4687
+      vertex -0.54352 2 -43.6784
+      vertex -0.274104 0.00428295 -43.732
+      vertex -0.274104 2 -43.732
     endloop
   endfacet
-  facet normal 0.555792 0 0.831322
+  facet normal 0.195125 0 0.980778
     outer loop
-      vertex -1.05 0 -43.4687
-      vertex -1.2784 5 -43.316
-      vertex -1.2784 0 -43.316
-    endloop
-  endfacet
-  facet normal 0.0655274 0 0.997851
-    outer loop
-      vertex -0.274104 5 -43.732
-      vertex 0 0 -43.75
-      vertex 0 5 -43.75
-    endloop
-  endfacet
-  facet normal 0.0655274 0 0.997851
-    outer loop
-      vertex 0 0 -43.75
-      vertex -0.274104 5 -43.732
-      vertex -0.274104 0 -43.732
+      vertex -0.274104 0.00428295 -43.732
+      vertex -0.54352 2 -43.6784
+      vertex -0.54352 0.00428295 -43.6784
     endloop
   endfacet
   facet normal -0.997858 0 -0.0654196
     outer loop
-      vertex 2.1 0 -41.65
-      vertex 2.08203 5 -41.3759
-      vertex 2.1 5 -41.65
+      vertex 2.1 0.00428295 -41.65
+      vertex 2.08203 2 -41.3759
+      vertex 2.1 2 -41.65
     endloop
   endfacet
   facet normal -0.997858 -0 -0.0654196
     outer loop
-      vertex 2.08203 5 -41.3759
-      vertex 2.1 0 -41.65
-      vertex 2.08203 0 -41.3759
+      vertex 2.08203 2 -41.3759
+      vertex 2.1 0.00428295 -41.65
+      vertex 2.08203 0.00428295 -41.3759
     endloop
   endfacet
-  facet normal -0.0655274 0 -0.997851
+  facet normal -0.751796 0 -0.659396
     outer loop
-      vertex 0 0 -39.55
-      vertex 0.274104 5 -39.568
-      vertex 0.274104 0 -39.568
+      vertex 1.66604 0.00428295 -40.3716
+      vertex 1.48492 2 -40.1651
+      vertex 1.66604 2 -40.3716
     endloop
   endfacet
-  facet normal -0.0655274 0 -0.997851
+  facet normal -0.751796 -0 -0.659396
     outer loop
-      vertex 0.274104 5 -39.568
-      vertex 0 0 -39.55
-      vertex 0 5 -39.55
+      vertex 1.48492 2 -40.1651
+      vertex 1.66604 0.00428295 -40.3716
+      vertex 1.48492 0.00428295 -40.1651
     endloop
   endfacet
-  facet normal -0.321449 0 -0.946927
+  facet normal 0.946932 0 -0.321433
     outer loop
-      vertex 0.54352 0 -39.6216
-      vertex 0.803635 5 -39.7099
-      vertex 0.803635 0 -39.7099
+      vertex -1.94015 0.00428295 -40.8464
+      vertex -2.02844 2 -41.1065
+      vertex -1.94015 2 -40.8464
     endloop
   endfacet
-  facet normal -0.321449 0 -0.946927
+  facet normal 0.946932 0 -0.321433
     outer loop
-      vertex 0.803635 5 -39.7099
-      vertex 0.54352 0 -39.6216
-      vertex 0.54352 5 -39.6216
-    endloop
-  endfacet
-  facet normal -0.659319 0 -0.751864
-    outer loop
-      vertex 1.2784 0 -39.984
-      vertex 1.48492 5 -40.1651
-      vertex 1.48492 0 -40.1651
-    endloop
-  endfacet
-  facet normal -0.659319 0 -0.751864
-    outer loop
-      vertex 1.48492 5 -40.1651
-      vertex 1.2784 0 -39.984
-      vertex 1.2784 5 -39.984
-    endloop
-  endfacet
-  facet normal -0.442014 0 -0.897008
-    outer loop
-      vertex 0.803635 0 -39.7099
-      vertex 1.05 5 -39.8313
-      vertex 1.05 0 -39.8313
-    endloop
-  endfacet
-  facet normal -0.442014 0 -0.897008
-    outer loop
-      vertex 1.05 5 -39.8313
-      vertex 0.803635 0 -39.7099
-      vertex 0.803635 5 -39.7099
+      vertex -2.02844 2 -41.1065
+      vertex -1.94015 0.00428295 -40.8464
+      vertex -2.02844 0.00428295 -41.1065
     endloop
   endfacet
   facet normal -0.896889 0 -0.442256
     outer loop
-      vertex 1.94015 0 -40.8464
-      vertex 1.81865 5 -40.6
-      vertex 1.94015 5 -40.8464
+      vertex 1.94015 0.00428295 -40.8464
+      vertex 1.81865 2 -40.6
+      vertex 1.94015 2 -40.8464
     endloop
   endfacet
   facet normal -0.896889 -0 -0.442256
     outer loop
-      vertex 1.81865 5 -40.6
-      vertex 1.94015 0 -40.8464
-      vertex 1.81865 0 -40.6
+      vertex 1.81865 2 -40.6
+      vertex 1.94015 0.00428295 -40.8464
+      vertex 1.81865 0.00428295 -40.6
     endloop
   endfacet
-  facet normal 0.555792 0 -0.831322
+  facet normal -0.946932 0 -0.321433
     outer loop
-      vertex -1.2784 0 -39.984
-      vertex -1.05 5 -39.8313
-      vertex -1.05 0 -39.8313
+      vertex 2.02844 0.00428295 -41.1065
+      vertex 1.94015 2 -40.8464
+      vertex 2.02844 2 -41.1065
     endloop
   endfacet
-  facet normal 0.555792 0 -0.831322
+  facet normal -0.946932 -0 -0.321433
     outer loop
-      vertex -1.05 5 -39.8313
-      vertex -1.2784 0 -39.984
-      vertex -1.2784 5 -39.984
-    endloop
-  endfacet
-  facet normal 0.195125 0 -0.980778
-    outer loop
-      vertex -0.54352 0 -39.6216
-      vertex -0.274104 5 -39.568
-      vertex -0.274104 0 -39.568
-    endloop
-  endfacet
-  facet normal 0.195125 0 -0.980778
-    outer loop
-      vertex -0.274104 5 -39.568
-      vertex -0.54352 0 -39.6216
-      vertex -0.54352 5 -39.6216
-    endloop
-  endfacet
-  facet normal 0.831473 0 -0.555565
-    outer loop
-      vertex -1.66604 0 -40.3716
-      vertex -1.81865 5 -40.6
-      vertex -1.66604 5 -40.3716
-    endloop
-  endfacet
-  facet normal 0.831473 0 -0.555565
-    outer loop
-      vertex -1.81865 5 -40.6
-      vertex -1.66604 0 -40.3716
-      vertex -1.81865 0 -40.6
-    endloop
-  endfacet
-  facet normal 0.980783 0 -0.195101
-    outer loop
-      vertex -2.02844 0 -41.1065
-      vertex -2.08203 5 -41.3759
-      vertex -2.02844 5 -41.1065
-    endloop
-  endfacet
-  facet normal 0.980783 0 -0.195101
-    outer loop
-      vertex -2.08203 5 -41.3759
-      vertex -2.02844 0 -41.1065
-      vertex -2.08203 0 -41.3759
-    endloop
-  endfacet
-  facet normal -0.195125 0 -0.980778
-    outer loop
-      vertex 0.274104 0 -39.568
-      vertex 0.54352 5 -39.6216
-      vertex 0.54352 0 -39.6216
-    endloop
-  endfacet
-  facet normal -0.195125 0 -0.980778
-    outer loop
-      vertex 0.54352 5 -39.6216
-      vertex 0.274104 0 -39.568
-      vertex 0.274104 5 -39.568
+      vertex 1.94015 2 -40.8464
+      vertex 2.02844 0.00428295 -41.1065
+      vertex 1.94015 0.00428295 -40.8464
     endloop
   endfacet
   facet normal -0.555792 0 -0.831322
     outer loop
-      vertex 1.05 0 -39.8313
-      vertex 1.2784 5 -39.984
-      vertex 1.2784 0 -39.984
+      vertex 1.05 0.00428295 -39.8313
+      vertex 1.2784 2 -39.984
+      vertex 1.2784 0.00428295 -39.984
     endloop
   endfacet
   facet normal -0.555792 0 -0.831322
     outer loop
-      vertex 1.2784 5 -39.984
-      vertex 1.05 0 -39.8313
-      vertex 1.05 5 -39.8313
+      vertex 1.2784 2 -39.984
+      vertex 1.05 0.00428295 -39.8313
+      vertex 1.05 2 -39.8313
+    endloop
+  endfacet
+  facet normal -0.659319 0 -0.751864
+    outer loop
+      vertex 1.2784 0.00428295 -39.984
+      vertex 1.48492 2 -40.1651
+      vertex 1.48492 0.00428295 -40.1651
+    endloop
+  endfacet
+  facet normal -0.659319 0 -0.751864
+    outer loop
+      vertex 1.48492 2 -40.1651
+      vertex 1.2784 0.00428295 -39.984
+      vertex 1.2784 2 -39.984
+    endloop
+  endfacet
+  facet normal 0.831473 0 -0.555565
+    outer loop
+      vertex -1.66604 0.00428295 -40.3716
+      vertex -1.81865 2 -40.6
+      vertex -1.66604 2 -40.3716
+    endloop
+  endfacet
+  facet normal 0.831473 0 -0.555565
+    outer loop
+      vertex -1.81865 2 -40.6
+      vertex -1.66604 0.00428295 -40.3716
+      vertex -1.81865 0.00428295 -40.6
+    endloop
+  endfacet
+  facet normal -0.321449 0 -0.946927
+    outer loop
+      vertex 0.54352 0.00428295 -39.6216
+      vertex 0.803635 2 -39.7099
+      vertex 0.803635 0.00428295 -39.7099
+    endloop
+  endfacet
+  facet normal -0.321449 0 -0.946927
+    outer loop
+      vertex 0.803635 2 -39.7099
+      vertex 0.54352 0.00428295 -39.6216
+      vertex 0.54352 2 -39.6216
+    endloop
+  endfacet
+  facet normal 0.0655274 0 -0.997851
+    outer loop
+      vertex -0.274104 0.00428295 -39.568
+      vertex 0 2 -39.55
+      vertex 0 0.00428295 -39.55
+    endloop
+  endfacet
+  facet normal 0.0655274 0 -0.997851
+    outer loop
+      vertex 0 2 -39.55
+      vertex -0.274104 0.00428295 -39.568
+      vertex -0.274104 2 -39.568
+    endloop
+  endfacet
+  facet normal 0.195125 0 -0.980778
+    outer loop
+      vertex -0.54352 0.00428295 -39.6216
+      vertex -0.274104 2 -39.568
+      vertex -0.274104 0.00428295 -39.568
+    endloop
+  endfacet
+  facet normal 0.195125 0 -0.980778
+    outer loop
+      vertex -0.274104 2 -39.568
+      vertex -0.54352 0.00428295 -39.6216
+      vertex -0.54352 2 -39.6216
+    endloop
+  endfacet
+  facet normal 0.659319 0 -0.751864
+    outer loop
+      vertex -1.48492 0.00428295 -40.1651
+      vertex -1.2784 2 -39.984
+      vertex -1.2784 0.00428295 -39.984
+    endloop
+  endfacet
+  facet normal 0.659319 0 -0.751864
+    outer loop
+      vertex -1.2784 2 -39.984
+      vertex -1.48492 0.00428295 -40.1651
+      vertex -1.48492 2 -40.1651
+    endloop
+  endfacet
+  facet normal 0.751796 0 -0.659396
+    outer loop
+      vertex -1.48492 0.00428295 -40.1651
+      vertex -1.66604 2 -40.3716
+      vertex -1.48492 2 -40.1651
+    endloop
+  endfacet
+  facet normal 0.751796 0 -0.659396
+    outer loop
+      vertex -1.66604 2 -40.3716
+      vertex -1.48492 0.00428295 -40.1651
+      vertex -1.66604 0.00428295 -40.3716
+    endloop
+  endfacet
+  facet normal 0.896889 0 -0.442256
+    outer loop
+      vertex -1.81865 0.00428295 -40.6
+      vertex -1.94015 2 -40.8464
+      vertex -1.81865 2 -40.6
+    endloop
+  endfacet
+  facet normal 0.896889 0 -0.442256
+    outer loop
+      vertex -1.94015 2 -40.8464
+      vertex -1.81865 0.00428295 -40.6
+      vertex -1.94015 0.00428295 -40.8464
+    endloop
+  endfacet
+  facet normal 0.980783 0 -0.195101
+    outer loop
+      vertex -2.02844 0.00428295 -41.1065
+      vertex -2.08203 2 -41.3759
+      vertex -2.02844 2 -41.1065
+    endloop
+  endfacet
+  facet normal 0.980783 0 -0.195101
+    outer loop
+      vertex -2.08203 2 -41.3759
+      vertex -2.02844 0.00428295 -41.1065
+      vertex -2.08203 0.00428295 -41.3759
+    endloop
+  endfacet
+  facet normal 0.997858 0 -0.0654196
+    outer loop
+      vertex -2.08203 0.00428295 -41.3759
+      vertex -2.1 2 -41.65
+      vertex -2.08203 2 -41.3759
+    endloop
+  endfacet
+  facet normal 0.997858 0 -0.0654196
+    outer loop
+      vertex -2.1 2 -41.65
+      vertex -2.08203 0.00428295 -41.3759
+      vertex -2.1 0.00428295 -41.65
+    endloop
+  endfacet
+  facet normal 0.555792 0 -0.831322
+    outer loop
+      vertex -1.2784 0.00428295 -39.984
+      vertex -1.05 2 -39.8313
+      vertex -1.05 0.00428295 -39.8313
+    endloop
+  endfacet
+  facet normal 0.555792 0 -0.831322
+    outer loop
+      vertex -1.05 2 -39.8313
+      vertex -1.2784 0.00428295 -39.984
+      vertex -1.2784 2 -39.984
+    endloop
+  endfacet
+  facet normal 0.321449 0 -0.946927
+    outer loop
+      vertex -0.803635 0.00428295 -39.7099
+      vertex -0.54352 2 -39.6216
+      vertex -0.54352 0.00428295 -39.6216
+    endloop
+  endfacet
+  facet normal 0.321449 0 -0.946927
+    outer loop
+      vertex -0.54352 2 -39.6216
+      vertex -0.803635 0.00428295 -39.7099
+      vertex -0.803635 2 -39.7099
+    endloop
+  endfacet
+  facet normal 0.442014 0 -0.897008
+    outer loop
+      vertex -1.05 0.00428295 -39.8313
+      vertex -0.803635 2 -39.7099
+      vertex -0.803635 0.00428295 -39.7099
+    endloop
+  endfacet
+  facet normal 0.442014 0 -0.897008
+    outer loop
+      vertex -0.803635 2 -39.7099
+      vertex -1.05 0.00428295 -39.8313
+      vertex -1.05 2 -39.8313
+    endloop
+  endfacet
+  facet normal -0.997859 0 0.0654027
+    outer loop
+      vertex 3.96578 2 -42.1721
+      vertex 4 4.99572 -41.65
+      vertex 3.96578 4.99572 -42.1721
+    endloop
+  endfacet
+  facet normal -0.997859 0 0.0654027
+    outer loop
+      vertex 4 4.99572 -41.65
+      vertex 3.96578 2 -42.1721
+      vertex 4 2 -41.65
+    endloop
+  endfacet
+  facet normal 0.997859 -0 0.0654027
+    outer loop
+      vertex -4 2 -41.65
+      vertex -3.96578 4.99572 -42.1721
+      vertex -4 4.99572 -41.65
+    endloop
+  endfacet
+  facet normal 0.997859 0 0.0654027
+    outer loop
+      vertex -3.96578 4.99572 -42.1721
+      vertex -4 2 -41.65
+      vertex -3.96578 2 -42.1721
+    endloop
+  endfacet
+  facet normal -0.0653641 0 0.997861
+    outer loop
+      vertex 0 4.99572 -45.65
+      vertex 0.522104 2 -45.6158
+      vertex 0.522104 4.99572 -45.6158
+    endloop
+  endfacet
+  facet normal -0.0653641 0 0.997861
+    outer loop
+      vertex 0.522104 2 -45.6158
+      vertex 0 4.99572 -45.65
+      vertex 0 2 -45.65
+    endloop
+  endfacet
+  facet normal 0.751861 0 -0.659321
+    outer loop
+      vertex -2.82843 2 -38.8216
+      vertex -3.17341 4.99572 -39.215
+      vertex -2.82843 4.99572 -38.8216
+    endloop
+  endfacet
+  facet normal 0.751861 0 -0.659321
+    outer loop
+      vertex -3.17341 4.99572 -39.215
+      vertex -2.82843 2 -38.8216
+      vertex -3.17341 2 -39.215
+    endloop
+  endfacet
+  facet normal -0.659362 0 0.751826
+    outer loop
+      vertex 2.43505 4.99572 -44.8234
+      vertex 2.82843 2 -44.4784
+      vertex 2.82843 4.99572 -44.4784
+    endloop
+  endfacet
+  facet normal -0.659362 0 0.751826
+    outer loop
+      vertex 2.82843 2 -44.4784
+      vertex 2.43505 4.99572 -44.8234
+      vertex 2.43505 2 -44.8234
+    endloop
+  endfacet
+  facet normal 0.659362 0 0.751826
+    outer loop
+      vertex -2.82843 4.99572 -44.4784
+      vertex -2.43505 2 -44.8234
+      vertex -2.43505 4.99572 -44.8234
+    endloop
+  endfacet
+  facet normal 0.659362 0 0.751826
+    outer loop
+      vertex -2.43505 2 -44.8234
+      vertex -2.82843 4.99572 -44.4784
+      vertex -2.82843 2 -44.4784
+    endloop
+  endfacet
+  facet normal 0.321469 0 0.94692
+    outer loop
+      vertex -1.53073 4.99572 -45.3455
+      vertex -1.03528 2 -45.5137
+      vertex -1.03528 4.99572 -45.5137
+    endloop
+  endfacet
+  facet normal 0.321469 0 0.94692
+    outer loop
+      vertex -1.03528 2 -45.5137
+      vertex -1.53073 4.99572 -45.3455
+      vertex -1.53073 2 -45.3455
+    endloop
+  endfacet
+  facet normal 0.946922 0 -0.321464
+    outer loop
+      vertex -3.69552 2 -40.1193
+      vertex -3.8637 4.99572 -40.6147
+      vertex -3.69552 4.99572 -40.1193
+    endloop
+  endfacet
+  facet normal 0.946922 0 -0.321464
+    outer loop
+      vertex -3.8637 4.99572 -40.6147
+      vertex -3.69552 2 -40.1193
+      vertex -3.8637 2 -40.6147
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 2 -39.55
+      vertex 0 2 -37.65
+      vertex 0.522104 2 -37.6842
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.274104 2 -39.568
+      vertex 0.522104 2 -37.6842
+      vertex 1.03528 2 -37.7863
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 2 -37.65
+      vertex 0 2 -39.55
+      vertex -0.522104 2 -37.6842
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.54352 2 -39.6216
+      vertex 1.03528 2 -37.7863
+      vertex 1.53073 2 -37.9545
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -0.274104 2 -39.568
+      vertex -0.522104 2 -37.6842
+      vertex 0 2 -39.55
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.803635 2 -39.7099
+      vertex 1.53073 2 -37.9545
+      vertex 2 2 -38.1859
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.522104 2 -37.6842
+      vertex -0.274104 2 -39.568
+      vertex -1.03528 2 -37.7863
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.05 2 -39.8313
+      vertex 2 2 -38.1859
+      vertex 2.43505 2 -38.4766
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -0.54352 2 -39.6216
+      vertex -1.03528 2 -37.7863
+      vertex -0.274104 2 -39.568
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.2784 2 -39.984
+      vertex 2.43505 2 -38.4766
+      vertex 2.82843 2 -38.8216
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.03528 2 -37.7863
+      vertex -0.54352 2 -39.6216
+      vertex -1.53073 2 -37.9545
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.48492 2 -40.1651
+      vertex 2.82843 2 -38.8216
+      vertex 3.17341 2 -39.215
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -0.803635 2 -39.7099
+      vertex -1.53073 2 -37.9545
+      vertex -0.54352 2 -39.6216
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.53073 2 -37.9545
+      vertex -0.803635 2 -39.7099
+      vertex -2 2 -38.1859
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.522104 2 -37.6842
+      vertex 0.274104 2 -39.568
+      vertex 0 2 -39.55
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.03528 2 -37.7863
+      vertex 0.54352 2 -39.6216
+      vertex 0.274104 2 -39.568
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.66604 2 -40.3716
+      vertex 3.17341 2 -39.215
+      vertex 3.4641 2 -39.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.53073 2 -37.9545
+      vertex 0.803635 2 -39.7099
+      vertex 0.54352 2 -39.6216
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2 2 -38.1859
+      vertex 1.05 2 -39.8313
+      vertex 0.803635 2 -39.7099
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.43505 2 -38.4766
+      vertex 1.2784 2 -39.984
+      vertex 1.05 2 -39.8313
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.81865 2 -40.6
+      vertex 3.4641 2 -39.65
+      vertex 3.69552 2 -40.1193
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.82843 2 -38.8216
+      vertex 1.48492 2 -40.1651
+      vertex 1.2784 2 -39.984
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.17341 2 -39.215
+      vertex 1.66604 2 -40.3716
+      vertex 1.48492 2 -40.1651
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.4641 2 -39.65
+      vertex 1.81865 2 -40.6
+      vertex 1.66604 2 -40.3716
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.94015 2 -40.8464
+      vertex 3.69552 2 -40.1193
+      vertex 3.8637 2 -40.6147
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.69552 2 -40.1193
+      vertex 1.94015 2 -40.8464
+      vertex 1.81865 2 -40.6
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.8637 2 -40.6147
+      vertex 2.02844 2 -41.1065
+      vertex 1.94015 2 -40.8464
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.96578 2 -41.1279
+      vertex 2.02844 2 -41.1065
+      vertex 3.8637 2 -40.6147
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.96578 2 -41.1279
+      vertex 2.08203 2 -41.3759
+      vertex 2.02844 2 -41.1065
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4 2 -41.65
+      vertex 2.08203 2 -41.3759
+      vertex 3.96578 2 -41.1279
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4 2 -41.65
+      vertex 2.1 2 -41.65
+      vertex 2.08203 2 -41.3759
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4 2 -41.65
+      vertex 2.08203 2 -41.9241
+      vertex 2.1 2 -41.65
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3.96578 2 -42.1721
+      vertex 2.08203 2 -41.9241
+      vertex 4 2 -41.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.96578 2 -42.1721
+      vertex 2.02844 2 -42.1935
+      vertex 2.08203 2 -41.9241
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3.8637 2 -42.6853
+      vertex 2.02844 2 -42.1935
+      vertex 3.96578 2 -42.1721
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.02844 2 -42.1935
+      vertex 3.8637 2 -42.6853
+      vertex 1.94015 2 -42.4536
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3.69552 2 -43.1807
+      vertex 1.94015 2 -42.4536
+      vertex 3.8637 2 -42.6853
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.94015 2 -42.4536
+      vertex 3.69552 2 -43.1807
+      vertex 1.81865 2 -42.7
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3.4641 2 -43.65
+      vertex 1.81865 2 -42.7
+      vertex 3.69552 2 -43.1807
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.81865 2 -42.7
+      vertex 3.4641 2 -43.65
+      vertex 1.66604 2 -42.9284
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3.17341 2 -44.085
+      vertex 1.66604 2 -42.9284
+      vertex 3.4641 2 -43.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.66604 2 -42.9284
+      vertex 3.17341 2 -44.085
+      vertex 1.48492 2 -43.1349
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 2.82843 2 -44.4784
+      vertex 1.48492 2 -43.1349
+      vertex 3.17341 2 -44.085
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.48492 2 -43.1349
+      vertex 2.82843 2 -44.4784
+      vertex 1.2784 2 -43.316
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 2.43505 2 -44.8234
+      vertex 1.2784 2 -43.316
+      vertex 2.82843 2 -44.4784
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.2784 2 -43.316
+      vertex 2.43505 2 -44.8234
+      vertex 1.05 2 -43.4687
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 2 2 -45.1141
+      vertex 1.05 2 -43.4687
+      vertex 2.43505 2 -44.8234
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.05 2 -43.4687
+      vertex 2 2 -45.1141
+      vertex 0.803635 2 -43.5901
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -1.05 2 -39.8313
+      vertex -2 2 -38.1859
+      vertex -0.803635 2 -39.7099
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2 2 -38.1859
+      vertex -1.05 2 -39.8313
+      vertex -2.43505 2 -38.4766
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -1.2784 2 -39.984
+      vertex -2.43505 2 -38.4766
+      vertex -1.05 2 -39.8313
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.43505 2 -38.4766
+      vertex -1.2784 2 -39.984
+      vertex -2.82843 2 -38.8216
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -1.48492 2 -40.1651
+      vertex -2.82843 2 -38.8216
+      vertex -1.2784 2 -39.984
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.82843 2 -38.8216
+      vertex -1.48492 2 -40.1651
+      vertex -3.17341 2 -39.215
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -1.66604 2 -40.3716
+      vertex -3.17341 2 -39.215
+      vertex -1.48492 2 -40.1651
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.17341 2 -39.215
+      vertex -1.66604 2 -40.3716
+      vertex -3.4641 2 -39.65
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -1.81865 2 -40.6
+      vertex -3.4641 2 -39.65
+      vertex -1.66604 2 -40.3716
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.4641 2 -39.65
+      vertex -1.81865 2 -40.6
+      vertex -3.69552 2 -40.1193
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -1.94015 2 -40.8464
+      vertex -3.69552 2 -40.1193
+      vertex -1.81865 2 -40.6
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.69552 2 -40.1193
+      vertex -1.94015 2 -40.8464
+      vertex -3.8637 2 -40.6147
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2.02844 2 -41.1065
+      vertex -3.8637 2 -40.6147
+      vertex -1.94015 2 -40.8464
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.02844 2 -41.1065
+      vertex -3.96578 2 -41.1279
+      vertex -3.8637 2 -40.6147
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2.08203 2 -41.3759
+      vertex -3.96578 2 -41.1279
+      vertex -2.02844 2 -41.1065
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2.1 2 -41.65
+      vertex -3.96578 2 -41.1279
+      vertex -2.08203 2 -41.3759
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.1 2 -41.65
+      vertex -4 2 -41.65
+      vertex -3.96578 2 -41.1279
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.08203 2 -41.9241
+      vertex -4 2 -41.65
+      vertex -2.1 2 -41.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.08203 2 -41.9241
+      vertex -3.96578 2 -42.1721
+      vertex -4 2 -41.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.02844 2 -42.1935
+      vertex -3.96578 2 -42.1721
+      vertex -2.08203 2 -41.9241
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.8637 2 -42.6853
+      vertex -2.02844 2 -42.1935
+      vertex -1.94015 2 -42.4536
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.02844 2 -42.1935
+      vertex -3.8637 2 -42.6853
+      vertex -3.96578 2 -42.1721
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.69552 2 -43.1807
+      vertex -1.94015 2 -42.4536
+      vertex -1.81865 2 -42.7
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.4641 2 -43.65
+      vertex -1.81865 2 -42.7
+      vertex -1.66604 2 -42.9284
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.17341 2 -44.085
+      vertex -1.66604 2 -42.9284
+      vertex -1.48492 2 -43.1349
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.94015 2 -42.4536
+      vertex -3.69552 2 -43.1807
+      vertex -3.8637 2 -42.6853
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.82843 2 -44.4784
+      vertex -1.48492 2 -43.1349
+      vertex -1.2784 2 -43.316
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.43505 2 -44.8234
+      vertex -1.2784 2 -43.316
+      vertex -1.05 2 -43.4687
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2 2 -45.1141
+      vertex -1.05 2 -43.4687
+      vertex -0.803635 2 -43.5901
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.81865 2 -42.7
+      vertex -3.4641 2 -43.65
+      vertex -3.69552 2 -43.1807
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.53073 2 -45.3455
+      vertex -0.803635 2 -43.5901
+      vertex -0.54352 2 -43.6784
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.03528 2 -45.5137
+      vertex -0.54352 2 -43.6784
+      vertex -0.274104 2 -43.732
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.522104 2 -45.6158
+      vertex -0.274104 2 -43.732
+      vertex 0 2 -43.75
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 1.53073 2 -45.3455
+      vertex 0.803635 2 -43.5901
+      vertex 2 2 -45.1141
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.66604 2 -42.9284
+      vertex -3.17341 2 -44.085
+      vertex -3.4641 2 -43.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.803635 2 -43.5901
+      vertex 1.53073 2 -45.3455
+      vertex 0.54352 2 -43.6784
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.48492 2 -43.1349
+      vertex -2.82843 2 -44.4784
+      vertex -3.17341 2 -44.085
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 1.03528 2 -45.5137
+      vertex 0.54352 2 -43.6784
+      vertex 1.53073 2 -45.3455
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.2784 2 -43.316
+      vertex -2.43505 2 -44.8234
+      vertex -2.82843 2 -44.4784
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.54352 2 -43.6784
+      vertex 1.03528 2 -45.5137
+      vertex 0.274104 2 -43.732
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.05 2 -43.4687
+      vertex -2 2 -45.1141
+      vertex -2.43505 2 -44.8234
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 0.522104 2 -45.6158
+      vertex 0.274104 2 -43.732
+      vertex 1.03528 2 -45.5137
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.803635 2 -43.5901
+      vertex -1.53073 2 -45.3455
+      vertex -2 2 -45.1141
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.274104 2 -43.732
+      vertex 0.522104 2 -45.6158
+      vertex 0 2 -43.75
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.54352 2 -43.6784
+      vertex -1.03528 2 -45.5137
+      vertex -1.53073 2 -45.3455
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 2 -45.65
+      vertex 0 2 -43.75
+      vertex 0.522104 2 -45.6158
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.274104 2 -43.732
+      vertex -0.522104 2 -45.6158
+      vertex -1.03528 2 -45.5137
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 2 -43.75
+      vertex 0 2 -45.65
+      vertex -0.522104 2 -45.6158
+    endloop
+  endfacet
+  facet normal -0.896883 0 0.442268
+    outer loop
+      vertex 3.4641 2 -43.65
+      vertex 3.69552 4.99572 -43.1807
+      vertex 3.4641 4.99572 -43.65
+    endloop
+  endfacet
+  facet normal -0.896883 0 0.442268
+    outer loop
+      vertex 3.69552 4.99572 -43.1807
+      vertex 3.4641 2 -43.65
+      vertex 3.69552 2 -43.1807
+    endloop
+  endfacet
+  facet normal -0.831441 0 0.555613
+    outer loop
+      vertex 3.17341 2 -44.085
+      vertex 3.4641 4.99572 -43.65
+      vertex 3.17341 4.99572 -44.085
+    endloop
+  endfacet
+  facet normal -0.831441 0 0.555613
+    outer loop
+      vertex 3.4641 4.99572 -43.65
+      vertex 3.17341 2 -44.085
+      vertex 3.4641 2 -43.65
+    endloop
+  endfacet
+  facet normal -0.44226 0 0.896887
+    outer loop
+      vertex 1.53073 4.99572 -45.3455
+      vertex 2 2 -45.1141
+      vertex 2 4.99572 -45.1141
+    endloop
+  endfacet
+  facet normal -0.44226 0 0.896887
+    outer loop
+      vertex 2 2 -45.1141
+      vertex 1.53073 4.99572 -45.3455
+      vertex 1.53073 2 -45.3455
+    endloop
+  endfacet
+  facet normal -0.555582 0 0.831462
+    outer loop
+      vertex 2 4.99572 -45.1141
+      vertex 2.43505 2 -44.8234
+      vertex 2.43505 4.99572 -44.8234
+    endloop
+  endfacet
+  facet normal -0.555582 0 0.831462
+    outer loop
+      vertex 2.43505 2 -44.8234
+      vertex 2 4.99572 -45.1141
+      vertex 2 2 -45.1141
+    endloop
+  endfacet
+  facet normal 0.896883 -0 0.442268
+    outer loop
+      vertex -3.69552 2 -43.1807
+      vertex -3.4641 4.99572 -43.65
+      vertex -3.69552 4.99572 -43.1807
+    endloop
+  endfacet
+  facet normal 0.896883 0 0.442268
+    outer loop
+      vertex -3.4641 4.99572 -43.65
+      vertex -3.69552 2 -43.1807
+      vertex -3.4641 2 -43.65
+    endloop
+  endfacet
+  facet normal 0.751861 -0 0.659321
+    outer loop
+      vertex -3.17341 2 -44.085
+      vertex -2.82843 4.99572 -44.4784
+      vertex -3.17341 4.99572 -44.085
+    endloop
+  endfacet
+  facet normal 0.751861 0 0.659321
+    outer loop
+      vertex -2.82843 4.99572 -44.4784
+      vertex -3.17341 2 -44.085
+      vertex -2.82843 2 -44.4784
+    endloop
+  endfacet
+  facet normal 0.0653641 0 0.997861
+    outer loop
+      vertex -0.522104 4.99572 -45.6158
+      vertex 0 2 -45.65
+      vertex 0 4.99572 -45.65
+    endloop
+  endfacet
+  facet normal 0.0653641 0 0.997861
+    outer loop
+      vertex 0 2 -45.65
+      vertex -0.522104 4.99572 -45.6158
+      vertex -0.522104 2 -45.6158
+    endloop
+  endfacet
+  facet normal -0.946922 0 -0.321464
+    outer loop
+      vertex 3.8637 2 -40.6147
+      vertex 3.69552 4.99572 -40.1193
+      vertex 3.8637 4.99572 -40.6147
+    endloop
+  endfacet
+  facet normal -0.946922 -0 -0.321464
+    outer loop
+      vertex 3.69552 4.99572 -40.1193
+      vertex 3.8637 2 -40.6147
+      vertex 3.69552 2 -40.1193
+    endloop
+  endfacet
+  facet normal -0.44226 0 -0.896887
+    outer loop
+      vertex 1.53073 2 -37.9545
+      vertex 2 4.99572 -38.1859
+      vertex 2 2 -38.1859
+    endloop
+  endfacet
+  facet normal -0.44226 0 -0.896887
+    outer loop
+      vertex 2 4.99572 -38.1859
+      vertex 1.53073 2 -37.9545
+      vertex 1.53073 4.99572 -37.9545
+    endloop
+  endfacet
+  facet normal -0.555582 0 -0.831462
+    outer loop
+      vertex 2 2 -38.1859
+      vertex 2.43505 4.99572 -38.4766
+      vertex 2.43505 2 -38.4766
+    endloop
+  endfacet
+  facet normal -0.555582 0 -0.831462
+    outer loop
+      vertex 2.43505 4.99572 -38.4766
+      vertex 2 2 -38.1859
+      vertex 2 4.99572 -38.1859
+    endloop
+  endfacet
+  facet normal 0.659362 0 -0.751826
+    outer loop
+      vertex -2.82843 2 -38.8216
+      vertex -2.43505 4.99572 -38.4766
+      vertex -2.43505 2 -38.4766
+    endloop
+  endfacet
+  facet normal 0.659362 0 -0.751826
+    outer loop
+      vertex -2.43505 4.99572 -38.4766
+      vertex -2.82843 2 -38.8216
+      vertex -2.82843 4.99572 -38.8216
+    endloop
+  endfacet
+  facet normal 0.997859 0 -0.0654027
+    outer loop
+      vertex -3.96578 2 -41.1279
+      vertex -4 4.99572 -41.65
+      vertex -3.96578 4.99572 -41.1279
+    endloop
+  endfacet
+  facet normal 0.997859 0 -0.0654027
+    outer loop
+      vertex -4 4.99572 -41.65
+      vertex -3.96578 2 -41.1279
+      vertex -4 2 -41.65
+    endloop
+  endfacet
+  facet normal -0.946922 0 0.321464
+    outer loop
+      vertex 3.69552 2 -43.1807
+      vertex 3.8637 4.99572 -42.6853
+      vertex 3.69552 4.99572 -43.1807
+    endloop
+  endfacet
+  facet normal -0.946922 0 0.321464
+    outer loop
+      vertex 3.8637 4.99572 -42.6853
+      vertex 3.69552 2 -43.1807
+      vertex 3.8637 2 -42.6853
+    endloop
+  endfacet
+  facet normal -0.980786 0 0.195087
+    outer loop
+      vertex 3.8637 2 -42.6853
+      vertex 3.96578 4.99572 -42.1721
+      vertex 3.8637 4.99572 -42.6853
+    endloop
+  endfacet
+  facet normal -0.980786 0 0.195087
+    outer loop
+      vertex 3.96578 4.99572 -42.1721
+      vertex 3.8637 2 -42.6853
+      vertex 3.96578 2 -42.1721
+    endloop
+  endfacet
+  facet normal -0.751861 0 0.659321
+    outer loop
+      vertex 2.82843 2 -44.4784
+      vertex 3.17341 4.99572 -44.085
+      vertex 2.82843 4.99572 -44.4784
+    endloop
+  endfacet
+  facet normal -0.751861 0 0.659321
+    outer loop
+      vertex 3.17341 4.99572 -44.085
+      vertex 2.82843 2 -44.4784
+      vertex 3.17341 2 -44.085
+    endloop
+  endfacet
+  facet normal -0.321469 0 0.94692
+    outer loop
+      vertex 1.03528 4.99572 -45.5137
+      vertex 1.53073 2 -45.3455
+      vertex 1.53073 4.99572 -45.3455
+    endloop
+  endfacet
+  facet normal -0.321469 0 0.94692
+    outer loop
+      vertex 1.53073 2 -45.3455
+      vertex 1.03528 4.99572 -45.5137
+      vertex 1.03528 2 -45.5137
+    endloop
+  endfacet
+  facet normal -0.195133 0 0.980777
+    outer loop
+      vertex 0.522104 4.99572 -45.6158
+      vertex 1.03528 2 -45.5137
+      vertex 1.03528 4.99572 -45.5137
+    endloop
+  endfacet
+  facet normal -0.195133 0 0.980777
+    outer loop
+      vertex 1.03528 2 -45.5137
+      vertex 0.522104 4.99572 -45.6158
+      vertex 0.522104 2 -45.6158
+    endloop
+  endfacet
+  facet normal 0.831441 -0 0.555613
+    outer loop
+      vertex -3.4641 2 -43.65
+      vertex -3.17341 4.99572 -44.085
+      vertex -3.4641 4.99572 -43.65
+    endloop
+  endfacet
+  facet normal 0.831441 0 0.555613
+    outer loop
+      vertex -3.17341 4.99572 -44.085
+      vertex -3.4641 2 -43.65
+      vertex -3.17341 2 -44.085
+    endloop
+  endfacet
+  facet normal 0.946922 -0 0.321464
+    outer loop
+      vertex -3.8637 2 -42.6853
+      vertex -3.69552 4.99572 -43.1807
+      vertex -3.8637 4.99572 -42.6853
+    endloop
+  endfacet
+  facet normal 0.946922 0 0.321464
+    outer loop
+      vertex -3.69552 4.99572 -43.1807
+      vertex -3.8637 2 -42.6853
+      vertex -3.69552 2 -43.1807
+    endloop
+  endfacet
+  facet normal 0.980786 -0 0.195087
+    outer loop
+      vertex -3.96578 2 -42.1721
+      vertex -3.8637 4.99572 -42.6853
+      vertex -3.96578 4.99572 -42.1721
+    endloop
+  endfacet
+  facet normal 0.980786 0 0.195087
+    outer loop
+      vertex -3.8637 4.99572 -42.6853
+      vertex -3.96578 2 -42.1721
+      vertex -3.8637 2 -42.6853
+    endloop
+  endfacet
+  facet normal 0.44226 0 0.896887
+    outer loop
+      vertex -2 4.99572 -45.1141
+      vertex -1.53073 2 -45.3455
+      vertex -1.53073 4.99572 -45.3455
+    endloop
+  endfacet
+  facet normal 0.44226 0 0.896887
+    outer loop
+      vertex -1.53073 2 -45.3455
+      vertex -2 4.99572 -45.1141
+      vertex -2 2 -45.1141
+    endloop
+  endfacet
+  facet normal 0.555582 0 0.831462
+    outer loop
+      vertex -2.43505 4.99572 -44.8234
+      vertex -2 2 -45.1141
+      vertex -2 4.99572 -45.1141
+    endloop
+  endfacet
+  facet normal 0.555582 0 0.831462
+    outer loop
+      vertex -2 2 -45.1141
+      vertex -2.43505 4.99572 -44.8234
+      vertex -2.43505 2 -44.8234
+    endloop
+  endfacet
+  facet normal 0.195133 0 0.980777
+    outer loop
+      vertex -1.03528 4.99572 -45.5137
+      vertex -0.522104 2 -45.6158
+      vertex -0.522104 4.99572 -45.6158
+    endloop
+  endfacet
+  facet normal 0.195133 0 0.980777
+    outer loop
+      vertex -0.522104 2 -45.6158
+      vertex -1.03528 4.99572 -45.5137
+      vertex -1.03528 2 -45.5137
+    endloop
+  endfacet
+  facet normal -0.997859 0 -0.0654027
+    outer loop
+      vertex 4 2 -41.65
+      vertex 3.96578 4.99572 -41.1279
+      vertex 4 4.99572 -41.65
+    endloop
+  endfacet
+  facet normal -0.997859 -0 -0.0654027
+    outer loop
+      vertex 3.96578 4.99572 -41.1279
+      vertex 4 2 -41.65
+      vertex 3.96578 2 -41.1279
+    endloop
+  endfacet
+  facet normal -0.0653641 0 -0.997861
+    outer loop
+      vertex 0 2 -37.65
+      vertex 0.522104 4.99572 -37.6842
+      vertex 0.522104 2 -37.6842
+    endloop
+  endfacet
+  facet normal -0.0653641 0 -0.997861
+    outer loop
+      vertex 0.522104 4.99572 -37.6842
+      vertex 0 2 -37.65
+      vertex 0 4.99572 -37.65
+    endloop
+  endfacet
+  facet normal -0.321469 0 -0.94692
+    outer loop
+      vertex 1.03528 2 -37.7863
+      vertex 1.53073 4.99572 -37.9545
+      vertex 1.53073 2 -37.9545
+    endloop
+  endfacet
+  facet normal -0.321469 0 -0.94692
+    outer loop
+      vertex 1.53073 4.99572 -37.9545
+      vertex 1.03528 2 -37.7863
+      vertex 1.03528 4.99572 -37.7863
+    endloop
+  endfacet
+  facet normal -0.659362 0 -0.751826
+    outer loop
+      vertex 2.43505 2 -38.4766
+      vertex 2.82843 4.99572 -38.8216
+      vertex 2.82843 2 -38.8216
+    endloop
+  endfacet
+  facet normal -0.659362 0 -0.751826
+    outer loop
+      vertex 2.82843 4.99572 -38.8216
+      vertex 2.43505 2 -38.4766
+      vertex 2.43505 4.99572 -38.4766
+    endloop
+  endfacet
+  facet normal -0.831441 0 -0.555613
+    outer loop
+      vertex 3.4641 2 -39.65
+      vertex 3.17341 4.99572 -39.215
+      vertex 3.4641 4.99572 -39.65
+    endloop
+  endfacet
+  facet normal -0.831441 -0 -0.555613
+    outer loop
+      vertex 3.17341 4.99572 -39.215
+      vertex 3.4641 2 -39.65
+      vertex 3.17341 2 -39.215
+    endloop
+  endfacet
+  facet normal 0.555582 0 -0.831462
+    outer loop
+      vertex -2.43505 2 -38.4766
+      vertex -2 4.99572 -38.1859
+      vertex -2 2 -38.1859
+    endloop
+  endfacet
+  facet normal 0.555582 0 -0.831462
+    outer loop
+      vertex -2 4.99572 -38.1859
+      vertex -2.43505 2 -38.4766
+      vertex -2.43505 4.99572 -38.4766
+    endloop
+  endfacet
+  facet normal 0.321469 0 -0.94692
+    outer loop
+      vertex -1.53073 2 -37.9545
+      vertex -1.03528 4.99572 -37.7863
+      vertex -1.03528 2 -37.7863
+    endloop
+  endfacet
+  facet normal 0.321469 0 -0.94692
+    outer loop
+      vertex -1.03528 4.99572 -37.7863
+      vertex -1.53073 2 -37.9545
+      vertex -1.53073 4.99572 -37.9545
+    endloop
+  endfacet
+  facet normal 0.0653641 0 -0.997861
+    outer loop
+      vertex -0.522104 2 -37.6842
+      vertex 0 4.99572 -37.65
+      vertex 0 2 -37.65
+    endloop
+  endfacet
+  facet normal 0.0653641 0 -0.997861
+    outer loop
+      vertex 0 4.99572 -37.65
+      vertex -0.522104 2 -37.6842
+      vertex -0.522104 4.99572 -37.6842
+    endloop
+  endfacet
+  facet normal 0.896883 0 -0.442268
+    outer loop
+      vertex -3.4641 2 -39.65
+      vertex -3.69552 4.99572 -40.1193
+      vertex -3.4641 4.99572 -39.65
+    endloop
+  endfacet
+  facet normal 0.896883 0 -0.442268
+    outer loop
+      vertex -3.69552 4.99572 -40.1193
+      vertex -3.4641 2 -39.65
+      vertex -3.69552 2 -40.1193
+    endloop
+  endfacet
+  facet normal 0.980786 0 -0.195087
+    outer loop
+      vertex -3.8637 2 -40.6147
+      vertex -3.96578 4.99572 -41.1279
+      vertex -3.8637 4.99572 -40.6147
+    endloop
+  endfacet
+  facet normal 0.980786 0 -0.195087
+    outer loop
+      vertex -3.96578 4.99572 -41.1279
+      vertex -3.8637 2 -40.6147
+      vertex -3.96578 2 -41.1279
+    endloop
+  endfacet
+  facet normal -0.195133 0 -0.980777
+    outer loop
+      vertex 0.522104 2 -37.6842
+      vertex 1.03528 4.99572 -37.7863
+      vertex 1.03528 2 -37.7863
+    endloop
+  endfacet
+  facet normal -0.195133 0 -0.980777
+    outer loop
+      vertex 1.03528 4.99572 -37.7863
+      vertex 0.522104 2 -37.6842
+      vertex 0.522104 4.99572 -37.6842
+    endloop
+  endfacet
+  facet normal -0.751861 0 -0.659321
+    outer loop
+      vertex 3.17341 2 -39.215
+      vertex 2.82843 4.99572 -38.8216
+      vertex 3.17341 4.99572 -39.215
+    endloop
+  endfacet
+  facet normal -0.751861 -0 -0.659321
+    outer loop
+      vertex 2.82843 4.99572 -38.8216
+      vertex 3.17341 2 -39.215
+      vertex 2.82843 2 -38.8216
+    endloop
+  endfacet
+  facet normal -0.980786 0 -0.195087
+    outer loop
+      vertex 3.96578 2 -41.1279
+      vertex 3.8637 4.99572 -40.6147
+      vertex 3.96578 4.99572 -41.1279
+    endloop
+  endfacet
+  facet normal -0.980786 -0 -0.195087
+    outer loop
+      vertex 3.8637 4.99572 -40.6147
+      vertex 3.96578 2 -41.1279
+      vertex 3.8637 2 -40.6147
+    endloop
+  endfacet
+  facet normal -0.896883 0 -0.442268
+    outer loop
+      vertex 3.69552 2 -40.1193
+      vertex 3.4641 4.99572 -39.65
+      vertex 3.69552 4.99572 -40.1193
+    endloop
+  endfacet
+  facet normal -0.896883 -0 -0.442268
+    outer loop
+      vertex 3.4641 4.99572 -39.65
+      vertex 3.69552 2 -40.1193
+      vertex 3.4641 2 -39.65
+    endloop
+  endfacet
+  facet normal 0.44226 0 -0.896887
+    outer loop
+      vertex -2 2 -38.1859
+      vertex -1.53073 4.99572 -37.9545
+      vertex -1.53073 2 -37.9545
+    endloop
+  endfacet
+  facet normal 0.44226 0 -0.896887
+    outer loop
+      vertex -1.53073 4.99572 -37.9545
+      vertex -2 2 -38.1859
+      vertex -2 4.99572 -38.1859
+    endloop
+  endfacet
+  facet normal 0.195133 0 -0.980777
+    outer loop
+      vertex -1.03528 2 -37.7863
+      vertex -0.522104 4.99572 -37.6842
+      vertex -0.522104 2 -37.6842
+    endloop
+  endfacet
+  facet normal 0.195133 0 -0.980777
+    outer loop
+      vertex -0.522104 4.99572 -37.6842
+      vertex -1.03528 2 -37.7863
+      vertex -1.03528 4.99572 -37.7863
+    endloop
+  endfacet
+  facet normal 0.831441 0 -0.555613
+    outer loop
+      vertex -3.17341 2 -39.215
+      vertex -3.4641 4.99572 -39.65
+      vertex -3.17341 4.99572 -39.215
+    endloop
+  endfacet
+  facet normal 0.831441 0 -0.555613
+    outer loop
+      vertex -3.4641 4.99572 -39.65
+      vertex -3.17341 2 -39.215
+      vertex -3.4641 2 -39.65
     endloop
   endfacet
   facet normal -0.997858 0 0.0654196
     outer loop
-      vertex 2.08203 0 41.3759
-      vertex 2.1 5 41.65
-      vertex 2.08203 5 41.3759
+      vertex 2.08203 0.00428295 41.3759
+      vertex 2.1 2 41.65
+      vertex 2.08203 2 41.3759
     endloop
   endfacet
   facet normal -0.997858 0 0.0654196
     outer loop
-      vertex 2.1 5 41.65
-      vertex 2.08203 0 41.3759
-      vertex 2.1 0 41.65
+      vertex 2.1 2 41.65
+      vertex 2.08203 0.00428295 41.3759
+      vertex 2.1 0.00428295 41.65
     endloop
   endfacet
   facet normal 0.997858 -0 0.0654196
     outer loop
-      vertex -2.1 0 41.65
-      vertex -2.08203 5 41.3759
-      vertex -2.1 5 41.65
+      vertex -2.1 0.00428295 41.65
+      vertex -2.08203 2 41.3759
+      vertex -2.1 2 41.65
     endloop
   endfacet
   facet normal 0.997858 0 0.0654196
     outer loop
-      vertex -2.08203 5 41.3759
-      vertex -2.1 0 41.65
-      vertex -2.08203 0 41.3759
-    endloop
-  endfacet
-  facet normal -0.0655274 0 0.997851
-    outer loop
-      vertex 0 5 39.55
-      vertex 0.274104 0 39.568
-      vertex 0.274104 5 39.568
-    endloop
-  endfacet
-  facet normal -0.0655274 0 0.997851
-    outer loop
-      vertex 0.274104 0 39.568
-      vertex 0 5 39.55
-      vertex 0 0 39.55
-    endloop
-  endfacet
-  facet normal 0.0655274 0 -0.997851
-    outer loop
-      vertex -0.274104 0 43.732
-      vertex 0 5 43.75
-      vertex 0 0 43.75
-    endloop
-  endfacet
-  facet normal 0.0655274 0 -0.997851
-    outer loop
-      vertex 0 5 43.75
-      vertex -0.274104 0 43.732
-      vertex -0.274104 5 43.732
-    endloop
-  endfacet
-  facet normal -0.659319 0 0.751864
-    outer loop
-      vertex 1.2784 5 39.984
-      vertex 1.48492 0 40.1651
-      vertex 1.48492 5 40.1651
-    endloop
-  endfacet
-  facet normal -0.659319 0 0.751864
-    outer loop
-      vertex 1.48492 0 40.1651
-      vertex 1.2784 5 39.984
-      vertex 1.2784 0 39.984
-    endloop
-  endfacet
-  facet normal 0.659319 0 0.751864
-    outer loop
-      vertex -1.48492 5 40.1651
-      vertex -1.2784 0 39.984
-      vertex -1.2784 5 39.984
-    endloop
-  endfacet
-  facet normal 0.659319 0 0.751864
-    outer loop
-      vertex -1.2784 0 39.984
-      vertex -1.48492 5 40.1651
-      vertex -1.48492 0 40.1651
-    endloop
-  endfacet
-  facet normal 0.321449 0 0.946927
-    outer loop
-      vertex -0.803635 5 39.7099
-      vertex -0.54352 0 39.6216
-      vertex -0.54352 5 39.6216
-    endloop
-  endfacet
-  facet normal 0.321449 0 0.946927
-    outer loop
-      vertex -0.54352 0 39.6216
-      vertex -0.803635 5 39.7099
-      vertex -0.803635 0 39.7099
-    endloop
-  endfacet
-  facet normal 0.980783 0 -0.195101
-    outer loop
-      vertex -2.02844 0 42.1935
-      vertex -2.08203 5 41.9241
-      vertex -2.02844 5 42.1935
-    endloop
-  endfacet
-  facet normal 0.980783 0 -0.195101
-    outer loop
-      vertex -2.08203 5 41.9241
-      vertex -2.02844 0 42.1935
-      vertex -2.08203 0 41.9241
-    endloop
-  endfacet
-  facet normal -0.896889 0 0.442256
-    outer loop
-      vertex 1.81865 0 40.6
-      vertex 1.94015 5 40.8464
-      vertex 1.81865 5 40.6
-    endloop
-  endfacet
-  facet normal -0.896889 0 0.442256
-    outer loop
-      vertex 1.94015 5 40.8464
-      vertex 1.81865 0 40.6
-      vertex 1.94015 0 40.8464
-    endloop
-  endfacet
-  facet normal -0.831473 0 0.555565
-    outer loop
-      vertex 1.66604 0 40.3716
-      vertex 1.81865 5 40.6
-      vertex 1.66604 5 40.3716
-    endloop
-  endfacet
-  facet normal -0.831473 0 0.555565
-    outer loop
-      vertex 1.81865 5 40.6
-      vertex 1.66604 0 40.3716
-      vertex 1.81865 0 40.6
-    endloop
-  endfacet
-  facet normal -0.442014 0 0.897008
-    outer loop
-      vertex 0.803635 5 39.7099
-      vertex 1.05 0 39.8313
-      vertex 1.05 5 39.8313
-    endloop
-  endfacet
-  facet normal -0.442014 0 0.897008
-    outer loop
-      vertex 1.05 0 39.8313
-      vertex 0.803635 5 39.7099
-      vertex 0.803635 0 39.7099
-    endloop
-  endfacet
-  facet normal -0.321449 0 0.946927
-    outer loop
-      vertex 0.54352 5 39.6216
-      vertex 0.803635 0 39.7099
-      vertex 0.803635 5 39.7099
-    endloop
-  endfacet
-  facet normal -0.321449 0 0.946927
-    outer loop
-      vertex 0.803635 0 39.7099
-      vertex 0.54352 5 39.6216
-      vertex 0.54352 0 39.6216
-    endloop
-  endfacet
-  facet normal -0.555792 0 0.831322
-    outer loop
-      vertex 1.05 5 39.8313
-      vertex 1.2784 0 39.984
-      vertex 1.2784 5 39.984
-    endloop
-  endfacet
-  facet normal -0.555792 0 0.831322
-    outer loop
-      vertex 1.2784 0 39.984
-      vertex 1.05 5 39.8313
-      vertex 1.05 0 39.8313
-    endloop
-  endfacet
-  facet normal 0.896889 -0 0.442256
-    outer loop
-      vertex -1.94015 0 40.8464
-      vertex -1.81865 5 40.6
-      vertex -1.94015 5 40.8464
-    endloop
-  endfacet
-  facet normal 0.896889 0 0.442256
-    outer loop
-      vertex -1.81865 5 40.6
-      vertex -1.94015 0 40.8464
-      vertex -1.81865 0 40.6
-    endloop
-  endfacet
-  facet normal 0.831473 -0 0.555565
-    outer loop
-      vertex -1.81865 0 40.6
-      vertex -1.66604 5 40.3716
-      vertex -1.81865 5 40.6
-    endloop
-  endfacet
-  facet normal 0.831473 0 0.555565
-    outer loop
-      vertex -1.66604 5 40.3716
-      vertex -1.81865 0 40.6
-      vertex -1.66604 0 40.3716
-    endloop
-  endfacet
-  facet normal 0.555792 0 0.831322
-    outer loop
-      vertex -1.2784 5 39.984
-      vertex -1.05 0 39.8313
-      vertex -1.05 5 39.8313
-    endloop
-  endfacet
-  facet normal 0.555792 0 0.831322
-    outer loop
-      vertex -1.05 0 39.8313
-      vertex -1.2784 5 39.984
-      vertex -1.2784 0 39.984
-    endloop
-  endfacet
-  facet normal 0.195125 0 0.980778
-    outer loop
-      vertex -0.54352 5 39.6216
-      vertex -0.274104 0 39.568
-      vertex -0.274104 5 39.568
-    endloop
-  endfacet
-  facet normal 0.195125 0 0.980778
-    outer loop
-      vertex -0.274104 0 39.568
-      vertex -0.54352 5 39.6216
-      vertex -0.54352 0 39.6216
-    endloop
-  endfacet
-  facet normal -0.946932 0 -0.321433
-    outer loop
-      vertex 2.02844 0 42.1935
-      vertex 1.94015 5 42.4536
-      vertex 2.02844 5 42.1935
-    endloop
-  endfacet
-  facet normal -0.946932 -0 -0.321433
-    outer loop
-      vertex 1.94015 5 42.4536
-      vertex 2.02844 0 42.1935
-      vertex 1.94015 0 42.4536
-    endloop
-  endfacet
-  facet normal 0.442014 0 -0.897008
-    outer loop
-      vertex -1.05 0 43.4687
-      vertex -0.803635 5 43.5901
-      vertex -0.803635 0 43.5901
-    endloop
-  endfacet
-  facet normal 0.442014 0 -0.897008
-    outer loop
-      vertex -0.803635 5 43.5901
-      vertex -1.05 0 43.4687
-      vertex -1.05 5 43.4687
-    endloop
-  endfacet
-  facet normal 0.659319 0 -0.751864
-    outer loop
-      vertex -1.48492 0 43.1349
-      vertex -1.2784 5 43.316
-      vertex -1.2784 0 43.316
-    endloop
-  endfacet
-  facet normal 0.659319 0 -0.751864
-    outer loop
-      vertex -1.2784 5 43.316
-      vertex -1.48492 0 43.1349
-      vertex -1.48492 5 43.1349
-    endloop
-  endfacet
-  facet normal 0.321449 0 -0.946927
-    outer loop
-      vertex -0.803635 0 43.5901
-      vertex -0.54352 5 43.6784
-      vertex -0.54352 0 43.6784
-    endloop
-  endfacet
-  facet normal 0.321449 0 -0.946927
-    outer loop
-      vertex -0.54352 5 43.6784
-      vertex -0.803635 0 43.5901
-      vertex -0.803635 5 43.5901
-    endloop
-  endfacet
-  facet normal 0.896889 0 -0.442256
-    outer loop
-      vertex -1.81865 0 42.7
-      vertex -1.94015 5 42.4536
-      vertex -1.81865 5 42.7
-    endloop
-  endfacet
-  facet normal 0.896889 0 -0.442256
-    outer loop
-      vertex -1.94015 5 42.4536
-      vertex -1.81865 0 42.7
-      vertex -1.94015 0 42.4536
-    endloop
-  endfacet
-  facet normal 0.831473 0 -0.555565
-    outer loop
-      vertex -1.66604 0 42.9284
-      vertex -1.81865 5 42.7
-      vertex -1.66604 5 42.9284
-    endloop
-  endfacet
-  facet normal 0.831473 0 -0.555565
-    outer loop
-      vertex -1.81865 5 42.7
-      vertex -1.66604 0 42.9284
-      vertex -1.81865 0 42.7
-    endloop
-  endfacet
-  facet normal 0.997858 0 -0.0654196
-    outer loop
-      vertex -2.08203 0 41.9241
-      vertex -2.1 5 41.65
-      vertex -2.08203 5 41.9241
-    endloop
-  endfacet
-  facet normal 0.997858 0 -0.0654196
-    outer loop
-      vertex -2.1 5 41.65
-      vertex -2.08203 0 41.9241
-      vertex -2.1 0 41.65
-    endloop
-  endfacet
-  facet normal -0.946932 0 0.321433
-    outer loop
-      vertex 1.94015 0 40.8464
-      vertex 2.02844 5 41.1065
-      vertex 1.94015 5 40.8464
-    endloop
-  endfacet
-  facet normal -0.946932 0 0.321433
-    outer loop
-      vertex 2.02844 5 41.1065
-      vertex 1.94015 0 40.8464
-      vertex 2.02844 0 41.1065
-    endloop
-  endfacet
-  facet normal -0.980783 0 0.195101
-    outer loop
-      vertex 2.02844 0 41.1065
-      vertex 2.08203 5 41.3759
-      vertex 2.02844 5 41.1065
-    endloop
-  endfacet
-  facet normal -0.980783 0 0.195101
-    outer loop
-      vertex 2.08203 5 41.3759
-      vertex 2.02844 0 41.1065
-      vertex 2.08203 0 41.3759
-    endloop
-  endfacet
-  facet normal -0.751796 0 0.659396
-    outer loop
-      vertex 1.48492 0 40.1651
-      vertex 1.66604 5 40.3716
-      vertex 1.48492 5 40.1651
-    endloop
-  endfacet
-  facet normal -0.751796 0 0.659396
-    outer loop
-      vertex 1.66604 5 40.3716
-      vertex 1.48492 0 40.1651
-      vertex 1.66604 0 40.3716
-    endloop
-  endfacet
-  facet normal -0.195125 0 0.980778
-    outer loop
-      vertex 0.274104 5 39.568
-      vertex 0.54352 0 39.6216
-      vertex 0.54352 5 39.6216
-    endloop
-  endfacet
-  facet normal -0.195125 0 0.980778
-    outer loop
-      vertex 0.54352 0 39.6216
-      vertex 0.274104 5 39.568
-      vertex 0.274104 0 39.568
-    endloop
-  endfacet
-  facet normal 0.946932 -0 0.321433
-    outer loop
-      vertex -2.02844 0 41.1065
-      vertex -1.94015 5 40.8464
-      vertex -2.02844 5 41.1065
-    endloop
-  endfacet
-  facet normal 0.946932 0 0.321433
-    outer loop
-      vertex -1.94015 5 40.8464
-      vertex -2.02844 0 41.1065
-      vertex -1.94015 0 40.8464
-    endloop
-  endfacet
-  facet normal 0.980783 -0 0.195101
-    outer loop
-      vertex -2.08203 0 41.3759
-      vertex -2.02844 5 41.1065
-      vertex -2.08203 5 41.3759
-    endloop
-  endfacet
-  facet normal 0.980783 0 0.195101
-    outer loop
-      vertex -2.02844 5 41.1065
-      vertex -2.08203 0 41.3759
-      vertex -2.02844 0 41.1065
-    endloop
-  endfacet
-  facet normal 0.442014 0 0.897008
-    outer loop
-      vertex -1.05 5 39.8313
-      vertex -0.803635 0 39.7099
-      vertex -0.803635 5 39.7099
-    endloop
-  endfacet
-  facet normal 0.442014 0 0.897008
-    outer loop
-      vertex -0.803635 0 39.7099
-      vertex -1.05 5 39.8313
-      vertex -1.05 0 39.8313
+      vertex -2.08203 2 41.3759
+      vertex -2.1 0.00428295 41.65
+      vertex -2.08203 0.00428295 41.3759
     endloop
   endfacet
   facet normal 0.0655274 0 0.997851
     outer loop
-      vertex -0.274104 5 39.568
-      vertex 0 0 39.55
-      vertex 0 5 39.55
+      vertex -0.274104 2 39.568
+      vertex 0 0.00428295 39.55
+      vertex 0 2 39.55
     endloop
   endfacet
   facet normal 0.0655274 0 0.997851
     outer loop
-      vertex 0 0 39.55
-      vertex -0.274104 5 39.568
-      vertex -0.274104 0 39.568
-    endloop
-  endfacet
-  facet normal -0.997858 0 -0.0654196
-    outer loop
-      vertex 2.1 0 41.65
-      vertex 2.08203 5 41.9241
-      vertex 2.1 5 41.65
-    endloop
-  endfacet
-  facet normal -0.997858 -0 -0.0654196
-    outer loop
-      vertex 2.08203 5 41.9241
-      vertex 2.1 0 41.65
-      vertex 2.08203 0 41.9241
+      vertex 0 0.00428295 39.55
+      vertex -0.274104 2 39.568
+      vertex -0.274104 0.00428295 39.568
     endloop
   endfacet
   facet normal -0.0655274 0 -0.997851
     outer loop
-      vertex 0 0 43.75
-      vertex 0.274104 5 43.732
-      vertex 0.274104 0 43.732
+      vertex 0 0.00428295 43.75
+      vertex 0.274104 2 43.732
+      vertex 0.274104 0.00428295 43.732
     endloop
   endfacet
   facet normal -0.0655274 0 -0.997851
     outer loop
-      vertex 0.274104 5 43.732
-      vertex 0 0 43.75
-      vertex 0 5 43.75
+      vertex 0.274104 2 43.732
+      vertex 0 0.00428295 43.75
+      vertex 0 2 43.75
     endloop
   endfacet
-  facet normal -0.321449 0 -0.946927
+  facet normal -0.659319 0 0.751864
     outer loop
-      vertex 0.54352 0 43.6784
-      vertex 0.803635 5 43.5901
-      vertex 0.803635 0 43.5901
+      vertex 1.2784 2 39.984
+      vertex 1.48492 0.00428295 40.1651
+      vertex 1.48492 2 40.1651
     endloop
   endfacet
-  facet normal -0.321449 0 -0.946927
+  facet normal -0.659319 0 0.751864
     outer loop
-      vertex 0.803635 5 43.5901
-      vertex 0.54352 0 43.6784
-      vertex 0.54352 5 43.6784
-    endloop
-  endfacet
-  facet normal -0.442014 0 -0.897008
-    outer loop
-      vertex 0.803635 0 43.5901
-      vertex 1.05 5 43.4687
-      vertex 1.05 0 43.4687
-    endloop
-  endfacet
-  facet normal -0.442014 0 -0.897008
-    outer loop
-      vertex 1.05 5 43.4687
-      vertex 0.803635 0 43.5901
-      vertex 0.803635 5 43.5901
-    endloop
-  endfacet
-  facet normal -0.659319 0 -0.751864
-    outer loop
-      vertex 1.2784 0 43.316
-      vertex 1.48492 5 43.1349
-      vertex 1.48492 0 43.1349
-    endloop
-  endfacet
-  facet normal -0.659319 0 -0.751864
-    outer loop
-      vertex 1.48492 5 43.1349
-      vertex 1.2784 0 43.316
-      vertex 1.2784 5 43.316
-    endloop
-  endfacet
-  facet normal -0.896889 0 -0.442256
-    outer loop
-      vertex 1.94015 0 42.4536
-      vertex 1.81865 5 42.7
-      vertex 1.94015 5 42.4536
-    endloop
-  endfacet
-  facet normal -0.896889 -0 -0.442256
-    outer loop
-      vertex 1.81865 5 42.7
-      vertex 1.94015 0 42.4536
-      vertex 1.81865 0 42.7
-    endloop
-  endfacet
-  facet normal -0.751796 0 -0.659396
-    outer loop
-      vertex 1.66604 0 42.9284
-      vertex 1.48492 5 43.1349
-      vertex 1.66604 5 42.9284
-    endloop
-  endfacet
-  facet normal -0.751796 -0 -0.659396
-    outer loop
-      vertex 1.48492 5 43.1349
-      vertex 1.66604 0 42.9284
-      vertex 1.48492 0 43.1349
-    endloop
-  endfacet
-  facet normal -0.831473 0 -0.555565
-    outer loop
-      vertex 1.81865 0 42.7
-      vertex 1.66604 5 42.9284
-      vertex 1.81865 5 42.7
-    endloop
-  endfacet
-  facet normal -0.831473 -0 -0.555565
-    outer loop
-      vertex 1.66604 5 42.9284
-      vertex 1.81865 0 42.7
-      vertex 1.66604 0 42.9284
-    endloop
-  endfacet
-  facet normal 0.555792 0 -0.831322
-    outer loop
-      vertex -1.2784 0 43.316
-      vertex -1.05 5 43.4687
-      vertex -1.05 0 43.4687
-    endloop
-  endfacet
-  facet normal 0.555792 0 -0.831322
-    outer loop
-      vertex -1.05 5 43.4687
-      vertex -1.2784 0 43.316
-      vertex -1.2784 5 43.316
-    endloop
-  endfacet
-  facet normal 0.195125 0 -0.980778
-    outer loop
-      vertex -0.54352 0 43.6784
-      vertex -0.274104 5 43.732
-      vertex -0.274104 0 43.732
-    endloop
-  endfacet
-  facet normal 0.195125 0 -0.980778
-    outer loop
-      vertex -0.274104 5 43.732
-      vertex -0.54352 0 43.6784
-      vertex -0.54352 5 43.6784
-    endloop
-  endfacet
-  facet normal 0.751796 0 -0.659396
-    outer loop
-      vertex -1.48492 0 43.1349
-      vertex -1.66604 5 42.9284
-      vertex -1.48492 5 43.1349
-    endloop
-  endfacet
-  facet normal 0.751796 0 -0.659396
-    outer loop
-      vertex -1.66604 5 42.9284
-      vertex -1.48492 0 43.1349
-      vertex -1.66604 0 42.9284
+      vertex 1.48492 0.00428295 40.1651
+      vertex 1.2784 2 39.984
+      vertex 1.2784 0.00428295 39.984
     endloop
   endfacet
   facet normal 0.751796 -0 0.659396
     outer loop
-      vertex -1.66604 0 40.3716
-      vertex -1.48492 5 40.1651
-      vertex -1.66604 5 40.3716
+      vertex -1.66604 0.00428295 40.3716
+      vertex -1.48492 2 40.1651
+      vertex -1.66604 2 40.3716
     endloop
   endfacet
   facet normal 0.751796 0 0.659396
     outer loop
-      vertex -1.48492 5 40.1651
-      vertex -1.66604 0 40.3716
-      vertex -1.48492 0 40.1651
+      vertex -1.48492 2 40.1651
+      vertex -1.66604 0.00428295 40.3716
+      vertex -1.48492 0.00428295 40.1651
     endloop
   endfacet
-  facet normal -0.195125 0 -0.980778
+  facet normal 0.442014 0 0.897008
     outer loop
-      vertex 0.274104 0 43.732
-      vertex 0.54352 5 43.6784
-      vertex 0.54352 0 43.6784
+      vertex -1.05 2 39.8313
+      vertex -0.803635 0.00428295 39.7099
+      vertex -0.803635 2 39.7099
     endloop
   endfacet
-  facet normal -0.195125 0 -0.980778
+  facet normal 0.442014 0 0.897008
     outer loop
-      vertex 0.54352 5 43.6784
-      vertex 0.274104 0 43.732
-      vertex 0.274104 5 43.732
+      vertex -0.803635 0.00428295 39.7099
+      vertex -1.05 2 39.8313
+      vertex -1.05 0.00428295 39.8313
     endloop
   endfacet
-  facet normal -0.555792 0 -0.831322
+  facet normal -0.831473 0 -0.555565
     outer loop
-      vertex 1.05 0 43.4687
-      vertex 1.2784 5 43.316
-      vertex 1.2784 0 43.316
+      vertex 1.81865 0.00428295 42.7
+      vertex 1.66604 2 42.9284
+      vertex 1.81865 2 42.7
     endloop
   endfacet
-  facet normal -0.555792 0 -0.831322
+  facet normal -0.831473 -0 -0.555565
     outer loop
-      vertex 1.2784 5 43.316
-      vertex 1.05 0 43.4687
-      vertex 1.05 5 43.4687
+      vertex 1.66604 2 42.9284
+      vertex 1.81865 0.00428295 42.7
+      vertex 1.66604 0.00428295 42.9284
+    endloop
+  endfacet
+  facet normal -0.896889 0 0.442256
+    outer loop
+      vertex 1.81865 0.00428295 40.6
+      vertex 1.94015 2 40.8464
+      vertex 1.81865 2 40.6
+    endloop
+  endfacet
+  facet normal -0.896889 0 0.442256
+    outer loop
+      vertex 1.94015 2 40.8464
+      vertex 1.81865 0.00428295 40.6
+      vertex 1.94015 0.00428295 40.8464
+    endloop
+  endfacet
+  facet normal -0.831473 0 0.555565
+    outer loop
+      vertex 1.66604 0.00428295 40.3716
+      vertex 1.81865 2 40.6
+      vertex 1.66604 2 40.3716
+    endloop
+  endfacet
+  facet normal -0.831473 0 0.555565
+    outer loop
+      vertex 1.81865 2 40.6
+      vertex 1.66604 0.00428295 40.3716
+      vertex 1.81865 0.00428295 40.6
+    endloop
+  endfacet
+  facet normal -0.321449 0 0.946927
+    outer loop
+      vertex 0.54352 2 39.6216
+      vertex 0.803635 0.00428295 39.7099
+      vertex 0.803635 2 39.7099
+    endloop
+  endfacet
+  facet normal -0.321449 0 0.946927
+    outer loop
+      vertex 0.803635 0.00428295 39.7099
+      vertex 0.54352 2 39.6216
+      vertex 0.54352 0.00428295 39.6216
+    endloop
+  endfacet
+  facet normal -0.195125 0 0.980778
+    outer loop
+      vertex 0.274104 2 39.568
+      vertex 0.54352 0.00428295 39.6216
+      vertex 0.54352 2 39.6216
+    endloop
+  endfacet
+  facet normal -0.195125 0 0.980778
+    outer loop
+      vertex 0.54352 0.00428295 39.6216
+      vertex 0.274104 2 39.568
+      vertex 0.274104 0.00428295 39.568
+    endloop
+  endfacet
+  facet normal -0.555792 0 0.831322
+    outer loop
+      vertex 1.05 2 39.8313
+      vertex 1.2784 0.00428295 39.984
+      vertex 1.2784 2 39.984
+    endloop
+  endfacet
+  facet normal -0.555792 0 0.831322
+    outer loop
+      vertex 1.2784 0.00428295 39.984
+      vertex 1.05 2 39.8313
+      vertex 1.05 0.00428295 39.8313
+    endloop
+  endfacet
+  facet normal 0.896889 -0 0.442256
+    outer loop
+      vertex -1.94015 0.00428295 40.8464
+      vertex -1.81865 2 40.6
+      vertex -1.94015 2 40.8464
+    endloop
+  endfacet
+  facet normal 0.896889 0 0.442256
+    outer loop
+      vertex -1.81865 2 40.6
+      vertex -1.94015 0.00428295 40.8464
+      vertex -1.81865 0.00428295 40.6
+    endloop
+  endfacet
+  facet normal 0.831473 -0 0.555565
+    outer loop
+      vertex -1.81865 0.00428295 40.6
+      vertex -1.66604 2 40.3716
+      vertex -1.81865 2 40.6
+    endloop
+  endfacet
+  facet normal 0.831473 0 0.555565
+    outer loop
+      vertex -1.66604 2 40.3716
+      vertex -1.81865 0.00428295 40.6
+      vertex -1.66604 0.00428295 40.3716
+    endloop
+  endfacet
+  facet normal 0.555792 0 0.831322
+    outer loop
+      vertex -1.2784 2 39.984
+      vertex -1.05 0.00428295 39.8313
+      vertex -1.05 2 39.8313
+    endloop
+  endfacet
+  facet normal 0.555792 0 0.831322
+    outer loop
+      vertex -1.05 0.00428295 39.8313
+      vertex -1.2784 2 39.984
+      vertex -1.2784 0.00428295 39.984
+    endloop
+  endfacet
+  facet normal 0.321449 0 0.946927
+    outer loop
+      vertex -0.803635 2 39.7099
+      vertex -0.54352 0.00428295 39.6216
+      vertex -0.54352 2 39.6216
+    endloop
+  endfacet
+  facet normal 0.321449 0 0.946927
+    outer loop
+      vertex -0.54352 0.00428295 39.6216
+      vertex -0.803635 2 39.7099
+      vertex -0.803635 0.00428295 39.7099
     endloop
   endfacet
   facet normal -0.980783 0 -0.195101
     outer loop
-      vertex 2.08203 0 41.9241
-      vertex 2.02844 5 42.1935
-      vertex 2.08203 5 41.9241
+      vertex 2.08203 0.00428295 41.9241
+      vertex 2.02844 2 42.1935
+      vertex 2.08203 2 41.9241
     endloop
   endfacet
   facet normal -0.980783 -0 -0.195101
     outer loop
-      vertex 2.02844 5 42.1935
-      vertex 2.08203 0 41.9241
-      vertex 2.02844 0 42.1935
+      vertex 2.02844 2 42.1935
+      vertex 2.08203 0.00428295 41.9241
+      vertex 2.02844 0.00428295 42.1935
+    endloop
+  endfacet
+  facet normal -0.195125 0 -0.980778
+    outer loop
+      vertex 0.274104 0.00428295 43.732
+      vertex 0.54352 2 43.6784
+      vertex 0.54352 0.00428295 43.6784
+    endloop
+  endfacet
+  facet normal -0.195125 0 -0.980778
+    outer loop
+      vertex 0.54352 2 43.6784
+      vertex 0.274104 0.00428295 43.732
+      vertex 0.274104 2 43.732
+    endloop
+  endfacet
+  facet normal -0.442014 0 -0.897008
+    outer loop
+      vertex 0.803635 0.00428295 43.5901
+      vertex 1.05 2 43.4687
+      vertex 1.05 0.00428295 43.4687
+    endloop
+  endfacet
+  facet normal -0.442014 0 -0.897008
+    outer loop
+      vertex 1.05 2 43.4687
+      vertex 0.803635 0.00428295 43.5901
+      vertex 0.803635 2 43.5901
+    endloop
+  endfacet
+  facet normal -0.946932 0 0.321433
+    outer loop
+      vertex 1.94015 0.00428295 40.8464
+      vertex 2.02844 2 41.1065
+      vertex 1.94015 2 40.8464
+    endloop
+  endfacet
+  facet normal -0.946932 0 0.321433
+    outer loop
+      vertex 2.02844 2 41.1065
+      vertex 1.94015 0.00428295 40.8464
+      vertex 2.02844 0.00428295 41.1065
+    endloop
+  endfacet
+  facet normal -0.980783 0 0.195101
+    outer loop
+      vertex 2.02844 0.00428295 41.1065
+      vertex 2.08203 2 41.3759
+      vertex 2.02844 2 41.1065
+    endloop
+  endfacet
+  facet normal -0.980783 0 0.195101
+    outer loop
+      vertex 2.08203 2 41.3759
+      vertex 2.02844 0.00428295 41.1065
+      vertex 2.08203 0.00428295 41.3759
+    endloop
+  endfacet
+  facet normal -0.751796 0 0.659396
+    outer loop
+      vertex 1.48492 0.00428295 40.1651
+      vertex 1.66604 2 40.3716
+      vertex 1.48492 2 40.1651
+    endloop
+  endfacet
+  facet normal -0.751796 0 0.659396
+    outer loop
+      vertex 1.66604 2 40.3716
+      vertex 1.48492 0.00428295 40.1651
+      vertex 1.66604 0.00428295 40.3716
+    endloop
+  endfacet
+  facet normal -0.0655274 0 0.997851
+    outer loop
+      vertex 0 2 39.55
+      vertex 0.274104 0.00428295 39.568
+      vertex 0.274104 2 39.568
+    endloop
+  endfacet
+  facet normal -0.0655274 0 0.997851
+    outer loop
+      vertex 0.274104 0.00428295 39.568
+      vertex 0 2 39.55
+      vertex 0 0.00428295 39.55
+    endloop
+  endfacet
+  facet normal -0.442014 0 0.897008
+    outer loop
+      vertex 0.803635 2 39.7099
+      vertex 1.05 0.00428295 39.8313
+      vertex 1.05 2 39.8313
+    endloop
+  endfacet
+  facet normal -0.442014 0 0.897008
+    outer loop
+      vertex 1.05 0.00428295 39.8313
+      vertex 0.803635 2 39.7099
+      vertex 0.803635 0.00428295 39.7099
+    endloop
+  endfacet
+  facet normal 0.946932 -0 0.321433
+    outer loop
+      vertex -2.02844 0.00428295 41.1065
+      vertex -1.94015 2 40.8464
+      vertex -2.02844 2 41.1065
+    endloop
+  endfacet
+  facet normal 0.946932 0 0.321433
+    outer loop
+      vertex -1.94015 2 40.8464
+      vertex -2.02844 0.00428295 41.1065
+      vertex -1.94015 0.00428295 40.8464
+    endloop
+  endfacet
+  facet normal 0.980783 -0 0.195101
+    outer loop
+      vertex -2.08203 0.00428295 41.3759
+      vertex -2.02844 2 41.1065
+      vertex -2.08203 2 41.3759
+    endloop
+  endfacet
+  facet normal 0.980783 0 0.195101
+    outer loop
+      vertex -2.02844 2 41.1065
+      vertex -2.08203 0.00428295 41.3759
+      vertex -2.02844 0.00428295 41.1065
+    endloop
+  endfacet
+  facet normal 0.659319 0 0.751864
+    outer loop
+      vertex -1.48492 2 40.1651
+      vertex -1.2784 0.00428295 39.984
+      vertex -1.2784 2 39.984
+    endloop
+  endfacet
+  facet normal 0.659319 0 0.751864
+    outer loop
+      vertex -1.2784 0.00428295 39.984
+      vertex -1.48492 2 40.1651
+      vertex -1.48492 0.00428295 40.1651
+    endloop
+  endfacet
+  facet normal 0.195125 0 0.980778
+    outer loop
+      vertex -0.54352 2 39.6216
+      vertex -0.274104 0.00428295 39.568
+      vertex -0.274104 2 39.568
+    endloop
+  endfacet
+  facet normal 0.195125 0 0.980778
+    outer loop
+      vertex -0.274104 0.00428295 39.568
+      vertex -0.54352 2 39.6216
+      vertex -0.54352 0.00428295 39.6216
+    endloop
+  endfacet
+  facet normal -0.997858 0 -0.0654196
+    outer loop
+      vertex 2.1 0.00428295 41.65
+      vertex 2.08203 2 41.9241
+      vertex 2.1 2 41.65
+    endloop
+  endfacet
+  facet normal -0.997858 -0 -0.0654196
+    outer loop
+      vertex 2.08203 2 41.9241
+      vertex 2.1 0.00428295 41.65
+      vertex 2.08203 0.00428295 41.9241
+    endloop
+  endfacet
+  facet normal -0.751796 0 -0.659396
+    outer loop
+      vertex 1.66604 0.00428295 42.9284
+      vertex 1.48492 2 43.1349
+      vertex 1.66604 2 42.9284
+    endloop
+  endfacet
+  facet normal -0.751796 -0 -0.659396
+    outer loop
+      vertex 1.48492 2 43.1349
+      vertex 1.66604 0.00428295 42.9284
+      vertex 1.48492 0.00428295 43.1349
     endloop
   endfacet
   facet normal 0.946932 0 -0.321433
     outer loop
-      vertex -1.94015 0 42.4536
-      vertex -2.02844 5 42.1935
-      vertex -1.94015 5 42.4536
+      vertex -1.94015 0.00428295 42.4536
+      vertex -2.02844 2 42.1935
+      vertex -1.94015 2 42.4536
     endloop
   endfacet
   facet normal 0.946932 0 -0.321433
     outer loop
-      vertex -2.02844 5 42.1935
-      vertex -1.94015 0 42.4536
-      vertex -2.02844 0 42.1935
+      vertex -2.02844 2 42.1935
+      vertex -1.94015 0.00428295 42.4536
+      vertex -2.02844 0.00428295 42.1935
+    endloop
+  endfacet
+  facet normal -0.896889 0 -0.442256
+    outer loop
+      vertex 1.94015 0.00428295 42.4536
+      vertex 1.81865 2 42.7
+      vertex 1.94015 2 42.4536
+    endloop
+  endfacet
+  facet normal -0.896889 -0 -0.442256
+    outer loop
+      vertex 1.81865 2 42.7
+      vertex 1.94015 0.00428295 42.4536
+      vertex 1.81865 0.00428295 42.7
+    endloop
+  endfacet
+  facet normal -0.946932 0 -0.321433
+    outer loop
+      vertex 2.02844 0.00428295 42.1935
+      vertex 1.94015 2 42.4536
+      vertex 2.02844 2 42.1935
+    endloop
+  endfacet
+  facet normal -0.946932 -0 -0.321433
+    outer loop
+      vertex 1.94015 2 42.4536
+      vertex 2.02844 0.00428295 42.1935
+      vertex 1.94015 0.00428295 42.4536
+    endloop
+  endfacet
+  facet normal -0.555792 0 -0.831322
+    outer loop
+      vertex 1.05 0.00428295 43.4687
+      vertex 1.2784 2 43.316
+      vertex 1.2784 0.00428295 43.316
+    endloop
+  endfacet
+  facet normal -0.555792 0 -0.831322
+    outer loop
+      vertex 1.2784 2 43.316
+      vertex 1.05 0.00428295 43.4687
+      vertex 1.05 2 43.4687
+    endloop
+  endfacet
+  facet normal -0.659319 0 -0.751864
+    outer loop
+      vertex 1.2784 0.00428295 43.316
+      vertex 1.48492 2 43.1349
+      vertex 1.48492 0.00428295 43.1349
+    endloop
+  endfacet
+  facet normal -0.659319 0 -0.751864
+    outer loop
+      vertex 1.48492 2 43.1349
+      vertex 1.2784 0.00428295 43.316
+      vertex 1.2784 2 43.316
+    endloop
+  endfacet
+  facet normal 0.831473 0 -0.555565
+    outer loop
+      vertex -1.66604 0.00428295 42.9284
+      vertex -1.81865 2 42.7
+      vertex -1.66604 2 42.9284
+    endloop
+  endfacet
+  facet normal 0.831473 0 -0.555565
+    outer loop
+      vertex -1.81865 2 42.7
+      vertex -1.66604 0.00428295 42.9284
+      vertex -1.81865 0.00428295 42.7
+    endloop
+  endfacet
+  facet normal -0.321449 0 -0.946927
+    outer loop
+      vertex 0.54352 0.00428295 43.6784
+      vertex 0.803635 2 43.5901
+      vertex 0.803635 0.00428295 43.5901
+    endloop
+  endfacet
+  facet normal -0.321449 0 -0.946927
+    outer loop
+      vertex 0.803635 2 43.5901
+      vertex 0.54352 0.00428295 43.6784
+      vertex 0.54352 2 43.6784
+    endloop
+  endfacet
+  facet normal 0.0655274 0 -0.997851
+    outer loop
+      vertex -0.274104 0.00428295 43.732
+      vertex 0 2 43.75
+      vertex 0 0.00428295 43.75
+    endloop
+  endfacet
+  facet normal 0.0655274 0 -0.997851
+    outer loop
+      vertex 0 2 43.75
+      vertex -0.274104 0.00428295 43.732
+      vertex -0.274104 2 43.732
+    endloop
+  endfacet
+  facet normal 0.195125 0 -0.980778
+    outer loop
+      vertex -0.54352 0.00428295 43.6784
+      vertex -0.274104 2 43.732
+      vertex -0.274104 0.00428295 43.732
+    endloop
+  endfacet
+  facet normal 0.195125 0 -0.980778
+    outer loop
+      vertex -0.274104 2 43.732
+      vertex -0.54352 0.00428295 43.6784
+      vertex -0.54352 2 43.6784
+    endloop
+  endfacet
+  facet normal 0.659319 0 -0.751864
+    outer loop
+      vertex -1.48492 0.00428295 43.1349
+      vertex -1.2784 2 43.316
+      vertex -1.2784 0.00428295 43.316
+    endloop
+  endfacet
+  facet normal 0.659319 0 -0.751864
+    outer loop
+      vertex -1.2784 2 43.316
+      vertex -1.48492 0.00428295 43.1349
+      vertex -1.48492 2 43.1349
+    endloop
+  endfacet
+  facet normal 0.751796 0 -0.659396
+    outer loop
+      vertex -1.48492 0.00428295 43.1349
+      vertex -1.66604 2 42.9284
+      vertex -1.48492 2 43.1349
+    endloop
+  endfacet
+  facet normal 0.751796 0 -0.659396
+    outer loop
+      vertex -1.66604 2 42.9284
+      vertex -1.48492 0.00428295 43.1349
+      vertex -1.66604 0.00428295 42.9284
+    endloop
+  endfacet
+  facet normal 0.896889 0 -0.442256
+    outer loop
+      vertex -1.81865 0.00428295 42.7
+      vertex -1.94015 2 42.4536
+      vertex -1.81865 2 42.7
+    endloop
+  endfacet
+  facet normal 0.896889 0 -0.442256
+    outer loop
+      vertex -1.94015 2 42.4536
+      vertex -1.81865 0.00428295 42.7
+      vertex -1.94015 0.00428295 42.4536
+    endloop
+  endfacet
+  facet normal 0.980783 0 -0.195101
+    outer loop
+      vertex -2.02844 0.00428295 42.1935
+      vertex -2.08203 2 41.9241
+      vertex -2.02844 2 42.1935
+    endloop
+  endfacet
+  facet normal 0.980783 0 -0.195101
+    outer loop
+      vertex -2.08203 2 41.9241
+      vertex -2.02844 0.00428295 42.1935
+      vertex -2.08203 0.00428295 41.9241
+    endloop
+  endfacet
+  facet normal 0.997858 0 -0.0654196
+    outer loop
+      vertex -2.08203 0.00428295 41.9241
+      vertex -2.1 2 41.65
+      vertex -2.08203 2 41.9241
+    endloop
+  endfacet
+  facet normal 0.997858 0 -0.0654196
+    outer loop
+      vertex -2.1 2 41.65
+      vertex -2.08203 0.00428295 41.9241
+      vertex -2.1 0.00428295 41.65
+    endloop
+  endfacet
+  facet normal 0.555792 0 -0.831322
+    outer loop
+      vertex -1.2784 0.00428295 43.316
+      vertex -1.05 2 43.4687
+      vertex -1.05 0.00428295 43.4687
+    endloop
+  endfacet
+  facet normal 0.555792 0 -0.831322
+    outer loop
+      vertex -1.05 2 43.4687
+      vertex -1.2784 0.00428295 43.316
+      vertex -1.2784 2 43.316
+    endloop
+  endfacet
+  facet normal 0.321449 0 -0.946927
+    outer loop
+      vertex -0.803635 0.00428295 43.5901
+      vertex -0.54352 2 43.6784
+      vertex -0.54352 0.00428295 43.6784
+    endloop
+  endfacet
+  facet normal 0.321449 0 -0.946927
+    outer loop
+      vertex -0.54352 2 43.6784
+      vertex -0.803635 0.00428295 43.5901
+      vertex -0.803635 2 43.5901
+    endloop
+  endfacet
+  facet normal 0.442014 0 -0.897008
+    outer loop
+      vertex -1.05 0.00428295 43.4687
+      vertex -0.803635 2 43.5901
+      vertex -0.803635 0.00428295 43.5901
+    endloop
+  endfacet
+  facet normal 0.442014 0 -0.897008
+    outer loop
+      vertex -0.803635 2 43.5901
+      vertex -1.05 0.00428295 43.4687
+      vertex -1.05 2 43.4687
+    endloop
+  endfacet
+  facet normal -0.997859 0 0.0654027
+    outer loop
+      vertex 3.96578 2 41.1279
+      vertex 4 4.99572 41.65
+      vertex 3.96578 4.99572 41.1279
+    endloop
+  endfacet
+  facet normal -0.997859 0 0.0654027
+    outer loop
+      vertex 4 4.99572 41.65
+      vertex 3.96578 2 41.1279
+      vertex 4 2 41.65
+    endloop
+  endfacet
+  facet normal 0.997859 -0 0.0654027
+    outer loop
+      vertex -4 2 41.65
+      vertex -3.96578 4.99572 41.1279
+      vertex -4 4.99572 41.65
+    endloop
+  endfacet
+  facet normal 0.997859 0 0.0654027
+    outer loop
+      vertex -3.96578 4.99572 41.1279
+      vertex -4 2 41.65
+      vertex -3.96578 2 41.1279
+    endloop
+  endfacet
+  facet normal -0.0653641 0 0.997861
+    outer loop
+      vertex 0 4.99572 37.65
+      vertex 0.522104 2 37.6842
+      vertex 0.522104 4.99572 37.6842
+    endloop
+  endfacet
+  facet normal -0.0653641 0 0.997861
+    outer loop
+      vertex 0.522104 2 37.6842
+      vertex 0 4.99572 37.65
+      vertex 0 2 37.65
+    endloop
+  endfacet
+  facet normal 0.751861 0 -0.659321
+    outer loop
+      vertex -2.82843 2 44.4784
+      vertex -3.17341 4.99572 44.085
+      vertex -2.82843 4.99572 44.4784
+    endloop
+  endfacet
+  facet normal 0.751861 0 -0.659321
+    outer loop
+      vertex -3.17341 4.99572 44.085
+      vertex -2.82843 2 44.4784
+      vertex -3.17341 2 44.085
+    endloop
+  endfacet
+  facet normal -0.659362 0 0.751826
+    outer loop
+      vertex 2.43505 4.99572 38.4766
+      vertex 2.82843 2 38.8216
+      vertex 2.82843 4.99572 38.8216
+    endloop
+  endfacet
+  facet normal -0.659362 0 0.751826
+    outer loop
+      vertex 2.82843 2 38.8216
+      vertex 2.43505 4.99572 38.4766
+      vertex 2.43505 2 38.4766
+    endloop
+  endfacet
+  facet normal 0.659362 0 0.751826
+    outer loop
+      vertex -2.82843 4.99572 38.8216
+      vertex -2.43505 2 38.4766
+      vertex -2.43505 4.99572 38.4766
+    endloop
+  endfacet
+  facet normal 0.659362 0 0.751826
+    outer loop
+      vertex -2.43505 2 38.4766
+      vertex -2.82843 4.99572 38.8216
+      vertex -2.82843 2 38.8216
+    endloop
+  endfacet
+  facet normal 0.321469 0 0.94692
+    outer loop
+      vertex -1.53073 4.99572 37.9545
+      vertex -1.03528 2 37.7863
+      vertex -1.03528 4.99572 37.7863
+    endloop
+  endfacet
+  facet normal 0.321469 0 0.94692
+    outer loop
+      vertex -1.03528 2 37.7863
+      vertex -1.53073 4.99572 37.9545
+      vertex -1.53073 2 37.9545
+    endloop
+  endfacet
+  facet normal 0.946922 0 -0.321464
+    outer loop
+      vertex -3.69552 2 43.1807
+      vertex -3.8637 4.99572 42.6853
+      vertex -3.69552 4.99572 43.1807
+    endloop
+  endfacet
+  facet normal 0.946922 0 -0.321464
+    outer loop
+      vertex -3.8637 4.99572 42.6853
+      vertex -3.69552 2 43.1807
+      vertex -3.8637 2 42.6853
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 2 43.75
+      vertex 0 2 45.65
+      vertex 0.522104 2 45.6158
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.274104 2 43.732
+      vertex 0.522104 2 45.6158
+      vertex 1.03528 2 45.5137
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 2 45.65
+      vertex 0 2 43.75
+      vertex -0.522104 2 45.6158
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.54352 2 43.6784
+      vertex 1.03528 2 45.5137
+      vertex 1.53073 2 45.3455
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -0.274104 2 43.732
+      vertex -0.522104 2 45.6158
+      vertex 0 2 43.75
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.803635 2 43.5901
+      vertex 1.53073 2 45.3455
+      vertex 2 2 45.1141
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.522104 2 45.6158
+      vertex -0.274104 2 43.732
+      vertex -1.03528 2 45.5137
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.05 2 43.4687
+      vertex 2 2 45.1141
+      vertex 2.43505 2 44.8234
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -0.54352 2 43.6784
+      vertex -1.03528 2 45.5137
+      vertex -0.274104 2 43.732
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.2784 2 43.316
+      vertex 2.43505 2 44.8234
+      vertex 2.82843 2 44.4784
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.03528 2 45.5137
+      vertex -0.54352 2 43.6784
+      vertex -1.53073 2 45.3455
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.48492 2 43.1349
+      vertex 2.82843 2 44.4784
+      vertex 3.17341 2 44.085
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -0.803635 2 43.5901
+      vertex -1.53073 2 45.3455
+      vertex -0.54352 2 43.6784
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.53073 2 45.3455
+      vertex -0.803635 2 43.5901
+      vertex -2 2 45.1141
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.522104 2 45.6158
+      vertex 0.274104 2 43.732
+      vertex 0 2 43.75
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.03528 2 45.5137
+      vertex 0.54352 2 43.6784
+      vertex 0.274104 2 43.732
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.66604 2 42.9284
+      vertex 3.17341 2 44.085
+      vertex 3.4641 2 43.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.53073 2 45.3455
+      vertex 0.803635 2 43.5901
+      vertex 0.54352 2 43.6784
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2 2 45.1141
+      vertex 1.05 2 43.4687
+      vertex 0.803635 2 43.5901
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.43505 2 44.8234
+      vertex 1.2784 2 43.316
+      vertex 1.05 2 43.4687
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.81865 2 42.7
+      vertex 3.4641 2 43.65
+      vertex 3.69552 2 43.1807
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.82843 2 44.4784
+      vertex 1.48492 2 43.1349
+      vertex 1.2784 2 43.316
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.17341 2 44.085
+      vertex 1.66604 2 42.9284
+      vertex 1.48492 2 43.1349
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.4641 2 43.65
+      vertex 1.81865 2 42.7
+      vertex 1.66604 2 42.9284
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.94015 2 42.4536
+      vertex 3.69552 2 43.1807
+      vertex 3.8637 2 42.6853
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.69552 2 43.1807
+      vertex 1.94015 2 42.4536
+      vertex 1.81865 2 42.7
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.8637 2 42.6853
+      vertex 2.02844 2 42.1935
+      vertex 1.94015 2 42.4536
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.96578 2 42.1721
+      vertex 2.02844 2 42.1935
+      vertex 3.8637 2 42.6853
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.96578 2 42.1721
+      vertex 2.08203 2 41.9241
+      vertex 2.02844 2 42.1935
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4 2 41.65
+      vertex 2.08203 2 41.9241
+      vertex 3.96578 2 42.1721
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4 2 41.65
+      vertex 2.1 2 41.65
+      vertex 2.08203 2 41.9241
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4 2 41.65
+      vertex 2.08203 2 41.3759
+      vertex 2.1 2 41.65
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3.96578 2 41.1279
+      vertex 2.08203 2 41.3759
+      vertex 4 2 41.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.96578 2 41.1279
+      vertex 2.02844 2 41.1065
+      vertex 2.08203 2 41.3759
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3.8637 2 40.6147
+      vertex 2.02844 2 41.1065
+      vertex 3.96578 2 41.1279
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.02844 2 41.1065
+      vertex 3.8637 2 40.6147
+      vertex 1.94015 2 40.8464
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3.69552 2 40.1193
+      vertex 1.94015 2 40.8464
+      vertex 3.8637 2 40.6147
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.94015 2 40.8464
+      vertex 3.69552 2 40.1193
+      vertex 1.81865 2 40.6
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3.4641 2 39.65
+      vertex 1.81865 2 40.6
+      vertex 3.69552 2 40.1193
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.81865 2 40.6
+      vertex 3.4641 2 39.65
+      vertex 1.66604 2 40.3716
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3.17341 2 39.215
+      vertex 1.66604 2 40.3716
+      vertex 3.4641 2 39.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.66604 2 40.3716
+      vertex 3.17341 2 39.215
+      vertex 1.48492 2 40.1651
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 2.82843 2 38.8216
+      vertex 1.48492 2 40.1651
+      vertex 3.17341 2 39.215
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.48492 2 40.1651
+      vertex 2.82843 2 38.8216
+      vertex 1.2784 2 39.984
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 2.43505 2 38.4766
+      vertex 1.2784 2 39.984
+      vertex 2.82843 2 38.8216
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.2784 2 39.984
+      vertex 2.43505 2 38.4766
+      vertex 1.05 2 39.8313
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 2 2 38.1859
+      vertex 1.05 2 39.8313
+      vertex 2.43505 2 38.4766
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.05 2 39.8313
+      vertex 2 2 38.1859
+      vertex 0.803635 2 39.7099
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -1.05 2 43.4687
+      vertex -2 2 45.1141
+      vertex -0.803635 2 43.5901
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2 2 45.1141
+      vertex -1.05 2 43.4687
+      vertex -2.43505 2 44.8234
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -1.2784 2 43.316
+      vertex -2.43505 2 44.8234
+      vertex -1.05 2 43.4687
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.43505 2 44.8234
+      vertex -1.2784 2 43.316
+      vertex -2.82843 2 44.4784
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -1.48492 2 43.1349
+      vertex -2.82843 2 44.4784
+      vertex -1.2784 2 43.316
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.82843 2 44.4784
+      vertex -1.48492 2 43.1349
+      vertex -3.17341 2 44.085
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -1.66604 2 42.9284
+      vertex -3.17341 2 44.085
+      vertex -1.48492 2 43.1349
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.17341 2 44.085
+      vertex -1.66604 2 42.9284
+      vertex -3.4641 2 43.65
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -1.81865 2 42.7
+      vertex -3.4641 2 43.65
+      vertex -1.66604 2 42.9284
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.4641 2 43.65
+      vertex -1.81865 2 42.7
+      vertex -3.69552 2 43.1807
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -1.94015 2 42.4536
+      vertex -3.69552 2 43.1807
+      vertex -1.81865 2 42.7
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.69552 2 43.1807
+      vertex -1.94015 2 42.4536
+      vertex -3.8637 2 42.6853
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2.02844 2 42.1935
+      vertex -3.8637 2 42.6853
+      vertex -1.94015 2 42.4536
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.02844 2 42.1935
+      vertex -3.96578 2 42.1721
+      vertex -3.8637 2 42.6853
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2.08203 2 41.9241
+      vertex -3.96578 2 42.1721
+      vertex -2.02844 2 42.1935
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2.1 2 41.65
+      vertex -3.96578 2 42.1721
+      vertex -2.08203 2 41.9241
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.1 2 41.65
+      vertex -4 2 41.65
+      vertex -3.96578 2 42.1721
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.08203 2 41.3759
+      vertex -4 2 41.65
+      vertex -2.1 2 41.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.08203 2 41.3759
+      vertex -3.96578 2 41.1279
+      vertex -4 2 41.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.02844 2 41.1065
+      vertex -3.96578 2 41.1279
+      vertex -2.08203 2 41.3759
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.8637 2 40.6147
+      vertex -2.02844 2 41.1065
+      vertex -1.94015 2 40.8464
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.02844 2 41.1065
+      vertex -3.8637 2 40.6147
+      vertex -3.96578 2 41.1279
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.69552 2 40.1193
+      vertex -1.94015 2 40.8464
+      vertex -1.81865 2 40.6
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.4641 2 39.65
+      vertex -1.81865 2 40.6
+      vertex -1.66604 2 40.3716
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.17341 2 39.215
+      vertex -1.66604 2 40.3716
+      vertex -1.48492 2 40.1651
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.94015 2 40.8464
+      vertex -3.69552 2 40.1193
+      vertex -3.8637 2 40.6147
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.82843 2 38.8216
+      vertex -1.48492 2 40.1651
+      vertex -1.2784 2 39.984
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.43505 2 38.4766
+      vertex -1.2784 2 39.984
+      vertex -1.05 2 39.8313
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2 2 38.1859
+      vertex -1.05 2 39.8313
+      vertex -0.803635 2 39.7099
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.81865 2 40.6
+      vertex -3.4641 2 39.65
+      vertex -3.69552 2 40.1193
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.53073 2 37.9545
+      vertex -0.803635 2 39.7099
+      vertex -0.54352 2 39.6216
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.03528 2 37.7863
+      vertex -0.54352 2 39.6216
+      vertex -0.274104 2 39.568
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.522104 2 37.6842
+      vertex -0.274104 2 39.568
+      vertex 0 2 39.55
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 1.53073 2 37.9545
+      vertex 0.803635 2 39.7099
+      vertex 2 2 38.1859
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.66604 2 40.3716
+      vertex -3.17341 2 39.215
+      vertex -3.4641 2 39.65
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.803635 2 39.7099
+      vertex 1.53073 2 37.9545
+      vertex 0.54352 2 39.6216
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.48492 2 40.1651
+      vertex -2.82843 2 38.8216
+      vertex -3.17341 2 39.215
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 1.03528 2 37.7863
+      vertex 0.54352 2 39.6216
+      vertex 1.53073 2 37.9545
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.2784 2 39.984
+      vertex -2.43505 2 38.4766
+      vertex -2.82843 2 38.8216
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.54352 2 39.6216
+      vertex 1.03528 2 37.7863
+      vertex 0.274104 2 39.568
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.05 2 39.8313
+      vertex -2 2 38.1859
+      vertex -2.43505 2 38.4766
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 0.522104 2 37.6842
+      vertex 0.274104 2 39.568
+      vertex 1.03528 2 37.7863
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.803635 2 39.7099
+      vertex -1.53073 2 37.9545
+      vertex -2 2 38.1859
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.274104 2 39.568
+      vertex 0.522104 2 37.6842
+      vertex 0 2 39.55
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.54352 2 39.6216
+      vertex -1.03528 2 37.7863
+      vertex -1.53073 2 37.9545
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 2 37.65
+      vertex 0 2 39.55
+      vertex 0.522104 2 37.6842
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.274104 2 39.568
+      vertex -0.522104 2 37.6842
+      vertex -1.03528 2 37.7863
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 2 39.55
+      vertex 0 2 37.65
+      vertex -0.522104 2 37.6842
+    endloop
+  endfacet
+  facet normal -0.896883 0 0.442268
+    outer loop
+      vertex 3.4641 2 39.65
+      vertex 3.69552 4.99572 40.1193
+      vertex 3.4641 4.99572 39.65
+    endloop
+  endfacet
+  facet normal -0.896883 0 0.442268
+    outer loop
+      vertex 3.69552 4.99572 40.1193
+      vertex 3.4641 2 39.65
+      vertex 3.69552 2 40.1193
+    endloop
+  endfacet
+  facet normal -0.831441 0 0.555613
+    outer loop
+      vertex 3.17341 2 39.215
+      vertex 3.4641 4.99572 39.65
+      vertex 3.17341 4.99572 39.215
+    endloop
+  endfacet
+  facet normal -0.831441 0 0.555613
+    outer loop
+      vertex 3.4641 4.99572 39.65
+      vertex 3.17341 2 39.215
+      vertex 3.4641 2 39.65
+    endloop
+  endfacet
+  facet normal -0.44226 0 0.896887
+    outer loop
+      vertex 1.53073 4.99572 37.9545
+      vertex 2 2 38.1859
+      vertex 2 4.99572 38.1859
+    endloop
+  endfacet
+  facet normal -0.44226 0 0.896887
+    outer loop
+      vertex 2 2 38.1859
+      vertex 1.53073 4.99572 37.9545
+      vertex 1.53073 2 37.9545
+    endloop
+  endfacet
+  facet normal -0.555582 0 0.831462
+    outer loop
+      vertex 2 4.99572 38.1859
+      vertex 2.43505 2 38.4766
+      vertex 2.43505 4.99572 38.4766
+    endloop
+  endfacet
+  facet normal -0.555582 0 0.831462
+    outer loop
+      vertex 2.43505 2 38.4766
+      vertex 2 4.99572 38.1859
+      vertex 2 2 38.1859
+    endloop
+  endfacet
+  facet normal 0.896883 -0 0.442268
+    outer loop
+      vertex -3.69552 2 40.1193
+      vertex -3.4641 4.99572 39.65
+      vertex -3.69552 4.99572 40.1193
+    endloop
+  endfacet
+  facet normal 0.896883 0 0.442268
+    outer loop
+      vertex -3.4641 4.99572 39.65
+      vertex -3.69552 2 40.1193
+      vertex -3.4641 2 39.65
+    endloop
+  endfacet
+  facet normal 0.751861 -0 0.659321
+    outer loop
+      vertex -3.17341 2 39.215
+      vertex -2.82843 4.99572 38.8216
+      vertex -3.17341 4.99572 39.215
+    endloop
+  endfacet
+  facet normal 0.751861 0 0.659321
+    outer loop
+      vertex -2.82843 4.99572 38.8216
+      vertex -3.17341 2 39.215
+      vertex -2.82843 2 38.8216
+    endloop
+  endfacet
+  facet normal 0.0653641 0 0.997861
+    outer loop
+      vertex -0.522104 4.99572 37.6842
+      vertex 0 2 37.65
+      vertex 0 4.99572 37.65
+    endloop
+  endfacet
+  facet normal 0.0653641 0 0.997861
+    outer loop
+      vertex 0 2 37.65
+      vertex -0.522104 4.99572 37.6842
+      vertex -0.522104 2 37.6842
+    endloop
+  endfacet
+  facet normal -0.946922 0 -0.321464
+    outer loop
+      vertex 3.8637 2 42.6853
+      vertex 3.69552 4.99572 43.1807
+      vertex 3.8637 4.99572 42.6853
+    endloop
+  endfacet
+  facet normal -0.946922 -0 -0.321464
+    outer loop
+      vertex 3.69552 4.99572 43.1807
+      vertex 3.8637 2 42.6853
+      vertex 3.69552 2 43.1807
+    endloop
+  endfacet
+  facet normal -0.44226 0 -0.896887
+    outer loop
+      vertex 1.53073 2 45.3455
+      vertex 2 4.99572 45.1141
+      vertex 2 2 45.1141
+    endloop
+  endfacet
+  facet normal -0.44226 0 -0.896887
+    outer loop
+      vertex 2 4.99572 45.1141
+      vertex 1.53073 2 45.3455
+      vertex 1.53073 4.99572 45.3455
+    endloop
+  endfacet
+  facet normal -0.555582 0 -0.831462
+    outer loop
+      vertex 2 2 45.1141
+      vertex 2.43505 4.99572 44.8234
+      vertex 2.43505 2 44.8234
+    endloop
+  endfacet
+  facet normal -0.555582 0 -0.831462
+    outer loop
+      vertex 2.43505 4.99572 44.8234
+      vertex 2 2 45.1141
+      vertex 2 4.99572 45.1141
+    endloop
+  endfacet
+  facet normal 0.659362 0 -0.751826
+    outer loop
+      vertex -2.82843 2 44.4784
+      vertex -2.43505 4.99572 44.8234
+      vertex -2.43505 2 44.8234
+    endloop
+  endfacet
+  facet normal 0.659362 0 -0.751826
+    outer loop
+      vertex -2.43505 4.99572 44.8234
+      vertex -2.82843 2 44.4784
+      vertex -2.82843 4.99572 44.4784
+    endloop
+  endfacet
+  facet normal 0.997859 0 -0.0654027
+    outer loop
+      vertex -3.96578 2 42.1721
+      vertex -4 4.99572 41.65
+      vertex -3.96578 4.99572 42.1721
+    endloop
+  endfacet
+  facet normal 0.997859 0 -0.0654027
+    outer loop
+      vertex -4 4.99572 41.65
+      vertex -3.96578 2 42.1721
+      vertex -4 2 41.65
+    endloop
+  endfacet
+  facet normal -0.946922 0 0.321464
+    outer loop
+      vertex 3.69552 2 40.1193
+      vertex 3.8637 4.99572 40.6147
+      vertex 3.69552 4.99572 40.1193
+    endloop
+  endfacet
+  facet normal -0.946922 0 0.321464
+    outer loop
+      vertex 3.8637 4.99572 40.6147
+      vertex 3.69552 2 40.1193
+      vertex 3.8637 2 40.6147
+    endloop
+  endfacet
+  facet normal -0.980786 0 0.195087
+    outer loop
+      vertex 3.8637 2 40.6147
+      vertex 3.96578 4.99572 41.1279
+      vertex 3.8637 4.99572 40.6147
+    endloop
+  endfacet
+  facet normal -0.980786 0 0.195087
+    outer loop
+      vertex 3.96578 4.99572 41.1279
+      vertex 3.8637 2 40.6147
+      vertex 3.96578 2 41.1279
+    endloop
+  endfacet
+  facet normal -0.751861 0 0.659321
+    outer loop
+      vertex 2.82843 2 38.8216
+      vertex 3.17341 4.99572 39.215
+      vertex 2.82843 4.99572 38.8216
+    endloop
+  endfacet
+  facet normal -0.751861 0 0.659321
+    outer loop
+      vertex 3.17341 4.99572 39.215
+      vertex 2.82843 2 38.8216
+      vertex 3.17341 2 39.215
+    endloop
+  endfacet
+  facet normal -0.321469 0 0.94692
+    outer loop
+      vertex 1.03528 4.99572 37.7863
+      vertex 1.53073 2 37.9545
+      vertex 1.53073 4.99572 37.9545
+    endloop
+  endfacet
+  facet normal -0.321469 0 0.94692
+    outer loop
+      vertex 1.53073 2 37.9545
+      vertex 1.03528 4.99572 37.7863
+      vertex 1.03528 2 37.7863
+    endloop
+  endfacet
+  facet normal -0.195133 0 0.980777
+    outer loop
+      vertex 0.522104 4.99572 37.6842
+      vertex 1.03528 2 37.7863
+      vertex 1.03528 4.99572 37.7863
+    endloop
+  endfacet
+  facet normal -0.195133 0 0.980777
+    outer loop
+      vertex 1.03528 2 37.7863
+      vertex 0.522104 4.99572 37.6842
+      vertex 0.522104 2 37.6842
+    endloop
+  endfacet
+  facet normal 0.831441 -0 0.555613
+    outer loop
+      vertex -3.4641 2 39.65
+      vertex -3.17341 4.99572 39.215
+      vertex -3.4641 4.99572 39.65
+    endloop
+  endfacet
+  facet normal 0.831441 0 0.555613
+    outer loop
+      vertex -3.17341 4.99572 39.215
+      vertex -3.4641 2 39.65
+      vertex -3.17341 2 39.215
+    endloop
+  endfacet
+  facet normal 0.946922 -0 0.321464
+    outer loop
+      vertex -3.8637 2 40.6147
+      vertex -3.69552 4.99572 40.1193
+      vertex -3.8637 4.99572 40.6147
+    endloop
+  endfacet
+  facet normal 0.946922 0 0.321464
+    outer loop
+      vertex -3.69552 4.99572 40.1193
+      vertex -3.8637 2 40.6147
+      vertex -3.69552 2 40.1193
+    endloop
+  endfacet
+  facet normal 0.980786 -0 0.195087
+    outer loop
+      vertex -3.96578 2 41.1279
+      vertex -3.8637 4.99572 40.6147
+      vertex -3.96578 4.99572 41.1279
+    endloop
+  endfacet
+  facet normal 0.980786 0 0.195087
+    outer loop
+      vertex -3.8637 4.99572 40.6147
+      vertex -3.96578 2 41.1279
+      vertex -3.8637 2 40.6147
+    endloop
+  endfacet
+  facet normal 0.44226 0 0.896887
+    outer loop
+      vertex -2 4.99572 38.1859
+      vertex -1.53073 2 37.9545
+      vertex -1.53073 4.99572 37.9545
+    endloop
+  endfacet
+  facet normal 0.44226 0 0.896887
+    outer loop
+      vertex -1.53073 2 37.9545
+      vertex -2 4.99572 38.1859
+      vertex -2 2 38.1859
+    endloop
+  endfacet
+  facet normal 0.555582 0 0.831462
+    outer loop
+      vertex -2.43505 4.99572 38.4766
+      vertex -2 2 38.1859
+      vertex -2 4.99572 38.1859
+    endloop
+  endfacet
+  facet normal 0.555582 0 0.831462
+    outer loop
+      vertex -2 2 38.1859
+      vertex -2.43505 4.99572 38.4766
+      vertex -2.43505 2 38.4766
+    endloop
+  endfacet
+  facet normal 0.195133 0 0.980777
+    outer loop
+      vertex -1.03528 4.99572 37.7863
+      vertex -0.522104 2 37.6842
+      vertex -0.522104 4.99572 37.6842
+    endloop
+  endfacet
+  facet normal 0.195133 0 0.980777
+    outer loop
+      vertex -0.522104 2 37.6842
+      vertex -1.03528 4.99572 37.7863
+      vertex -1.03528 2 37.7863
+    endloop
+  endfacet
+  facet normal -0.997859 0 -0.0654027
+    outer loop
+      vertex 4 2 41.65
+      vertex 3.96578 4.99572 42.1721
+      vertex 4 4.99572 41.65
+    endloop
+  endfacet
+  facet normal -0.997859 -0 -0.0654027
+    outer loop
+      vertex 3.96578 4.99572 42.1721
+      vertex 4 2 41.65
+      vertex 3.96578 2 42.1721
+    endloop
+  endfacet
+  facet normal -0.0653641 0 -0.997861
+    outer loop
+      vertex 0 2 45.65
+      vertex 0.522104 4.99572 45.6158
+      vertex 0.522104 2 45.6158
+    endloop
+  endfacet
+  facet normal -0.0653641 0 -0.997861
+    outer loop
+      vertex 0.522104 4.99572 45.6158
+      vertex 0 2 45.65
+      vertex 0 4.99572 45.65
+    endloop
+  endfacet
+  facet normal -0.321469 0 -0.94692
+    outer loop
+      vertex 1.03528 2 45.5137
+      vertex 1.53073 4.99572 45.3455
+      vertex 1.53073 2 45.3455
+    endloop
+  endfacet
+  facet normal -0.321469 0 -0.94692
+    outer loop
+      vertex 1.53073 4.99572 45.3455
+      vertex 1.03528 2 45.5137
+      vertex 1.03528 4.99572 45.5137
+    endloop
+  endfacet
+  facet normal -0.659362 0 -0.751826
+    outer loop
+      vertex 2.43505 2 44.8234
+      vertex 2.82843 4.99572 44.4784
+      vertex 2.82843 2 44.4784
+    endloop
+  endfacet
+  facet normal -0.659362 0 -0.751826
+    outer loop
+      vertex 2.82843 4.99572 44.4784
+      vertex 2.43505 2 44.8234
+      vertex 2.43505 4.99572 44.8234
+    endloop
+  endfacet
+  facet normal -0.831441 0 -0.555613
+    outer loop
+      vertex 3.4641 2 43.65
+      vertex 3.17341 4.99572 44.085
+      vertex 3.4641 4.99572 43.65
+    endloop
+  endfacet
+  facet normal -0.831441 -0 -0.555613
+    outer loop
+      vertex 3.17341 4.99572 44.085
+      vertex 3.4641 2 43.65
+      vertex 3.17341 2 44.085
+    endloop
+  endfacet
+  facet normal 0.555582 0 -0.831462
+    outer loop
+      vertex -2.43505 2 44.8234
+      vertex -2 4.99572 45.1141
+      vertex -2 2 45.1141
+    endloop
+  endfacet
+  facet normal 0.555582 0 -0.831462
+    outer loop
+      vertex -2 4.99572 45.1141
+      vertex -2.43505 2 44.8234
+      vertex -2.43505 4.99572 44.8234
+    endloop
+  endfacet
+  facet normal 0.321469 0 -0.94692
+    outer loop
+      vertex -1.53073 2 45.3455
+      vertex -1.03528 4.99572 45.5137
+      vertex -1.03528 2 45.5137
+    endloop
+  endfacet
+  facet normal 0.321469 0 -0.94692
+    outer loop
+      vertex -1.03528 4.99572 45.5137
+      vertex -1.53073 2 45.3455
+      vertex -1.53073 4.99572 45.3455
+    endloop
+  endfacet
+  facet normal 0.0653641 0 -0.997861
+    outer loop
+      vertex -0.522104 2 45.6158
+      vertex 0 4.99572 45.65
+      vertex 0 2 45.65
+    endloop
+  endfacet
+  facet normal 0.0653641 0 -0.997861
+    outer loop
+      vertex 0 4.99572 45.65
+      vertex -0.522104 2 45.6158
+      vertex -0.522104 4.99572 45.6158
+    endloop
+  endfacet
+  facet normal 0.896883 0 -0.442268
+    outer loop
+      vertex -3.4641 2 43.65
+      vertex -3.69552 4.99572 43.1807
+      vertex -3.4641 4.99572 43.65
+    endloop
+  endfacet
+  facet normal 0.896883 0 -0.442268
+    outer loop
+      vertex -3.69552 4.99572 43.1807
+      vertex -3.4641 2 43.65
+      vertex -3.69552 2 43.1807
+    endloop
+  endfacet
+  facet normal 0.980786 0 -0.195087
+    outer loop
+      vertex -3.8637 2 42.6853
+      vertex -3.96578 4.99572 42.1721
+      vertex -3.8637 4.99572 42.6853
+    endloop
+  endfacet
+  facet normal 0.980786 0 -0.195087
+    outer loop
+      vertex -3.96578 4.99572 42.1721
+      vertex -3.8637 2 42.6853
+      vertex -3.96578 2 42.1721
+    endloop
+  endfacet
+  facet normal -0.195133 0 -0.980777
+    outer loop
+      vertex 0.522104 2 45.6158
+      vertex 1.03528 4.99572 45.5137
+      vertex 1.03528 2 45.5137
+    endloop
+  endfacet
+  facet normal -0.195133 0 -0.980777
+    outer loop
+      vertex 1.03528 4.99572 45.5137
+      vertex 0.522104 2 45.6158
+      vertex 0.522104 4.99572 45.6158
+    endloop
+  endfacet
+  facet normal -0.751861 0 -0.659321
+    outer loop
+      vertex 3.17341 2 44.085
+      vertex 2.82843 4.99572 44.4784
+      vertex 3.17341 4.99572 44.085
+    endloop
+  endfacet
+  facet normal -0.751861 -0 -0.659321
+    outer loop
+      vertex 2.82843 4.99572 44.4784
+      vertex 3.17341 2 44.085
+      vertex 2.82843 2 44.4784
+    endloop
+  endfacet
+  facet normal -0.980786 0 -0.195087
+    outer loop
+      vertex 3.96578 2 42.1721
+      vertex 3.8637 4.99572 42.6853
+      vertex 3.96578 4.99572 42.1721
+    endloop
+  endfacet
+  facet normal -0.980786 -0 -0.195087
+    outer loop
+      vertex 3.8637 4.99572 42.6853
+      vertex 3.96578 2 42.1721
+      vertex 3.8637 2 42.6853
+    endloop
+  endfacet
+  facet normal -0.896883 0 -0.442268
+    outer loop
+      vertex 3.69552 2 43.1807
+      vertex 3.4641 4.99572 43.65
+      vertex 3.69552 4.99572 43.1807
+    endloop
+  endfacet
+  facet normal -0.896883 -0 -0.442268
+    outer loop
+      vertex 3.4641 4.99572 43.65
+      vertex 3.69552 2 43.1807
+      vertex 3.4641 2 43.65
+    endloop
+  endfacet
+  facet normal 0.44226 0 -0.896887
+    outer loop
+      vertex -2 2 45.1141
+      vertex -1.53073 4.99572 45.3455
+      vertex -1.53073 2 45.3455
+    endloop
+  endfacet
+  facet normal 0.44226 0 -0.896887
+    outer loop
+      vertex -1.53073 4.99572 45.3455
+      vertex -2 2 45.1141
+      vertex -2 4.99572 45.1141
+    endloop
+  endfacet
+  facet normal 0.195133 0 -0.980777
+    outer loop
+      vertex -1.03528 2 45.5137
+      vertex -0.522104 4.99572 45.6158
+      vertex -0.522104 2 45.6158
+    endloop
+  endfacet
+  facet normal 0.195133 0 -0.980777
+    outer loop
+      vertex -0.522104 4.99572 45.6158
+      vertex -1.03528 2 45.5137
+      vertex -1.03528 4.99572 45.5137
+    endloop
+  endfacet
+  facet normal 0.831441 0 -0.555613
+    outer loop
+      vertex -3.17341 2 44.085
+      vertex -3.4641 4.99572 43.65
+      vertex -3.17341 4.99572 44.085
+    endloop
+  endfacet
+  facet normal 0.831441 0 -0.555613
+    outer loop
+      vertex -3.4641 4.99572 43.65
+      vertex -3.17341 2 44.085
+      vertex -3.4641 2 43.65
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex -40 0 35
-      vertex -40 5 7.5
-      vertex -40 5 35
+      vertex -40 0.00428295 35
+      vertex -40 4.99572 5
+      vertex -40 4.99572 35
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex -40 5 7.5
-      vertex -40 0 35
-      vertex -40 0 7.5
+      vertex -40 4.99572 5
+      vertex -40 0.00428295 35
+      vertex -40 0.00428295 5
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -40 0 35
-      vertex -7.5 5 35
-      vertex -7.5 0 35
+      vertex -40 0.00428295 35
+      vertex -5 4.99572 35
+      vertex -5 0.00428295 35
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -7.5 5 35
-      vertex -40 0 35
-      vertex -40 5 35
+      vertex -5 4.99572 35
+      vertex -40 0.00428295 35
+      vertex -40 4.99572 35
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex -7.5 0 7.5
-      vertex -7.5 5 35
-      vertex -7.5 5 7.5
+      vertex -5 0.00428295 5
+      vertex -5 4.99572 35
+      vertex -5 4.99572 5
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex -7.5 5 35
-      vertex -7.5 0 7.5
-      vertex -7.5 0 35
+      vertex -5 4.99572 35
+      vertex -5 0.00428295 5
+      vertex -5 0.00428295 35
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -40 5 7.5
-      vertex -7.5 0 7.5
-      vertex -7.5 5 7.5
+      vertex -40 4.99572 5
+      vertex -5 0.00428295 5
+      vertex -5 4.99572 5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -7.5 0 7.5
-      vertex -40 5 7.5
-      vertex -40 0 7.5
+      vertex -5 0.00428295 5
+      vertex -40 4.99572 5
+      vertex -40 0.00428295 5
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 7.5 0 35
-      vertex 7.5 5 7.5
-      vertex 7.5 5 35
+      vertex 5 0.00428295 35
+      vertex 5 4.99572 5
+      vertex 5 4.99572 35
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 7.5 5 7.5
-      vertex 7.5 0 35
-      vertex 7.5 0 7.5
+      vertex 5 4.99572 5
+      vertex 5 0.00428295 35
+      vertex 5 0.00428295 5
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 7.5 0 35
-      vertex 40 5 35
-      vertex 40 0 35
+      vertex 5 0.00428295 35
+      vertex 40 4.99572 35
+      vertex 40 0.00428295 35
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 40 5 35
-      vertex 7.5 0 35
-      vertex 7.5 5 35
+      vertex 40 4.99572 35
+      vertex 5 0.00428295 35
+      vertex 5 4.99572 35
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 40 0 7.5
-      vertex 40 5 35
-      vertex 40 5 7.5
+      vertex 40 0.00428295 5
+      vertex 40 4.99572 35
+      vertex 40 4.99572 5
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 40 5 35
-      vertex 40 0 7.5
-      vertex 40 0 35
+      vertex 40 4.99572 35
+      vertex 40 0.00428295 5
+      vertex 40 0.00428295 35
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 7.5 5 7.5
-      vertex 40 0 7.5
-      vertex 40 5 7.5
+      vertex 5 4.99572 5
+      vertex 40 0.00428295 5
+      vertex 40 4.99572 5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 40 0 7.5
-      vertex 7.5 5 7.5
-      vertex 7.5 0 7.5
+      vertex 40 0.00428295 5
+      vertex 5 4.99572 5
+      vertex 5 0.00428295 5
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex -40 0 -7.5
-      vertex -40 5 -35
-      vertex -40 5 -7.5
+      vertex -40 0.00428295 -5
+      vertex -40 4.99572 -45
+      vertex -40 4.99572 -5
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex -40 5 -35
-      vertex -40 0 -7.5
-      vertex -40 0 -35
+      vertex -40 4.99572 -45
+      vertex -40 0.00428295 -5
+      vertex -40 0.00428295 -45
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -40 0 -7.5
-      vertex -7.5 5 -7.5
-      vertex -7.5 0 -7.5
+      vertex -40 0.00428295 -5
+      vertex -5 4.99572 -5
+      vertex -5 0.00428295 -5
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -7.5 5 -7.5
-      vertex -40 0 -7.5
-      vertex -40 5 -7.5
+      vertex -5 4.99572 -5
+      vertex -40 0.00428295 -5
+      vertex -40 4.99572 -5
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex -7.5 0 -35
-      vertex -7.5 5 -7.5
-      vertex -7.5 5 -35
+      vertex -5 0.00428295 -45
+      vertex -5 4.99572 -5
+      vertex -5 4.99572 -45
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex -7.5 5 -7.5
-      vertex -7.5 0 -35
-      vertex -7.5 0 -7.5
+      vertex -5 4.99572 -5
+      vertex -5 0.00428295 -45
+      vertex -5 0.00428295 -5
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -40 5 -35
-      vertex -7.5 0 -35
-      vertex -7.5 5 -35
+      vertex -40 4.99572 -45
+      vertex -5 0.00428295 -45
+      vertex -5 4.99572 -45
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -7.5 0 -35
-      vertex -40 5 -35
-      vertex -40 0 -35
+      vertex -5 0.00428295 -45
+      vertex -40 4.99572 -45
+      vertex -40 0.00428295 -45
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 7.5 0 -7.5
-      vertex 7.5 5 -35
-      vertex 7.5 5 -7.5
+      vertex 5 0.00428295 -5
+      vertex 5 4.99572 -45
+      vertex 5 4.99572 -5
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 7.5 5 -35
-      vertex 7.5 0 -7.5
-      vertex 7.5 0 -35
+      vertex 5 4.99572 -45
+      vertex 5 0.00428295 -5
+      vertex 5 0.00428295 -45
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 7.5 0 -7.5
-      vertex 40 5 -7.5
-      vertex 40 0 -7.5
+      vertex 5 0.00428295 -5
+      vertex 40 4.99572 -5
+      vertex 40 0.00428295 -5
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 40 5 -7.5
-      vertex 7.5 0 -7.5
-      vertex 7.5 5 -7.5
+      vertex 40 4.99572 -5
+      vertex 5 0.00428295 -5
+      vertex 5 4.99572 -5
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 40 0 -35
-      vertex 40 5 -7.5
-      vertex 40 5 -35
+      vertex 40 0.00428295 -45
+      vertex 40 4.99572 -5
+      vertex 40 4.99572 -45
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 40 5 -7.5
-      vertex 40 0 -35
-      vertex 40 0 -7.5
+      vertex 40 4.99572 -5
+      vertex 40 0.00428295 -45
+      vertex 40 0.00428295 -5
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 7.5 5 -35
-      vertex 40 0 -35
-      vertex 40 5 -35
+      vertex 5 4.99572 -45
+      vertex 40 0.00428295 -45
+      vertex 40 4.99572 -45
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 40 0 -35
-      vertex 7.5 5 -35
-      vertex 7.5 0 -35
+      vertex 40 0.00428295 -45
+      vertex 5 4.99572 -45
+      vertex 5 0.00428295 -45
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
       vertex -30 4.99 -49
-      vertex -30 5 -50
-      vertex -30 5 -49
+      vertex -30 4.99572 -55.1
+      vertex -30 4.99572 -49
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex -30 4.99 -55.1
-      vertex -30 5 -50
+      vertex -30 4.99572 -55.1
       vertex -30 4.99 -49
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex -30 5 -50
       vertex -30 4.99 -55.1
-      vertex -30 5 -55
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex -30 5 -55
-      vertex -30 4.99 -55.1
-      vertex -30 5 -55.1
     endloop
   endfacet
   facet normal 1 -0 0
@@ -3782,43 +23788,29 @@ solid OpenSCAD_Model
   facet normal 0 0 -1
     outer loop
       vertex -30 4.99 -49
-      vertex 30 5 -49
+      vertex 30 4.99572 -49
       vertex 30 4.99 -49
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 30 5 -49
+      vertex 30 4.99572 -49
       vertex -30 4.99 -49
-      vertex -30 5 -49
+      vertex -30 4.99572 -49
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
       vertex 30 4.99 -55.1
-      vertex 30 5 -55
-      vertex 30 5 -55.1
+      vertex 30 4.99572 -49
+      vertex 30 4.99572 -55.1
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 30 5 -55
+      vertex 30 4.99572 -49
       vertex 30 4.99 -55.1
-      vertex 30 5 -50
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
       vertex 30 4.99 -49
-      vertex 30 5 -50
-      vertex 30 4.99 -55.1
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 30 5 -50
-      vertex 30 4.99 -49
-      vertex 30 5 -49
     endloop
   endfacet
   facet normal -1 0 0
@@ -3837,15 +23829,15 @@ solid OpenSCAD_Model
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -30 5 -55.1
+      vertex -30 4.99572 -55.1
       vertex 30 4.99 -55.1
-      vertex 30 5 -55.1
+      vertex 30 4.99572 -55.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
       vertex 30 4.99 -55.1
-      vertex -30 5 -55.1
+      vertex -30 4.99572 -55.1
       vertex -30 4.99 -55.1
     endloop
   endfacet
@@ -4001,6 +23993,1350 @@ solid OpenSCAD_Model
       vertex 39.2 21 33
       vertex 39.2 18 -45
       vertex 39.2 18 33
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.99826 21.625
+      vertex 5 6.99826 20.375
+      vertex 5 7 21
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.99304 22.25
+      vertex 5 6.99826 20.375
+      vertex 5 6.99826 21.625
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.99826 20.375
+      vertex 5 6.99304 22.25
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.99304 22.25
+      vertex 5 6.9843 22.875
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.99826 20.375
+      vertex 5 5 36
+      vertex 5 6.99304 19.75
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.9843 22.875
+      vertex 5 6.97202 23.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 6
+      vertex 5 6.99304 19.75
+      vertex 5 5 36
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.97202 23.5
+      vertex 5 6.95612 24.125
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.99304 19.75
+      vertex 5 5 6
+      vertex 5 6.9843 19.125
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.95612 24.125
+      vertex 5 6.93648 24.75
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.9843 19.125
+      vertex 5 5 6
+      vertex 5 6.97202 18.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.93648 24.75
+      vertex 5 6.91302 25.375
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.97202 18.5
+      vertex 5 5 6
+      vertex 5 6.95612 17.875
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.91302 25.375
+      vertex 5 6.8856 26
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.95612 17.875
+      vertex 5 5 6
+      vertex 5 6.93648 17.25
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.8856 26
+      vertex 5 6.85403 26.625
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.93648 17.25
+      vertex 5 5 6
+      vertex 5 6.91302 16.625
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.85403 26.625
+      vertex 5 6.81812 27.25
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.91302 16.625
+      vertex 5 5 6
+      vertex 5 6.8856 16
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.81812 27.25
+      vertex 5 6.77756 27.875
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.8856 16
+      vertex 5 5 6
+      vertex 5 6.85403 15.375
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.77756 27.875
+      vertex 5 6.73204 28.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.85403 15.375
+      vertex 5 5 6
+      vertex 5 6.81812 14.75
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.73204 28.5
+      vertex 5 6.68118 29.125
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.81812 14.75
+      vertex 5 5 6
+      vertex 5 6.77756 14.125
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.68118 29.125
+      vertex 5 6.62445 29.75
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.77756 14.125
+      vertex 5 5 6
+      vertex 5 6.73204 13.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.62445 29.75
+      vertex 5 6.56125 30.375
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.73204 13.5
+      vertex 5 5 6
+      vertex 5 6.68118 12.875
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.56125 30.375
+      vertex 5 6.49071 31
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.68118 12.875
+      vertex 5 5 6
+      vertex 5 6.62445 12.25
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.49071 31
+      vertex 5 6.41174 31.625
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.62445 12.25
+      vertex 5 5 6
+      vertex 5 6.56125 11.625
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.41174 31.625
+      vertex 5 6.32286 32.25
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.56125 11.625
+      vertex 5 5 6
+      vertex 5 6.49071 11
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.32286 32.25
+      vertex 5 6.22189 32.875
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.49071 11
+      vertex 5 5 6
+      vertex 5 6.41174 10.375
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.22189 32.875
+      vertex 5 6.10553 33.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.41174 10.375
+      vertex 5 5 6
+      vertex 5 6.32286 9.75
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 6.10553 33.5
+      vertex 5 5.96823 34.125
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.32286 9.75
+      vertex 5 5 6
+      vertex 5 6.22189 9.125
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 5.96823 34.125
+      vertex 5 5.7993 34.75
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.22189 9.125
+      vertex 5 5 6
+      vertex 5 6.10553 8.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 36
+      vertex 5 5.7993 34.75
+      vertex 5 5.5713 35.375
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 6.10553 8.5
+      vertex 5 5 6
+      vertex 5 5.96823 7.875
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5.96823 7.875
+      vertex 5 5 6
+      vertex 5 5.7993 7.25
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5.7993 7.25
+      vertex 5 5 6
+      vertex 5 5.5713 6.625
+    endloop
+  endfacet
+  facet normal 0 0.738104 0.674686
+    outer loop
+      vertex 5 5.5713 35.375
+      vertex -5 5 36
+      vertex 5 5 36
+    endloop
+  endfacet
+  facet normal 0 0.738104 0.674686
+    outer loop
+      vertex -5 5 36
+      vertex 5 5.5713 35.375
+      vertex -5 5.5713 35.375
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 5 6
+      vertex 5 5 36
+      vertex -5 5 36
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 5 5 36
+      vertex -5 5 6
+      vertex 5 5 6
+    endloop
+  endfacet
+  facet normal 0 0.738104 -0.674686
+    outer loop
+      vertex 5 5 6
+      vertex -5 5.5713 6.625
+      vertex 5 5.5713 6.625
+    endloop
+  endfacet
+  facet normal 0 0.738104 -0.674686
+    outer loop
+      vertex -5 5.5713 6.625
+      vertex 5 5 6
+      vertex -5 5 6
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.99826 20.375
+      vertex -5 6.99826 21.625
+      vertex -5 7 21
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.99304 19.75
+      vertex -5 6.99826 21.625
+      vertex -5 6.99826 20.375
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.99826 21.625
+      vertex -5 6.99304 19.75
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.99304 19.75
+      vertex -5 6.9843 19.125
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -5 6.99826 21.625
+      vertex -5 5 6
+      vertex -5 6.99304 22.25
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.9843 19.125
+      vertex -5 6.97202 18.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 36
+      vertex -5 6.99304 22.25
+      vertex -5 5 6
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.97202 18.5
+      vertex -5 6.95612 17.875
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.99304 22.25
+      vertex -5 5 36
+      vertex -5 6.9843 22.875
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.95612 17.875
+      vertex -5 6.93648 17.25
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.9843 22.875
+      vertex -5 5 36
+      vertex -5 6.97202 23.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.93648 17.25
+      vertex -5 6.91302 16.625
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.97202 23.5
+      vertex -5 5 36
+      vertex -5 6.95612 24.125
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.91302 16.625
+      vertex -5 6.8856 16
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.95612 24.125
+      vertex -5 5 36
+      vertex -5 6.93648 24.75
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.8856 16
+      vertex -5 6.85403 15.375
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.93648 24.75
+      vertex -5 5 36
+      vertex -5 6.91302 25.375
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.85403 15.375
+      vertex -5 6.81812 14.75
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.91302 25.375
+      vertex -5 5 36
+      vertex -5 6.8856 26
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.81812 14.75
+      vertex -5 6.77756 14.125
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.8856 26
+      vertex -5 5 36
+      vertex -5 6.85403 26.625
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.77756 14.125
+      vertex -5 6.73204 13.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.85403 26.625
+      vertex -5 5 36
+      vertex -5 6.81812 27.25
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.73204 13.5
+      vertex -5 6.68118 12.875
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.81812 27.25
+      vertex -5 5 36
+      vertex -5 6.77756 27.875
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.68118 12.875
+      vertex -5 6.62445 12.25
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.77756 27.875
+      vertex -5 5 36
+      vertex -5 6.73204 28.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.62445 12.25
+      vertex -5 6.56125 11.625
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.73204 28.5
+      vertex -5 5 36
+      vertex -5 6.68118 29.125
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.56125 11.625
+      vertex -5 6.49071 11
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.68118 29.125
+      vertex -5 5 36
+      vertex -5 6.62445 29.75
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.49071 11
+      vertex -5 6.41174 10.375
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.62445 29.75
+      vertex -5 5 36
+      vertex -5 6.56125 30.375
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.41174 10.375
+      vertex -5 6.32286 9.75
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.56125 30.375
+      vertex -5 5 36
+      vertex -5 6.49071 31
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.32286 9.75
+      vertex -5 6.22189 9.125
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.49071 31
+      vertex -5 5 36
+      vertex -5 6.41174 31.625
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.22189 9.125
+      vertex -5 6.10553 8.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.41174 31.625
+      vertex -5 5 36
+      vertex -5 6.32286 32.25
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 6.10553 8.5
+      vertex -5 5.96823 7.875
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.32286 32.25
+      vertex -5 5 36
+      vertex -5 6.22189 32.875
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 5.96823 7.875
+      vertex -5 5.7993 7.25
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.22189 32.875
+      vertex -5 5 36
+      vertex -5 6.10553 33.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5 6
+      vertex -5 5.7993 7.25
+      vertex -5 5.5713 6.625
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 6.10553 33.5
+      vertex -5 5 36
+      vertex -5 5.96823 34.125
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5.96823 34.125
+      vertex -5 5 36
+      vertex -5 5.7993 34.75
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 5.7993 34.75
+      vertex -5 5 36
+      vertex -5 5.5713 35.375
+    endloop
+  endfacet
+  facet normal 0 0.939442 -0.342708
+    outer loop
+      vertex 5 5.5713 6.625
+      vertex -5 5.7993 7.25
+      vertex 5 5.7993 7.25
+    endloop
+  endfacet
+  facet normal 0 0.939442 -0.342708
+    outer loop
+      vertex -5 5.7993 7.25
+      vertex 5 5.5713 6.625
+      vertex -5 5.5713 6.625
+    endloop
+  endfacet
+  facet normal 0 0.9872 0.159484
+    outer loop
+      vertex 5 6.32286 32.25
+      vertex -5 6.22189 32.875
+      vertex 5 6.22189 32.875
+    endloop
+  endfacet
+  facet normal 0 0.9872 0.159484
+    outer loop
+      vertex -5 6.22189 32.875
+      vertex 5 6.32286 32.25
+      vertex -5 6.32286 32.25
+    endloop
+  endfacet
+  facet normal 0 0.998353 -0.0573614
+    outer loop
+      vertex 5 6.81812 14.75
+      vertex -5 6.85403 15.375
+      vertex 5 6.85403 15.375
+    endloop
+  endfacet
+  facet normal 0 0.998353 -0.0573614
+    outer loop
+      vertex -5 6.85403 15.375
+      vertex 5 6.81812 14.75
+      vertex -5 6.81812 14.75
+    endloop
+  endfacet
+  facet normal 0 0.999296 -0.0375096
+    outer loop
+      vertex 5 6.91302 16.625
+      vertex -5 6.93648 17.25
+      vertex 5 6.93648 17.25
+    endloop
+  endfacet
+  facet normal 0 0.999296 -0.0375096
+    outer loop
+      vertex -5 6.93648 17.25
+      vertex 5 6.91302 16.625
+      vertex -5 6.91302 16.625
+    endloop
+  endfacet
+  facet normal 0 0.97671 -0.214564
+    outer loop
+      vertex 5 5.96823 7.875
+      vertex -5 6.10553 8.5
+      vertex 5 6.10553 8.5
+    endloop
+  endfacet
+  facet normal 0 0.97671 -0.214564
+    outer loop
+      vertex -5 6.10553 8.5
+      vertex 5 5.96823 7.875
+      vertex -5 5.96823 7.875
+    endloop
+  endfacet
+  facet normal 0 0.983107 -0.183031
+    outer loop
+      vertex 5 6.10553 8.5
+      vertex -5 6.22189 9.125
+      vertex 5 6.22189 9.125
+    endloop
+  endfacet
+  facet normal 0 0.983107 -0.183031
+    outer loop
+      vertex -5 6.22189 9.125
+      vertex 5 6.10553 8.5
+      vertex -5 6.10553 8.5
+    endloop
+  endfacet
+  facet normal 0 0.9872 -0.159484
+    outer loop
+      vertex 5 6.22189 9.125
+      vertex -5 6.32286 9.75
+      vertex 5 6.32286 9.75
+    endloop
+  endfacet
+  facet normal 0 0.9872 -0.159484
+    outer loop
+      vertex -5 6.32286 9.75
+      vertex 5 6.22189 9.125
+      vertex -5 6.22189 9.125
+    endloop
+  endfacet
+  facet normal 0 0.992112 -0.125355
+    outer loop
+      vertex 5 6.41174 10.375
+      vertex -5 6.49071 11
+      vertex 5 6.49071 11
+    endloop
+  endfacet
+  facet normal 0 0.992112 -0.125355
+    outer loop
+      vertex -5 6.49071 11
+      vertex 5 6.41174 10.375
+      vertex -5 6.41174 10.375
+    endloop
+  endfacet
+  facet normal 0 0.993691 -0.112152
+    outer loop
+      vertex 5 6.49071 11
+      vertex -5 6.56125 11.625
+      vertex 5 6.56125 11.625
+    endloop
+  endfacet
+  facet normal 0 0.993691 -0.112152
+    outer loop
+      vertex -5 6.56125 11.625
+      vertex 5 6.49071 11
+      vertex -5 6.49071 11
+    endloop
+  endfacet
+  facet normal 0 0.996705 -0.0811079
+    outer loop
+      vertex 5 6.68118 12.875
+      vertex -5 6.73204 13.5
+      vertex 5 6.73204 13.5
+    endloop
+  endfacet
+  facet normal 0 0.996705 -0.0811079
+    outer loop
+      vertex -5 6.73204 13.5
+      vertex 5 6.68118 12.875
+      vertex -5 6.68118 12.875
+    endloop
+  endfacet
+  facet normal 0 0.996705 0.0811079
+    outer loop
+      vertex 5 6.73204 28.5
+      vertex -5 6.68118 29.125
+      vertex 5 6.68118 29.125
+    endloop
+  endfacet
+  facet normal 0 0.996705 0.0811079
+    outer loop
+      vertex -5 6.68118 29.125
+      vertex 5 6.73204 28.5
+      vertex -5 6.73204 28.5
+    endloop
+  endfacet
+  facet normal 0 0.939442 0.342708
+    outer loop
+      vertex 5 5.7993 34.75
+      vertex -5 5.5713 35.375
+      vertex 5 5.5713 35.375
+    endloop
+  endfacet
+  facet normal 0 0.939442 0.342708
+    outer loop
+      vertex -5 5.5713 35.375
+      vertex 5 5.7993 34.75
+      vertex -5 5.7993 34.75
+    endloop
+  endfacet
+  facet normal 0 0.965359 0.260925
+    outer loop
+      vertex 5 5.96823 34.125
+      vertex -5 5.7993 34.75
+      vertex 5 5.7993 34.75
+    endloop
+  endfacet
+  facet normal 0 0.965359 0.260925
+    outer loop
+      vertex -5 5.7993 34.75
+      vertex 5 5.96823 34.125
+      vertex -5 5.96823 34.125
+    endloop
+  endfacet
+  facet normal 0 0.965359 -0.260925
+    outer loop
+      vertex 5 5.7993 7.25
+      vertex -5 5.96823 7.875
+      vertex 5 5.96823 7.875
+    endloop
+  endfacet
+  facet normal 0 0.965359 -0.260925
+    outer loop
+      vertex -5 5.96823 7.875
+      vertex 5 5.7993 7.25
+      vertex -5 5.7993 7.25
+    endloop
+  endfacet
+  facet normal 0 0.999507 -0.0314085
+    outer loop
+      vertex 5 6.93648 17.25
+      vertex -5 6.95612 17.875
+      vertex 5 6.95612 17.875
+    endloop
+  endfacet
+  facet normal 0 0.999507 -0.0314085
+    outer loop
+      vertex -5 6.95612 17.875
+      vertex 5 6.93648 17.25
+      vertex -5 6.93648 17.25
+    endloop
+  endfacet
+  facet normal 0 0.998727 -0.0504477
+    outer loop
+      vertex 5 6.85403 15.375
+      vertex -5 6.8856 16
+      vertex 5 6.8856 16
+    endloop
+  endfacet
+  facet normal 0 0.998727 -0.0504477
+    outer loop
+      vertex -5 6.8856 16
+      vertex 5 6.85403 15.375
+      vertex -5 6.85403 15.375
+    endloop
+  endfacet
+  facet normal 0 0.990039 -0.140792
+    outer loop
+      vertex 5 6.32286 9.75
+      vertex -5 6.41174 10.375
+      vertex 5 6.41174 10.375
+    endloop
+  endfacet
+  facet normal 0 0.990039 -0.140792
+    outer loop
+      vertex -5 6.41174 10.375
+      vertex 5 6.32286 9.75
+      vertex -5 6.32286 9.75
+    endloop
+  endfacet
+  facet normal 0 0.994926 -0.100607
+    outer loop
+      vertex 5 6.56125 11.625
+      vertex -5 6.62445 12.25
+      vertex 5 6.62445 12.25
+    endloop
+  endfacet
+  facet normal 0 0.994926 -0.100607
+    outer loop
+      vertex -5 6.62445 12.25
+      vertex 5 6.56125 11.625
+      vertex -5 6.56125 11.625
+    endloop
+  endfacet
+  facet normal 0 0.997901 -0.0647598
+    outer loop
+      vertex 5 6.77756 14.125
+      vertex -5 6.81812 14.75
+      vertex 5 6.81812 14.75
+    endloop
+  endfacet
+  facet normal 0 0.997901 -0.0647598
+    outer loop
+      vertex -5 6.81812 14.75
+      vertex 5 6.77756 14.125
+      vertex -5 6.77756 14.125
+    endloop
+  endfacet
+  facet normal 0 0.999902 -0.0139826
+    outer loop
+      vertex 5 6.9843 19.125
+      vertex -5 6.99304 19.75
+      vertex 5 6.99304 19.75
+    endloop
+  endfacet
+  facet normal 0 0.999902 -0.0139826
+    outer loop
+      vertex -5 6.99304 19.75
+      vertex 5 6.9843 19.125
+      vertex -5 6.9843 19.125
+    endloop
+  endfacet
+  facet normal 0 0.999296 0.0375096
+    outer loop
+      vertex 5 6.93648 24.75
+      vertex -5 6.91302 25.375
+      vertex 5 6.91302 25.375
+    endloop
+  endfacet
+  facet normal 0 0.999296 0.0375096
+    outer loop
+      vertex -5 6.91302 25.375
+      vertex 5 6.93648 24.75
+      vertex -5 6.93648 24.75
+    endloop
+  endfacet
+  facet normal 0 0.992112 0.125355
+    outer loop
+      vertex 5 6.49071 31
+      vertex -5 6.41174 31.625
+      vertex 5 6.41174 31.625
+    endloop
+  endfacet
+  facet normal 0 0.992112 0.125355
+    outer loop
+      vertex -5 6.41174 31.625
+      vertex 5 6.49071 31
+      vertex -5 6.49071 31
+    endloop
+  endfacet
+  facet normal 0 0.993691 0.112152
+    outer loop
+      vertex 5 6.56125 30.375
+      vertex -5 6.49071 31
+      vertex 5 6.49071 31
+    endloop
+  endfacet
+  facet normal 0 0.993691 0.112152
+    outer loop
+      vertex -5 6.49071 31
+      vertex 5 6.56125 30.375
+      vertex -5 6.56125 30.375
+    endloop
+  endfacet
+  facet normal 0 0.999039 -0.0438298
+    outer loop
+      vertex 5 6.8856 16
+      vertex -5 6.91302 16.625
+      vertex 5 6.91302 16.625
+    endloop
+  endfacet
+  facet normal 0 0.999039 -0.0438298
+    outer loop
+      vertex -5 6.91302 16.625
+      vertex 5 6.8856 16
+      vertex -5 6.8856 16
+    endloop
+  endfacet
+  facet normal 0 0.995906 -0.0903964
+    outer loop
+      vertex 5 6.62445 12.25
+      vertex -5 6.68118 12.875
+      vertex 5 6.68118 12.875
+    endloop
+  endfacet
+  facet normal 0 0.995906 -0.0903964
+    outer loop
+      vertex -5 6.68118 12.875
+      vertex 5 6.62445 12.25
+      vertex -5 6.62445 12.25
+    endloop
+  endfacet
+  facet normal 0 0.997358 -0.0726396
+    outer loop
+      vertex 5 6.73204 13.5
+      vertex -5 6.77756 14.125
+      vertex 5 6.77756 14.125
+    endloop
+  endfacet
+  facet normal 0 0.997358 -0.0726396
+    outer loop
+      vertex -5 6.77756 14.125
+      vertex 5 6.73204 13.5
+      vertex -5 6.73204 13.5
+    endloop
+  endfacet
+  facet normal 0 0.999807 0.0196442
+    outer loop
+      vertex 5 6.9843 22.875
+      vertex -5 6.97202 23.5
+      vertex 5 6.97202 23.5
+    endloop
+  endfacet
+  facet normal 0 0.999807 0.0196442
+    outer loop
+      vertex -5 6.97202 23.5
+      vertex 5 6.9843 22.875
+      vertex -5 6.9843 22.875
+    endloop
+  endfacet
+  facet normal 0 0.995906 0.0903964
+    outer loop
+      vertex 5 6.68118 29.125
+      vertex -5 6.62445 29.75
+      vertex 5 6.62445 29.75
+    endloop
+  endfacet
+  facet normal 0 0.995906 0.0903964
+    outer loop
+      vertex -5 6.62445 29.75
+      vertex 5 6.68118 29.125
+      vertex -5 6.68118 29.125
+    endloop
+  endfacet
+  facet normal 0 0.990039 0.140792
+    outer loop
+      vertex 5 6.41174 31.625
+      vertex -5 6.32286 32.25
+      vertex 5 6.32286 32.25
+    endloop
+  endfacet
+  facet normal 0 0.990039 0.140792
+    outer loop
+      vertex -5 6.32286 32.25
+      vertex 5 6.41174 31.625
+      vertex -5 6.41174 31.625
+    endloop
+  endfacet
+  facet normal 0 0.994926 0.100607
+    outer loop
+      vertex 5 6.62445 29.75
+      vertex -5 6.56125 30.375
+      vertex 5 6.56125 30.375
+    endloop
+  endfacet
+  facet normal 0 0.994926 0.100607
+    outer loop
+      vertex -5 6.56125 30.375
+      vertex 5 6.62445 29.75
+      vertex -5 6.62445 29.75
+    endloop
+  endfacet
+  facet normal 0 0.983107 0.183031
+    outer loop
+      vertex 5 6.22189 32.875
+      vertex -5 6.10553 33.5
+      vertex 5 6.10553 33.5
+    endloop
+  endfacet
+  facet normal 0 0.983107 0.183031
+    outer loop
+      vertex -5 6.10553 33.5
+      vertex 5 6.22189 32.875
+      vertex -5 6.22189 32.875
+    endloop
+  endfacet
+  facet normal 0 0.97671 0.214564
+    outer loop
+      vertex 5 6.10553 33.5
+      vertex -5 5.96823 34.125
+      vertex 5 5.96823 34.125
+    endloop
+  endfacet
+  facet normal 0 0.97671 0.214564
+    outer loop
+      vertex -5 5.96823 34.125
+      vertex 5 6.10553 33.5
+      vertex -5 6.10553 33.5
+    endloop
+  endfacet
+  facet normal 0 0.998353 0.0573614
+    outer loop
+      vertex 5 6.85403 26.625
+      vertex -5 6.81812 27.25
+      vertex 5 6.81812 27.25
+    endloop
+  endfacet
+  facet normal 0 0.998353 0.0573614
+    outer loop
+      vertex -5 6.81812 27.25
+      vertex 5 6.85403 26.625
+      vertex -5 6.85403 26.625
+    endloop
+  endfacet
+  facet normal 0 0.997358 0.0726396
+    outer loop
+      vertex 5 6.77756 27.875
+      vertex -5 6.73204 28.5
+      vertex 5 6.73204 28.5
+    endloop
+  endfacet
+  facet normal 0 0.997358 0.0726396
+    outer loop
+      vertex -5 6.73204 28.5
+      vertex 5 6.77756 27.875
+      vertex -5 6.77756 27.875
+    endloop
+  endfacet
+  facet normal 0 0.999965 -0.00835171
+    outer loop
+      vertex 5 6.99304 19.75
+      vertex -5 6.99826 20.375
+      vertex 5 6.99826 20.375
+    endloop
+  endfacet
+  facet normal 0 0.999965 -0.00835171
+    outer loop
+      vertex -5 6.99826 20.375
+      vertex 5 6.99304 19.75
+      vertex -5 6.99304 19.75
+    endloop
+  endfacet
+  facet normal 0 0.999996 0.00278399
+    outer loop
+      vertex 5 7 21
+      vertex -5 6.99826 21.625
+      vertex 5 6.99826 21.625
+    endloop
+  endfacet
+  facet normal 0 0.999996 0.00278399
+    outer loop
+      vertex -5 6.99826 21.625
+      vertex 5 7 21
+      vertex -5 7 21
+    endloop
+  endfacet
+  facet normal 0 0.999039 0.0438298
+    outer loop
+      vertex 5 6.91302 25.375
+      vertex -5 6.8856 26
+      vertex 5 6.8856 26
+    endloop
+  endfacet
+  facet normal 0 0.999039 0.0438298
+    outer loop
+      vertex -5 6.8856 26
+      vertex 5 6.91302 25.375
+      vertex -5 6.91302 25.375
+    endloop
+  endfacet
+  facet normal 0 0.999507 0.0314085
+    outer loop
+      vertex 5 6.95612 24.125
+      vertex -5 6.93648 24.75
+      vertex 5 6.93648 24.75
+    endloop
+  endfacet
+  facet normal 0 0.999507 0.0314085
+    outer loop
+      vertex -5 6.93648 24.75
+      vertex 5 6.95612 24.125
+      vertex -5 6.95612 24.125
+    endloop
+  endfacet
+  facet normal 0 0.999677 0.0254318
+    outer loop
+      vertex 5 6.97202 23.5
+      vertex -5 6.95612 24.125
+      vertex 5 6.95612 24.125
+    endloop
+  endfacet
+  facet normal 0 0.999677 0.0254318
+    outer loop
+      vertex -5 6.95612 24.125
+      vertex 5 6.97202 23.5
+      vertex -5 6.97202 23.5
+    endloop
+  endfacet
+  facet normal 0 0.997901 0.0647598
+    outer loop
+      vertex 5 6.81812 27.25
+      vertex -5 6.77756 27.875
+      vertex 5 6.77756 27.875
+    endloop
+  endfacet
+  facet normal 0 0.997901 0.0647598
+    outer loop
+      vertex -5 6.77756 27.875
+      vertex 5 6.81812 27.25
+      vertex -5 6.81812 27.25
+    endloop
+  endfacet
+  facet normal 0 0.999902 0.0139826
+    outer loop
+      vertex 5 6.99304 22.25
+      vertex -5 6.9843 22.875
+      vertex 5 6.9843 22.875
+    endloop
+  endfacet
+  facet normal 0 0.999902 0.0139826
+    outer loop
+      vertex -5 6.9843 22.875
+      vertex 5 6.99304 22.25
+      vertex -5 6.99304 22.25
+    endloop
+  endfacet
+  facet normal 0 0.999965 0.00835171
+    outer loop
+      vertex 5 6.99826 21.625
+      vertex -5 6.99304 22.25
+      vertex 5 6.99304 22.25
+    endloop
+  endfacet
+  facet normal 0 0.999965 0.00835171
+    outer loop
+      vertex -5 6.99304 22.25
+      vertex 5 6.99826 21.625
+      vertex -5 6.99826 21.625
+    endloop
+  endfacet
+  facet normal 0 0.999807 -0.0196442
+    outer loop
+      vertex 5 6.97202 18.5
+      vertex -5 6.9843 19.125
+      vertex 5 6.9843 19.125
+    endloop
+  endfacet
+  facet normal 0 0.999807 -0.0196442
+    outer loop
+      vertex -5 6.9843 19.125
+      vertex 5 6.97202 18.5
+      vertex -5 6.97202 18.5
+    endloop
+  endfacet
+  facet normal 0 0.999677 -0.0254318
+    outer loop
+      vertex 5 6.95612 17.875
+      vertex -5 6.97202 18.5
+      vertex 5 6.97202 18.5
+    endloop
+  endfacet
+  facet normal 0 0.999677 -0.0254318
+    outer loop
+      vertex -5 6.97202 18.5
+      vertex 5 6.95612 17.875
+      vertex -5 6.95612 17.875
+    endloop
+  endfacet
+  facet normal 0 0.999996 -0.00278399
+    outer loop
+      vertex 5 6.99826 20.375
+      vertex -5 7 21
+      vertex 5 7 21
+    endloop
+  endfacet
+  facet normal 0 0.999996 -0.00278399
+    outer loop
+      vertex -5 7 21
+      vertex 5 6.99826 20.375
+      vertex -5 6.99826 20.375
+    endloop
+  endfacet
+  facet normal 0 0.998727 0.0504477
+    outer loop
+      vertex 5 6.8856 26
+      vertex -5 6.85403 26.625
+      vertex 5 6.85403 26.625
+    endloop
+  endfacet
+  facet normal 0 0.998727 0.0504477
+    outer loop
+      vertex -5 6.85403 26.625
+      vertex 5 6.8856 26
+      vertex -5 6.8856 26
     endloop
   endfacet
 endsolid OpenSCAD_Model


### PR DESCRIPTION
## Summary
3D model revisions for the cradle and plate, driven by the first physical print:

- **Plate**: 4 rounded outer corners (sphere-minkowski, 2 mm radius)
- **Plate**: counterbored gang-box screw holes so the screw heads sit below the plate face and don't impede the device
- **Plate**: trimmed bottom-bar (the strip below the wire passthrough) from 25 mm to 15 mm by extending the lower wire-hole quadrants downward — keeps the plate at 110x100 and leaves the central column intact for the lower screw
- **Cradle**: vertical spine narrowed 15 mm -> 10 mm
- **Cradle**: horizontal spine narrowed 15 mm -> 10 mm
- **Cradle**: half-ellipse pressure ridge on the back face of the plate (cradle-side), centered on the vertical spine, in the upper half between the horizontal spine and the top screw. 30 mm tall, 10 mm wide, 2 mm sagitta. Pushes the device against the front retention frame.
- **STL**: re-exported

## Test plan
- [ ] Slice with PETG, 0.2 mm layer, 30% infill, 4 perimeters
- [ ] Verify gang-box screws sit flush with the device-facing surface
- [ ] Verify device tilts in and is pressed firmly by the ridge against the retention frame
- [ ] Confirm wire bundle still routes through the central column

[Claude Code](https://claude.com/claude-code)