### PR TITLE
feat: add bedroom sleep mode with touch-to-wake

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,3 +55,8 @@ jobs:
 
       - name: Compile firmware (ESP32-S3 / esp-idf)
         run: esphome compile esp32-hass-panel.yaml
+
+      - name: Compile test fixture (sleep-mode enabled, 30s timeout)
+        # Exercises non-default sleep_mode_default_state / _timeout
+        # substitutions in packages/sleep-mode.yaml.
+        run: esphome compile tests/esp32-hass-panel.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,10 +53,47 @@ jobs:
         # No valid keys in test fixtures — strip the encryption block
         run: sed -i '/^  encryption:/,/^    key:/d' esp32-hass-panel.yaml
 
+      # All compile steps use tests/compile.py, which mutes ESPHome's
+      # unsuppressable GPIO19/GPIO20 USB-Serial-JTAG warning (board-fixed
+      # pins: GPIO19 = touchscreen I2C SDA, GPIO20 = display green data
+      # line — no per-pin opt-out in ESPHome's schema). Every other
+      # warning still surfaces, and the grep guard fails the build on
+      # any of them.
+
       - name: Compile firmware (ESP32-S3 / esp-idf)
-        run: esphome compile esp32-hass-panel.yaml
+        shell: bash
+        run: |
+          set -o pipefail
+          python tests/compile.py compile esp32-hass-panel.yaml 2>&1 \
+              | tee main-build.log
+          if grep -E '^WARNING ' main-build.log; then
+              echo "::error::Unexpected warning(s) in main build (above)"
+              exit 1
+          fi
 
       - name: Compile test fixture (sleep-mode enabled, 30s timeout)
         # Exercises non-default sleep_mode_default_state / _timeout
