### PR TITLE
feat!: rename nav substitutions; rename garage to cover

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Available on AliExpress — search: *"ESP32-S3 Arduino LVGL Wifi 4.0 inch 480x48
 | `packages/board.yaml` | Board hardware — display, touchscreen, backlight, SPI, I2C, touch-state globals |
 | `packages/alarm-keypad-ui.yaml` | Alarm keypad UI — globals, HA sensors, animations, fonts, LVGL page |
 | `packages/thermostat-ui.yaml` | Thermostat UI — target/current temp, HVAC modes, presets, LVGL page |
+| `packages/cover-ui.yaml` | Cover UI — any `cover.*` entity (garage door, blinds, gate), open/stop/close + state + progress, LVGL page |
 | `packages/nav.yaml` | Navigation orchestrator — swipe cycling, connecting overlay, idle auto-return |
 | `packages/sleep-mode.yaml` | Bedroom sleep mode — touch-to-wake backlight + idle auto-off, exposed to HA as a switch + number |
 | `tests/secrets.yaml` | Dummy secrets for CI config validation |
@@ -78,6 +79,7 @@ esp32-hass-panel.yaml                ← substitutions + device setup
   ├─ packages/board.yaml             ← hardware peripherals (swappable per board)
   ├─ packages/alarm-keypad-ui.yaml   ← alarm LVGL page (reusable UI component)
   ├─ packages/thermostat-ui.yaml     ← thermostat LVGL page (reusable UI component)