-        # substitutions in packages/sleep-mode.yaml.
-        run: esphome compile tests/esp32-hass-panel.yaml
+        # substitutions in packages/sleep-mode.yaml against the full panel.
+        shell: bash
+        run: |
+          set -o pipefail
+          python tests/compile.py compile tests/esp32-hass-panel.yaml 2>&1 \
+              | tee sleep-override-build.log
+          if grep -E '^WARNING ' sleep-override-build.log; then
+              echo "::error::Unexpected warning(s) in sleep-override build (above)"
+              exit 1
+          fi
+
+      - name: Compile bedroom alarm panel (one-page sleep test)
+        # Slim alarm-only (nav_page_count: 1) bedroom config with sleep
+        # mode enabled by default and minimal substitutions (board /
+        # alarm defaults come from the packages).
+        shell: bash
+        run: |
+          set -o pipefail
+          python tests/compile.py compile tests/bedroom-alarm-panel.yaml 2>&1 \
+              | tee bedroom-build.log
+          if grep -E '^WARNING ' bedroom-build.log; then
+              echo "::error::Unexpected warning(s) in bedroom-alarm-panel build (above)"
+              exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ The YAML uses ESPHome [substitutions](https://esphome.io/components/substitution
 | `nav_page_3` | `alarm_page` | Page at index 3 (unused slots default to home) |
 | `nav_page_count` | `1` | Number of active pages in the swipe cycle (1–4) |
 | `nav_auto_return_delay` | `30s` | Idle time before auto-returning to home page |
+| **Sleep mode** | | |
+| `sleep_mode_default_state` | `OFF` | Factory-default state of the sleep-mode switch (`OFF` / `ON`). Set to `ON` for bedroom panels so they boot dark. HA-stored state wins on subsequent boots. |
+| `sleep_mode_default_timeout` | `-1` | Factory-default value of the auto-off timeout, in seconds. `-1` = never; values `0–5` snap to `-1`; `>=6` re-sleeps after that many idle seconds. |
 
 Override them on the command line or in a per-device YAML:
 

--- a/README.md
+++ b/README.md
@@ -139,37 +139,77 @@ The YAML uses ESPHome [substitutions](https://esphome.io/components/substitution
 | `sleep_mode_default_state` | `OFF` | Factory-default state of the sleep-mode switch (`OFF` / `ON`). Set to `ON` for bedroom panels so they boot dark. HA-stored state wins on subsequent boots. |
 | `sleep_mode_default_timeout` | `-1` | Factory-default value of the auto-off timeout, in seconds. `-1` = never; values `0–5` snap to `-1`; `>=6` re-sleeps after that many idle seconds. |
 
-Override them on the command line or in a per-device YAML:
+Per-device YAML pulls in `esp32-hass-panel.yaml` as a single [ESPHome git
+package](https://esphome.io/components/packages#git-source) and overrides
+only what's specific to that device.
+
+### 1-page panel (bedroom — alarm only, sleep mode on)
+
+`panel-bedroom.yaml`:
 
 ```yaml
-# home-alarm-keypad-downstairs.yaml
 substitutions:
-  name: home-alarm-keypad-downstairs
-  friendly_name: Home Alarm Keypad Downstairs
-
-<<: !include esp32-hass-panel.yaml
-```
-
-To compose multiple UI panels on a larger screen, add more packages and register the pages:
-
-```yaml
-# home-panel.yaml — alarm + thermostat on a 800x480 display
-substitutions:
-  name: home-panel
-  friendly_name: Home Panel
-  display_width: "800"
-  display_height: "480"
-  display_rotation: "0"
-  # Register thermostat as the second swipe page
-  nav_home_page: alarm_page
-  nav_page_1: thermostat_page
-  nav_page_count: "2"
+  name: panel-bedroom
+  friendly_name: Bedroom Panel
+  alarm_entity_id: alarm_control_panel.home_alarm
+  nav_page_count: "1"
+  sleep_mode_default_state: "ON"
+  sleep_mode_default_timeout: "60"
 
 packages:
-  board: !include packages/board.yaml
-  alarm_ui: !include packages/alarm-keypad-ui.yaml
-  thermostat_ui: !include packages/thermostat-ui.yaml
-  nav: !include packages/nav.yaml
+  keypad:
+    url: https://github.com/HomeOps/esphome-hass-panels
+    ref: main          # or a tag like `v1.9.1` to pin
+    file: esp32-hass-panel.yaml
+    refresh: 0d        # always re-pull on compile
+```
+
+### 2-page panel (alarm + thermostat)
+
+`panel-hallway.yaml`:
+
+```yaml
+substitutions:
+  name: panel-hallway
+  friendly_name: Hallway Panel
+  alarm_entity_id: alarm_control_panel.home_alarm
+  thermostat_entity_id: climate.hallway_thermostat
+  nav_page_count: "2"
+  nav_page_1: thermostat_page
+
+packages:
+  keypad:
+    url: https://github.com/HomeOps/esphome-hass-panels
+    ref: main
+    file: esp32-hass-panel.yaml
+    refresh: 0d
+```
+
+### Substitution cheat sheet
+
+| Want… | Set… |
+|---|---|
+| 1 page — alarm only | `nav_page_count: "1"` |
+| 2 pages — alarm + thermostat | `nav_page_count: "2"`, `nav_page_1: thermostat_page`, `thermostat_entity_id: ...` |
+| 3 pages — alarm + thermostat + garage (default) | `nav_page_count: "3"`, `nav_page_1: thermostat_page`, `nav_page_2: garage_page`, `thermostat_entity_id: ...`, `garage_entity_id: ...` |
+| Bedroom sleep behaviour | `sleep_mode_default_state: "ON"` and (optionally) `sleep_mode_default_timeout: "<seconds>"` |
+| Pin to a release | `ref: v1.9.1` instead of `ref: main` |
+
+### secrets.yaml requirements
+
+The per-device YAML's directory must contain a `secrets.yaml`. ESPHome
+resolves every `!secret` reference (including ones inside the
+git-fetched panel YAML) against the *entry-point* config's directory,
+so all of the following keys must be present even though the references
+live in the fetched file:
+
+```yaml
+wifi_ssid: "..."
+wifi_password: "..."
+api_encryption_key: "..."   # generate: esphome generate-api-key
+ota_password: "..."
+ap_ssid: "..."
+ap_password: "..."
 ```
 
 ## secrets.yaml format

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Available on AliExpress — search: *"ESP32-S3 Arduino LVGL Wifi 4.0 inch 480x48
 - **Idle auto-return** — returns to the home page after a configurable timeout (default 30 s)
 - **Extensible** — supports up to 4 pages via substitutions; unused slots safely no-op
 
+### Sleep mode (for bedrooms)
+- **Touch-to-wake** — when enabled, the backlight stays off and a black overlay blocks click-through. The first touch only wakes the screen; it does not activate the widget under the finger
+- **Idle auto-off** — after a configurable period of inactivity, the panel sleeps itself again
+- **HA-exposed controls** — `switch.<device>_sleep_mode` and `number.<device>_sleep_mode_timeout`, both persisted to flash and toggleable per device without re-flashing
+- **Timeout values** — `-1` (default) never auto-sleeps after a wake; `0–5 s` are snapped to `-1` (too short to use); `≥6 s` re-sleeps after that many idle seconds
+
 ### General
 - **OTA updates** — backlight fades out during flash to avoid visual glitches
 - **Fallback AP** — captive portal on first boot / wifi loss
@@ -57,6 +63,7 @@ Available on AliExpress — search: *"ESP32-S3 Arduino LVGL Wifi 4.0 inch 480x48
 | `packages/alarm-keypad-ui.yaml` | Alarm keypad UI — globals, HA sensors, animations, fonts, LVGL page |
 | `packages/thermostat-ui.yaml` | Thermostat UI — target/current temp, HVAC modes, presets, LVGL page |
 | `packages/nav.yaml` | Navigation orchestrator — swipe cycling, connecting overlay, idle auto-return |
+| `packages/sleep-mode.yaml` | Bedroom sleep mode — touch-to-wake backlight + idle auto-off, exposed to HA as a switch + number |
 | `tests/secrets.yaml` | Dummy secrets for CI config validation |
 | `secrets.yaml` | *(not committed)* wifi, API key, OTA password, AP credentials |
 | `3d/cradle.scad` | OpenSCAD source for the 3D-printable wall-mount cradle |

--- a/esp32-hass-panel.yaml
+++ b/esp32-hass-panel.yaml
@@ -62,6 +62,7 @@ packages:
   thermostat_ui: !include packages/thermostat-ui.yaml
   garage_ui: !include packages/garage-door-ui.yaml
   nav: !include packages/nav.yaml
+  sleep_mode: !include packages/sleep-mode.yaml
 
 esphome:
   name: ${name}

--- a/packages/alarm-keypad-ui.yaml
+++ b/packages/alarm-keypad-ui.yaml
@@ -15,6 +15,10 @@
 #   Writes formatted alarm state to any nav slot mapped to alarm_page, then calls
 #   nav_refresh_status.
 
+substitutions:
+  # HA alarm entity this keypad controls. Override per device when needed.
+  alarm_entity_id: alarm_control_panel.home_alarm
+
 globals:
   - id: entered_code
     type: std::string

--- a/packages/board.yaml
+++ b/packages/board.yaml
@@ -6,6 +6,38 @@
 #   https://devices.esphome.io/devices/guition-esp32-s3-4848s040/
 #   https://homeding.github.io/boards/esp32s3/panel-4848S040.htm
 
+# Package defaults — match the Guition ESP32-S3-4848S040 reference board.
+# Overridable from the entry-point YAML (main config or per-device wrapper)
+# to target a different hardware variant without re-declaring every pin.
+substitutions:
+  display_platform: "st7701s"
+  display_width: "480"
+  display_height: "480"
+  display_rotation: "270"
+  display_color_order: "RGB"
+  display_invert_colors: "False"
+  display_spi_mode: "MODE3"
+  display_data_rate: "2MHz"
+  display_pclk_frequency: "12MHz"
+  display_pclk_inverted: "False"
+  display_hsync_pulse_width: "8"
+  display_hsync_front_porch: "10"
+  display_hsync_back_porch: "20"
+  display_vsync_pulse_width: "8"
+  display_vsync_front_porch: "10"
+  display_vsync_back_porch: "10"
+  display_cs_pin: "39"
+  display_de_pin: "18"
+  display_hsync_pin: "16"
+  display_vsync_pin: "17"
+  display_pclk_pin: "21"
+  spi_clk_pin: "GPIO48"
+  spi_mosi_pin: "GPIO47"
+  i2c_sda_pin: "GPIO19"
+  i2c_scl_pin: "45"
+  touchscreen_platform: "gt911"
+  backlight_pin: "GPIO38"
+
 # Backlight — ${backlight_pin}, PWM via LEDC
 output:
   - platform: ledc

--- a/packages/board.yaml
+++ b/packages/board.yaml
@@ -87,15 +87,38 @@ globals:
     restore_value: no
     initial_value: '0'
 
-# Contract: nav.yaml must define scripts nav_touch and nav_release
+# Contract:
+#   nav.yaml         defines scripts nav_touch / nav_release.
+#   sleep-mode.yaml  defines g_screen_awake, g_swallow_touch, and the
+#                    sleep_mode_wake / sleep_mode_auto_off scripts. When the
+#                    panel is asleep, the first touch only wakes the backlight
+#                    — it does not propagate to swipe tracking or to nav, so a
+#                    sleepy hand can't drag the wake gesture into a swipe.
 touchscreen:
   - platform: ${touchscreen_platform}
     id: tft_touch
     display: tft_display
     on_touch:
-      - lambda: |-
-          if (id(nav_swipe_start_x) == -1) id(nav_swipe_start_x) = touch.x;
-          id(nav_last_touch_x) = touch.x;
-      - script.execute: nav_touch
+      - if:
+          condition:
+            lambda: 'return id(sleep_mode_enable).state && !id(g_screen_awake);'
+          then:
+            - lambda: 'id(g_swallow_touch) = true;'
+            - script.execute: sleep_mode_wake
+      - if:
+          condition:
+            lambda: 'return !id(g_swallow_touch);'
+          then:
+            - lambda: |-
+                if (id(nav_swipe_start_x) == -1) id(nav_swipe_start_x) = touch.x;
+                id(nav_last_touch_x) = touch.x;
+            - script.execute: nav_touch
+            - script.execute: sleep_mode_auto_off
     on_release:
-      - script.execute: nav_release
+      - if:
+          condition:
+            lambda: 'return id(g_swallow_touch);'
+          then:
+            - lambda: 'id(g_swallow_touch) = false;'
+          else:
+            - script.execute: nav_release

--- a/packages/sleep-mode.yaml
+++ b/packages/sleep-mode.yaml
@@ -1,0 +1,169 @@
+# sleep-mode.yaml — Bedroom sleep mode (backlight + touch-to-wake)
+#
+# When the panel is mounted in a room where someone sleeps, the backlight
+# would otherwise glow all night. This package adds a runtime-toggleable
+# "sleep mode":
+#
+#   switch.<device>_sleep_mode          — enable / disable the feature
+#   number.<device>_sleep_mode_timeout  — seconds of inactivity before the
+#                                         screen sleeps again after a wake
+#
+# Both entities are exposed to Home Assistant (no re-flash needed per device)
+# and persisted to flash so they survive reboots.
+#
+# Behaviour while enabled:
+#   - At boot (and on switch turn-on) the backlight goes off and a black,
+#     click-blocking overlay covers the UI.
+#   - The first touch is consumed: it wakes the backlight, hides the overlay,
+#     and does NOT activate the widget under the finger. This avoids a
+#     sleepy-handed disarm/arm in the dark.
+#   - Subsequent touches behave normally. Every touch restarts the idle
+#     auto-off timer (if configured).
+#
+# Timeout semantics:
+#   -1   → never auto-off (default). Once woken, the screen stays on until
+#          the switch is toggled off (or back on).
+#    0–5 → snapped to -1. Values that small would shut the screen off mid-tap
+#          and aren't useful.
+#   ≥6   → backlight returns to sleep after this many seconds of inactivity.
+#
+# Contract with board.yaml:
+#   board.yaml's touchscreen on_touch/on_release branch on g_screen_awake
+#   and g_swallow_touch so a wake-touch doesn't propagate to nav/swipe.
+
+globals:
+  # True while the backlight is lit and widgets accept touches.
+  - id: g_screen_awake
+    type: bool
+    restore_value: no
+    initial_value: 'true'
+  # Set on a wake-touch's touch-down, cleared on its release. While set,
+  # board.yaml skips swipe tracking and nav_touch/nav_release so the
+  # wake gesture can't be interpreted as a swipe.
+  - id: g_swallow_touch
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+
+switch:
+  - platform: template
+    id: sleep_mode_enable
+    name: Sleep Mode
+    icon: mdi:bed
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    on_turn_on:
+      - script.execute: sleep_mode_sleep
+    on_turn_off:
+      - script.stop: sleep_mode_auto_off
+      - script.execute: sleep_mode_wake
+
+number:
+  - platform: template
+    id: sleep_mode_timeout
+    name: Sleep Mode Timeout
+    icon: mdi:timer-outline
+    unit_of_measurement: s
+    mode: box
+    min_value: -1
+    max_value: 3600
+    step: 1
+    restore_value: true
+    initial_value: -1
+    optimistic: true
+    on_value:
+      # Snap "too low" values (0–5s) to -1 so the screen never sleeps
+      # mid-interaction. The set_action assignment re-enters on_value, but
+      # the second pass has x == -1 and falls through to the else branch
+      # — no infinite loop.
+      - if:
+          condition:
+            lambda: 'return x > -1.0f && x < 6.0f;'
+          then:
+            - number.set:
+                id: sleep_mode_timeout
+                value: -1
+          else:
+            # Apply the new timeout to any in-flight idle countdown.
+            - script.execute: sleep_mode_auto_off
+
+script:
+  # Wake: backlight on, overlay off, idle timer (re)armed.
+  - id: sleep_mode_wake
+    mode: restart
+    then:
+      - lambda: 'id(g_screen_awake) = true;'
+      - lvgl.widget.hide:
+          id: sleep_overlay
+      - light.turn_on:
+          id: display_backlight
+          transition_length: 200ms
+      - script.execute: sleep_mode_auto_off
+
+  # Sleep: reset to home page (so wake always lands on the alarm keypad),
+  # show black overlay, fade backlight off.
+  - id: sleep_mode_sleep
+    mode: restart
+    then:
+      - lambda: |-
+          id(g_screen_awake) = false;
+          id(nav_idx) = 0;
+      - script.execute: nav_show_page
+      - lvgl.widget.show:
+          id: sleep_overlay
+      - light.turn_off:
+          id: display_backlight
+          transition_length: 500ms
+
+  # Idle auto-off. Restart-mode → each touch (board.yaml) re-arms it.
+  # Disabled when sleep mode is off, the screen is already asleep, or the
+  # configured timeout is below the 6 s usability floor.
+  - id: sleep_mode_auto_off
+    mode: restart
+    then:
+      - if:
+          condition:
+            lambda: |-
+              return id(sleep_mode_enable).state &&
+                     id(g_screen_awake) &&
+                     id(sleep_mode_timeout).state >= 6.0f;
+          then:
+            - delay: !lambda |-
+                return (uint32_t)(id(sleep_mode_timeout).state * 1000);
+            - script.execute: sleep_mode_sleep
+
+# If sleep mode was on before a reboot, RESTORE_DEFAULT_OFF brings the
+# switch back as ON (template switch restores user state). This on_boot
+# ensures the panel actually goes to sleep at startup rather than sitting
+# lit until the next touch. Priority -100: after LVGL init.
+esphome:
+  on_boot:
+    priority: -100
+    then:
+      - if:
+          condition:
+            lambda: 'return id(sleep_mode_enable).state;'
+          then:
+            - script.execute: sleep_mode_sleep
+
+# Full-screen black widget on the top layer. Shown when asleep, it both
+# hides any residual LCD content and intercepts LVGL touch routing so
+# widgets below cannot fire. The actual wake action is driven from
+# board.yaml's on_touch — this overlay just blocks click-through.
+lvgl:
+  top_layer:
+    widgets:
+      - obj:
+          id: sleep_overlay
+          x: 0
+          y: 0
+          width: ${display_width}
+          height: ${display_height}
+          bg_color: 0x000000
+          bg_opa: COVER
+          border_width: 0
+          pad_all: 0
+          scrollbar_mode: "off"
+          scrollable: false
+          clickable: true
+          hidden: true

--- a/packages/sleep-mode.yaml
+++ b/packages/sleep-mode.yaml
@@ -31,6 +31,17 @@
 #   board.yaml's touchscreen on_touch/on_release branch on g_screen_awake
 #   and g_swallow_touch so a wake-touch doesn't propagate to nav/swipe.
 
+substitutions:
+  # Factory-default state of the sleep-mode switch (first boot or after a
+  # full erase). Set to "ON" for bedroom panels so the screen starts dark
+  # on first power-up. Once HA has flipped the toggle, the user-set value
+  # is restored from flash on subsequent boots regardless of this default.
+  # Must be "ON" or "OFF" — used verbatim as the RESTORE_DEFAULT_* suffix.
+  sleep_mode_default_state: "OFF"
+  # Factory-default value of the auto-off timeout, in seconds. -1 = never
+  # auto-sleep. See timeout semantics in the header comment.
+  sleep_mode_default_timeout: "-1"
+
 globals:
   # True while the backlight is lit and widgets accept touches.
   - id: g_screen_awake
@@ -50,7 +61,7 @@ switch:
     id: sleep_mode_enable
     name: Sleep Mode
     icon: mdi:bed
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: RESTORE_DEFAULT_${sleep_mode_default_state}
     optimistic: true
     on_turn_on:
       - script.execute: sleep_mode_sleep
@@ -69,7 +80,7 @@ number:
     max_value: 3600
     step: 1
     restore_value: true
-    initial_value: -1
+    initial_value: ${sleep_mode_default_timeout}
     optimistic: true
     on_value:
       # Snap "too low" values (0–5s) to -1 so the screen never sleeps

--- a/tests/bedroom-alarm-panel.yaml
+++ b/tests/bedroom-alarm-panel.yaml
@@ -1,0 +1,68 @@
+# CI fixture — bedroom alarm panel.
+#
+# Slim per-device config: one swipeable page (alarm keypad only — no
+# thermostat, no garage), sleep mode enabled by default on first boot
+# with a 60s auto-off timeout. Mirrors what a real bedroom-mounted
+# panel would look like.
+#
+# All board hardware substitutions come from packages/board.yaml's
+# defaults; `alarm_entity_id` defaults from packages/alarm-keypad-ui.yaml.
+# Only the substitutions specific to this device's role are listed.
+#
+# Compile-only — never flashed to a real device.
+
+substitutions:
+  name: test-bedroom-alarm-panel
+  friendly_name: Test Bedroom Alarm Panel
+  nav_page_count: "1"
+  sleep_mode_default_state: "ON"
+  sleep_mode_default_timeout: "60"
+
+packages:
+  board: !include ../packages/board.yaml
+  alarm_ui: !include ../packages/alarm-keypad-ui.yaml
+  nav: !include ../packages/nav.yaml
+  sleep_mode: !include ../packages/sleep-mode.yaml
+
+esphome:
+  name: ${name}
+  friendly_name: ${friendly_name}
+  project:
+    name: "HomeOps.esphome-hass-panels"
+    version: "1.9.1" # x-release-please-version
+
+esp32:
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal
+  speed: 80MHz
+
+logger:
+
+# No encryption — test secrets fixture has no api_encryption_key.
+api:
+
+ota:
+  - platform: esphome
+    password: !secret ota_password
+    on_begin:
+      - light.turn_off:
+          id: display_backlight
+          transition_length: 0s
+      - lambda: "id(display_backlight).loop();"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: !secret ap_ssid
+    password: !secret ap_password
+
+captive_portal:
+
+lvgl:
+  rotation: ${display_rotation}

--- a/tests/compile.py
+++ b/tests/compile.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""CI wrapper around `esphome` that mutes board-inherent GPIO warnings.
+
+ESPHome's ESP32-S3 pin validator
+(`esphome/components/esp32/gpio_esp32_s3.py:51-56`) emits a USB-Serial-JTAG
+conflict warning *unconditionally* whenever GPIO19 or GPIO20 are used as
+GPIO. There is no per-pin opt-out flag in the schema and the warning fires
+regardless of whether USB-Serial-JTAG is actually enabled in sdkconfig.
+
+The Guition ESP32-S3-4848S040 board these panels target hard-wires GPIO19
+to the touchscreen I2C SDA line and GPIO20 to the display's green data
+line. Both are board-fixed and unavoidable, so the warnings are pure
+noise on every compile.
+
+Raising that one module's logger level to ERROR suppresses just those
+warnings. Every other ESPHome warning still surfaces, so the CI guard
+step that fails on `^WARNING ` lines still catches real issues.
+
+Usage: `python tests/compile.py compile <config.yaml>` — same arguments
+as `esphome` itself.
+"""
+import logging
+import sys
+
+logging.getLogger("esphome.components.esp32.gpio_esp32_s3").setLevel(
+    logging.ERROR
+)
+
+from esphome.__main__ import main  # noqa: E402  (logger setup must precede import)
+
+sys.exit(main() or 0)

--- a/tests/esp32-hass-panel.yaml
+++ b/tests/esp32-hass-panel.yaml
@@ -1,17 +1,26 @@
-# CI fixture — non-default sleep-mode configuration.
+# CI fixture — non-default sleep-mode configuration on the full panel.
 #
-# Wraps the main panel YAML and flips the two sleep-mode substitutions to
-# the opposite of their package defaults so CI exercises the
-# RESTORE_DEFAULT_ON branch of the template switch and the non-`-1` branch
-# of the timeout. Compile-only — never flashed to a real device.
+# Wraps the main panel YAML via the ESPHome `packages:` mechanism (NOT
+# `<<: !include`, which is plain YAML merge and replaces the included
+# substitutions: block wholesale — every display_*/thermostat_*/garage_*
+# substitution would become undefined). With packages:, parent
+# substitutions override package substitutions and the rest cascade
+# untouched.
+#
+# Flips both sleep-mode substitutions to the opposite of their package
+# defaults so CI exercises the RESTORE_DEFAULT_ON branch of the template
+# switch and the non-`-1` branch of the auto-off timer.
+#
+# Compile-only — never flashed to a real device.
 
 substitutions:
   name: test-sleep-mode
   friendly_name: Test Sleep Mode
-  # Boot straight into sleep state — exercises the on_boot path that calls
-  # sleep_mode_sleep and shows sleep_overlay at startup.
+  # Boot straight into sleep state — exercises the on_boot path that
+  # calls sleep_mode_sleep and shows sleep_overlay at startup.
   sleep_mode_default_state: "ON"
   # Non-`-1` default — exercises the >= 6s auto-off timer path.
   sleep_mode_default_timeout: "30"
 
-<<: !include ../esp32-hass-panel.yaml
+packages:
+  base: !include ../esp32-hass-panel.yaml

--- a/tests/esp32-hass-panel.yaml
+++ b/tests/esp32-hass-panel.yaml
@@ -1,0 +1,17 @@
+# CI fixture — non-default sleep-mode configuration.
+#
+# Wraps the main panel YAML and flips the two sleep-mode substitutions to
+# the opposite of their package defaults so CI exercises the
+# RESTORE_DEFAULT_ON branch of the template switch and the non-`-1` branch
+# of the timeout. Compile-only — never flashed to a real device.
+
+substitutions:
+  name: test-sleep-mode
+  friendly_name: Test Sleep Mode
+  # Boot straight into sleep state — exercises the on_boot path that calls
+  # sleep_mode_sleep and shows sleep_overlay at startup.
+  sleep_mode_default_state: "ON"
+  # Non-`-1` default — exercises the >= 6s auto-off timer path.
+  sleep_mode_default_timeout: "30"
+
+<<: !include ../esp32-hass-panel.yaml


### PR DESCRIPTION
## Summary
- New `packages/sleep-mode.yaml` adds a runtime-toggleable bedroom sleep mode exposed to HA as `switch.<device>_sleep_mode` + `number.<device>_sleep_mode_timeout` (both persisted to flash).
- Backlight stays off and a full-screen black LVGL overlay blocks click-through; the first touch only wakes — `board.yaml` gates `on_touch`/`on_release` on a `g_swallow_touch` flag so a wake-drag can''t turn into a swipe.
- Timeout: `-1` = never auto-sleep (default); values `0–5` are snapped to `-1` in `on_value` (too short to be useful); `>=6` re-sleeps after that many idle seconds. Sleep also resets nav to the home page so wake always lands on the alarm keypad.

## Test plan
- [ ] CI: yamllint + ESPHome compile pass on this branch
- [ ] On a real panel, toggle `switch.<device>_sleep_mode` ON in HA → backlight fades off, screen goes black, touches are inert
- [ ] Touch the panel → backlight wakes, no widget under the finger fires, alarm keypad is visible
- [ ] Set `number.<device>_sleep_mode_timeout` = 30 → after 30 s of no touches, screen sleeps again; tapping wakes it
- [ ] Set timeout = 3 → snaps back to `-1` in HA UI (number entity shows `-1`)
- [ ] Set timeout = `-1` → screen stays on indefinitely after wake
- [ ] Toggle switch OFF → backlight comes back, overlay hides, any pending auto-off is cancelled
- [ ] Reboot panel while switch is ON → boots straight into sleep state (backlight off, overlay on)
- [ ] Try a fast swipe gesture that starts on a sleeping screen → wakes only, does not change page

🤖 Generated with [Claude Code](https://claude.com/claude-code)