+  ├─ packages/cover-ui.yaml          ← cover LVGL page (garage / blinds / gate)
   └─ packages/nav.yaml               ← swipe nav, connecting overlay, idle return
 ```
 
@@ -128,12 +130,15 @@ The YAML uses ESPHome [substitutions](https://esphome.io/components/substitution
 | `thermostat_temp_min` | `16.0` | Minimum settable target temperature |
 | `thermostat_temp_max` | `30.0` | Maximum settable target temperature |
 | `thermostat_temp_step` | `0.5` | Temperature increment per button press |
+| **Cover** | | |
+| `cover_entity_id` | `cover.garage_door` | HA `cover.*` entity (garage door, blinds, gate, …) shown on the cover page |
 | **Navigation** | | |
-| `nav_home_page` | `alarm_page` | LVGL page ID shown on connect and idle return |
-| `nav_page_1` | `alarm_page` | Page at index 1 (set to real page or leave as home) |
-| `nav_page_2` | `alarm_page` | Page at index 2 (unused slots default to home) |
-| `nav_page_3` | `alarm_page` | Page at index 3 (unused slots default to home) |
+| `nav_page_1` | `alarm_page` | LVGL page ID at swipe slot 1 (leftmost) |
+| `nav_page_2` | `alarm_page` | Page at slot 2 (unused slots fall back to `nav_page_1`) |
+| `nav_page_3` | `alarm_page` | Page at slot 3 |
+| `nav_page_4` | `alarm_page` | Page at slot 4 |
 | `nav_page_count` | `1` | Number of active pages in the swipe cycle (1–4) |
+| `nav_home_page` | `"1"` | 1-based index (1…`nav_page_count`) of the landing page. The home page is shown on connect, when sleep mode wakes, and as the idle auto-return target. Must be ≤ `nav_page_count`. |
 | `nav_auto_return_delay` | `30s` | Idle time before auto-returning to home page |
 | **Sleep mode** | | |
 | `sleep_mode_default_state` | `OFF` | Factory-default state of the sleep-mode switch (`OFF` / `ON`). Set to `ON` for bedroom panels so they boot dark. HA-stored state wins on subsequent boots. |
@@ -174,8 +179,34 @@ substitutions:
   friendly_name: Hallway Panel
   alarm_entity_id: alarm_control_panel.home_alarm
   thermostat_entity_id: climate.hallway_thermostat
+  nav_page_1: alarm_page
+  nav_page_2: thermostat_page
   nav_page_count: "2"
-  nav_page_1: thermostat_page
+
+packages:
+  keypad:
+    url: https://github.com/HomeOps/esphome-hass-panels
+    ref: main
+    file: esp32-hass-panel.yaml
+    refresh: 0d
+```
+
+### 2-page panel with cover first, alarm second
+
+Reorder the swipe slots. The landing page is whichever `nav_page_N`
+slot `nav_home_page` points at (default `"1"`, the leftmost).
+
+`panel-garage.yaml`:
+
+```yaml
+substitutions:
+  name: panel-garage
+  friendly_name: Garage Panel
+  alarm_entity_id: alarm_control_panel.home_alarm
+  cover_entity_id: cover.garage_door
+  nav_page_1: cover_page       # landing page (nav_home_page defaults to "1")
+  nav_page_2: alarm_page
+  nav_page_count: "2"
 
 packages:
   keypad:
@@ -190,10 +221,12 @@ packages:
 | Want… | Set… |
 |---|---|
 | 1 page — alarm only | `nav_page_count: "1"` |
-| 2 pages — alarm + thermostat | `nav_page_count: "2"`, `nav_page_1: thermostat_page`, `thermostat_entity_id: ...` |
-| 3 pages — alarm + thermostat + garage (default) | `nav_page_count: "3"`, `nav_page_1: thermostat_page`, `nav_page_2: garage_page`, `thermostat_entity_id: ...`, `garage_entity_id: ...` |
-| Bedroom sleep behaviour | `sleep_mode_default_state: "ON"` and (optionally) `sleep_mode_default_timeout: "<seconds>"` |
-| Pin to a release | `ref: v1.9.1` instead of `ref: main` |
+| 2 pages — alarm + thermostat | `nav_page_1: alarm_page`, `nav_page_2: thermostat_page`, `nav_page_count: "2"`, `thermostat_entity_id: …` |
+| 3 pages — alarm + thermostat + cover (default) | `nav_page_count: "3"` (other defaults already match) |
+| Reorder, e.g. cover-first / alarm-second | `nav_page_1: cover_page`, `nav_page_2: alarm_page`, `nav_page_count: "2"`, `cover_entity_id: …` |
+| Keep swipe order but pin home to a different slot | `nav_home_page: "2"` (must be ≤ `nav_page_count`) |
+| Bedroom sleep behaviour | `sleep_mode_default_state: "ON"` and optionally `sleep_mode_default_timeout: "<seconds>"` |
+| Pin to a release | `ref: v2.0.0` instead of `ref: main` |
 
 ### secrets.yaml requirements
 

--- a/esp32-hass-panel.yaml
+++ b/esp32-hass-panel.yaml
@@ -48,19 +48,21 @@ substitutions:
   thermostat_temp_min: "16.0"
   thermostat_temp_max: "30.0"
   thermostat_temp_step: "0.5"
-  # Garage door entity — any HA `cover.*` (garage door opener)
-  garage_entity_id: cover.garage_door
-  # Navigation — register all pages in the swipe cycle
-  nav_home_page: alarm_page
-  nav_page_1: thermostat_page
-  nav_page_2: garage_page
+  # Cover entity — any HA `cover.*` (garage door opener, blinds, gate, …)
+  cover_entity_id: cover.garage_door
+  # Navigation — register all pages in the swipe cycle (1-based)
+  nav_page_1: alarm_page
+  nav_page_2: thermostat_page
+  nav_page_3: cover_page
   nav_page_count: "3"
+  # nav_home_page defaults to "1" in packages/nav.yaml — override here
+  # if a different declared page should be the landing / auto-return target.
 
 packages:
   board: !include packages/board.yaml
   alarm_ui: !include packages/alarm-keypad-ui.yaml
   thermostat_ui: !include packages/thermostat-ui.yaml
-  garage_ui: !include packages/garage-door-ui.yaml
+  cover_ui: !include packages/cover-ui.yaml
   nav: !include packages/nav.yaml
   sleep_mode: !include packages/sleep-mode.yaml
 

--- a/packages/alarm-keypad-ui.yaml
+++ b/packages/alarm-keypad-ui.yaml
@@ -76,10 +76,10 @@ text_sensor:
           else if (x == "pending")    txt = "PENDING...";
           else if (x == "triggered")  txt = "!! TRIGGERED !!";
           else txt = x;
-          if (strcmp("${nav_home_page}", "alarm_page") == 0) id(g_nav_status_0) = txt;
-          if (strcmp("${nav_page_1}", "alarm_page") == 0) id(g_nav_status_1) = txt;
-          if (strcmp("${nav_page_2}", "alarm_page") == 0) id(g_nav_status_2) = txt;
-          if (strcmp("${nav_page_3}", "alarm_page") == 0) id(g_nav_status_3) = txt;
+          if (strcmp("${nav_page_1}", "alarm_page") == 0) id(g_nav_status_0) = txt;
+          if (strcmp("${nav_page_2}", "alarm_page") == 0) id(g_nav_status_1) = txt;
+          if (strcmp("${nav_page_3}", "alarm_page") == 0) id(g_nav_status_2) = txt;
+          if (strcmp("${nav_page_4}", "alarm_page") == 0) id(g_nav_status_3) = txt;
       # Update status bar with state and appropriate color
       - lvgl.label.update:
           id: lbl_alarm_status

--- a/packages/cover-ui.yaml
+++ b/packages/cover-ui.yaml
@@ -1,5 +1,6 @@
-# Garage door UI — LVGL interface wired to Home Assistant cover entity
-# Board-independent; include alongside board.yaml.
+# Cover UI — LVGL interface wired to a Home Assistant `cover.*` entity
+# (garage door, blinds, gate, awning, etc.). Board-independent; include
+# alongside board.yaml.
 #
 # Layout (480×480 display, nav_bar_height=60):
 #   y=  0..59   — navbar (top_layer, handled by nav.yaml)
@@ -12,6 +13,10 @@
 #   When the cover exposes `current_position` (0-100), the bar widget
 #   shows true progress. Otherwise, a sliding block (marquee) runs while
 #   state is opening/closing to signal motion without faking progress.
+
+substitutions:
+  # HA cover entity this page controls. Override per device when needed.
+  cover_entity_id: cover.garage_door
 
 globals:
   # Flips true the first time HA reports `current_position`. Controls
@@ -32,7 +37,7 @@ globals:
 sensor:
   - platform: homeassistant
     id: cov_position
-    entity_id: ${garage_entity_id}
+    entity_id: ${cover_entity_id}
     attribute: current_position
     on_value:
       - lambda: id(garage_pos_known) = true;
@@ -46,7 +51,7 @@ sensor:
 text_sensor:
   - platform: homeassistant
     id: cov_friendly_name
-    entity_id: ${garage_entity_id}
+    entity_id: ${cover_entity_id}
     attribute: friendly_name
     on_value:
       - lvgl.label.update:
@@ -55,7 +60,7 @@ text_sensor:
 
   - platform: homeassistant
     id: cov_state
-    entity_id: ${garage_entity_id}
+    entity_id: ${cover_entity_id}
     on_value:
       # State text
       - lvgl.label.update:
@@ -113,10 +118,10 @@ text_sensor:
           else if (x == "closing") st = "Closing";
           else st = x;
           std::string buf = name + " - " + st;
-          if (strcmp("${nav_home_page}", "garage_page") == 0) id(g_nav_status_0) = buf;
-          if (strcmp("${nav_page_1}", "garage_page") == 0) id(g_nav_status_1) = buf;
-          if (strcmp("${nav_page_2}", "garage_page") == 0) id(g_nav_status_2) = buf;
-          if (strcmp("${nav_page_3}", "garage_page") == 0) id(g_nav_status_3) = buf;
+          if (strcmp("${nav_page_1}", "cover_page") == 0) id(g_nav_status_0) = buf;
+          if (strcmp("${nav_page_2}", "cover_page") == 0) id(g_nav_status_1) = buf;
+          if (strcmp("${nav_page_3}", "cover_page") == 0) id(g_nav_status_2) = buf;
+          if (strcmp("${nav_page_4}", "cover_page") == 0) id(g_nav_status_3) = buf;
       - script.execute: nav_refresh_status
 
 script:
@@ -125,21 +130,21 @@ script:
       - homeassistant.service:
           service: cover.open_cover
           data:
-            entity_id: ${garage_entity_id}
+            entity_id: ${cover_entity_id}
 
   - id: garage_close_cmd
     then:
       - homeassistant.service:
           service: cover.close_cover
           data:
-            entity_id: ${garage_entity_id}
+            entity_id: ${cover_entity_id}
 
   - id: garage_stop_cmd
     then:
       - homeassistant.service:
           service: cover.stop_cover
           data:
-            entity_id: ${garage_entity_id}
+            entity_id: ${cover_entity_id}
 
   # Indeterminate marquee: a 100px block ping-pongs across the 460px
   # track while the cover is opening/closing without a reported position.
@@ -176,7 +181,7 @@ font:
 
 lvgl:
   pages:
-    - id: garage_page
+    - id: cover_page
       widgets:
         - obj:
             width: ${display_width}

--- a/packages/nav.yaml
+++ b/packages/nav.yaml
@@ -13,11 +13,14 @@
 # Supports up to 4 panel pages. Register them in your instance YAML:
 #
 #   substitutions:
-#     nav_home_page:  alarm_page      # index 0, always required
-#     nav_page_1:     thermostat_page # index 1
-#     nav_page_2:     alarm_page      # unused slots default to home page (safe no-op)
-#     nav_page_3:     alarm_page
+#     nav_page_1:     alarm_page      # leftmost swipe slot
+#     nav_page_2:     thermostat_page
+#     nav_page_3:     alarm_page      # unused slots fall back to nav_page_1
+#     nav_page_4:     alarm_page
 #     nav_page_count: "2"             # how many slots are active (1–4)
+#     nav_home_page:  "1"             # 1-based index of the landing page
+#                                     # (shown on connect, target of idle return).
+#                                     # Defaults to "1". Must be <= nav_page_count.
 #
 # Contract with board.yaml:
 #   board.yaml populates globals nav_swipe_start_x / nav_last_touch_x / nav_swipe_dx
@@ -33,11 +36,12 @@
 #   HA has accepted our subscriptions (i.e. permissions granted).
 
 substitutions:
-  nav_home_page: alarm_page
-  nav_page_1: alarm_page      # unused → redirect to home (safe no-op)
-  nav_page_2: alarm_page
+  nav_page_1: alarm_page      # leftmost swipe slot (default first page)
+  nav_page_2: alarm_page      # unused slots fall back to nav_page_1 (safe no-op)
   nav_page_3: alarm_page
+  nav_page_4: alarm_page
   nav_page_count: "1"
+  nav_home_page: "1"          # 1-based index of the landing page (1..nav_page_count)
   nav_auto_return_delay: 30s
   nav_bar_height: "60"        # pixels — page content must start below this value
 
@@ -159,21 +163,22 @@ script:
             - lambda: id(nav_idx) = (id(nav_idx) + ${nav_page_count} - 1) % ${nav_page_count};
             - script.execute: nav_show_page
 
-  # Show the page that matches nav_idx, then refresh the status label.
+  # Show the page that matches nav_idx (0-based internal), then refresh
+  # the status label. nav_idx == N maps to nav_page_(N+1).
   - id: nav_show_page
     then:
       - if:
           condition: {lambda: return id(nav_idx) == 0;}
-          then: [{lvgl.page.show: "${nav_home_page}"}]
-      - if:
-          condition: {lambda: return id(nav_idx) == 1;}
           then: [{lvgl.page.show: "${nav_page_1}"}]
       - if:
-          condition: {lambda: return id(nav_idx) == 2;}
+          condition: {lambda: return id(nav_idx) == 1;}
           then: [{lvgl.page.show: "${nav_page_2}"}]
       - if:
-          condition: {lambda: return id(nav_idx) == 3;}
+          condition: {lambda: return id(nav_idx) == 2;}
           then: [{lvgl.page.show: "${nav_page_3}"}]
+      - if:
+          condition: {lambda: return id(nav_idx) == 3;}
+          then: [{lvgl.page.show: "${nav_page_4}"}]
       - script.execute: nav_refresh_status
 
   # Update the navbar status label from the active panel's status string.
@@ -192,7 +197,8 @@ script:
           else
             lv_label_set_text(id(lbl_nav_status), "");
 
-  # Auto-return: only fires when connected; resets to home page.
+  # Auto-return: only fires when connected; resets to the home page
+  # (whichever nav_page_N is selected by nav_home_page).
   - id: auto_return
     mode: restart
     then:
@@ -201,7 +207,7 @@ script:
           condition:
             lambda: return id(nav_connected);
           then:
-            - lambda: id(nav_idx) = 0;
+            - lambda: id(nav_idx) = ${nav_home_page} - 1;
             - script.execute: nav_show_page
 
   # Central readiness handler. Recolours the three step indicators, updates the
@@ -252,7 +258,7 @@ script:
           then:
             - lambda: |-
                 id(nav_connected) = true;
-                id(nav_idx) = 0;
+                id(nav_idx) = ${nav_home_page} - 1;
             - script.stop: anim_connecting_dots
             - lvgl.widget.hide:
                 id: connecting_overlay
@@ -262,7 +268,7 @@ script:
           else:
             - lambda: |-
                 id(nav_connected) = false;
-                id(nav_idx) = 0;
+                id(nav_idx) = ${nav_home_page} - 1;
             - lvgl.widget.hide:
                 id: navbar
             - lvgl.widget.show:

--- a/packages/sleep-mode.yaml
+++ b/packages/sleep-mode.yaml
@@ -111,14 +111,15 @@ script:
           transition_length: 200ms
       - script.execute: sleep_mode_auto_off
 
-  # Sleep: reset to home page (so wake always lands on the alarm keypad),
+  # Sleep: reset to the configured home page (nav_home_page) so wake always
+  # lands there rather than wherever the last user left it. Then
   # show black overlay, fade backlight off.
   - id: sleep_mode_sleep
     mode: restart
     then:
       - lambda: |-
           id(g_screen_awake) = false;
-          id(nav_idx) = 0;
+          id(nav_idx) = ${nav_home_page} - 1;
       - script.execute: nav_show_page
       - lvgl.widget.show:
           id: sleep_overlay

--- a/packages/thermostat-ui.yaml
+++ b/packages/thermostat-ui.yaml
@@ -30,10 +30,10 @@ sensor:
           if (preset.empty()) preset = "--";
           char buf[64];
           snprintf(buf, sizeof(buf), "%s - %.1f C", preset.c_str(), x);
-          if (strcmp("${nav_home_page}", "thermostat_page") == 0) id(g_nav_status_0) = buf;
-          if (strcmp("${nav_page_1}", "thermostat_page") == 0) id(g_nav_status_1) = buf;
-          if (strcmp("${nav_page_2}", "thermostat_page") == 0) id(g_nav_status_2) = buf;
-          if (strcmp("${nav_page_3}", "thermostat_page") == 0) id(g_nav_status_3) = buf;
+          if (strcmp("${nav_page_1}", "thermostat_page") == 0) id(g_nav_status_0) = buf;
+          if (strcmp("${nav_page_2}", "thermostat_page") == 0) id(g_nav_status_1) = buf;
+          if (strcmp("${nav_page_3}", "thermostat_page") == 0) id(g_nav_status_2) = buf;
+          if (strcmp("${nav_page_4}", "thermostat_page") == 0) id(g_nav_status_3) = buf;
       - script.execute: nav_refresh_status
 
   - platform: homeassistant
@@ -71,10 +71,10 @@ text_sensor:
       - lambda: |-
           char buf[64];
           snprintf(buf, sizeof(buf), "%s - %.1f C", x.c_str(), id(clim_current_temp).state);
-          if (strcmp("${nav_home_page}", "thermostat_page") == 0) id(g_nav_status_0) = buf;
-          if (strcmp("${nav_page_1}", "thermostat_page") == 0) id(g_nav_status_1) = buf;
-          if (strcmp("${nav_page_2}", "thermostat_page") == 0) id(g_nav_status_2) = buf;
-          if (strcmp("${nav_page_3}", "thermostat_page") == 0) id(g_nav_status_3) = buf;
+          if (strcmp("${nav_page_1}", "thermostat_page") == 0) id(g_nav_status_0) = buf;
+          if (strcmp("${nav_page_2}", "thermostat_page") == 0) id(g_nav_status_1) = buf;
+          if (strcmp("${nav_page_3}", "thermostat_page") == 0) id(g_nav_status_2) = buf;
+          if (strcmp("${nav_page_4}", "thermostat_page") == 0) id(g_nav_status_3) = buf;
       - script.execute: nav_refresh_status
       - lvgl.dropdown.update:
           id: dd_preset_mode


### PR DESCRIPTION
## Summary

Two related renames bundled so per-device wrappers migrate once.

### Nav indexing (off-by-one fix)

`nav_home_page` used to be a page id at index 0; `nav_page_1` was at index 1. `nav_page_1` looked like *the first* page but was actually the second.

- Renamed the page-id slots to sequential 1-based names.
- Added a numeric `nav_home_page` (1…`nav_page_count`, default `"1"`) that picks which declared slot is the landing / auto-return target.
- Swipe order and which-page-is-home are now independent decisions.

| Old | New |
|---|---|
| `nav_home_page` (page id) | `nav_page_1` |
| `nav_page_1` | `nav_page_2` |
| `nav_page_2` | `nav_page_3` |
| `nav_page_3` | `nav_page_4` |
| *(new)* | `nav_home_page` (numeric, default `"1"`) |

### Garage → Cover

The UI package controls any `cover.*` entity (garage door, blinds, gate, awning). `packages/garage-door-remote.yaml` already used `cover_entity_id`, so the UI package was the outlier.

| Old | New |
|---|---|
| `garage_page` | `cover_page` |
| `garage_entity_id` | `cover_entity_id` |
| `packages/garage-door-ui.yaml` | `packages/cover-ui.yaml` (git mv, history preserved) |
| `garage_ui:` (include key) | `cover_ui:` |

## Touchpoints

- `packages/nav.yaml` — substitutions + header doc + `nav_show_page` + `auto_return` + `nav_connection_check`
- `packages/sleep-mode.yaml` — `sleep_mode_sleep` now resets to `${nav_home_page} - 1`
- `packages/{alarm-keypad,thermostat,cover}-ui.yaml` — strcmp lines: shifted index, added a row for `nav_page_4` so the 4th status slot is reachable
- `packages/cover-ui.yaml` — `${garage_entity_id}` → `${cover_entity_id}`, page id rename, new `cover_entity_id` substitution default (`cover.garage_door`)
- `esp32-hass-panel.yaml` — substitutions and `packages:` include key
- `README.md` — substitution table, cheat sheet, new cover-first example
- Both test fixtures inherit the new defaults and need no edits.

## Test plan

- [ ] CI: yamllint + the three ESPHome compile jobs pass
- [ ] On a real panel: 3-page default swipes alarm → thermostat → cover (was alarm → thermostat → garage_page); idle return lands on alarm
- [ ] Set `nav_home_page: "2"`, verify idle return lands on thermostat instead of alarm
- [ ] Set `nav_page_1: cover_page` / `nav_page_2: alarm_page` / `nav_page_count: "2"`, verify cover is the landing page
- [ ] Set `cover_entity_id: cover.bedroom_blinds`, verify the cover page controls the blinds

## Breaking change

Per-device wrappers using any of the old names must migrate:

- `nav_home_page: <page_id>` → `nav_page_1: <page_id>`
- `nav_page_1`/`2`/`3` → `nav_page_2`/`3`/`4`
- `garage_page` → `cover_page`
- `garage_entity_id` → `cover_entity_id`
- `garage_ui: !include packages/garage-door-ui.yaml` → `cover_ui: !include packages/cover-ui.yaml`

release-please will bump to 2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)