### PR TITLE
feat: add energy monitoring page with low-power alert override

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ Available on AliExpress — search: *"ESP32-S3 Arduino LVGL Wifi 4.0 inch 480x48
 - **Idle auto-off** — after a configurable period of inactivity, the panel sleeps itself again
 - **HA-exposed controls** — `switch.<device>_sleep_mode` and `number.<device>_sleep_mode_timeout`, both persisted to flash and toggleable per device without re-flashing
 - **Timeout values** — `-1` (default) never auto-sleeps after a wake; `0–5 s` are snapped to `-1` (too short to use); `≥6 s` re-sleeps after that many idle seconds
+- **Programmatic bypass** — other packages (e.g. `energy-ui`'s low-power alert) can flip a `g_sleep_bypass` global via the `sleep_bypass_set` / `sleep_bypass_clear` scripts to forcibly keep the screen on during an alert condition
+
+### Energy monitoring page
+- **Battery state of charge** — color-coded percentage readout + LVGL bar from a HA numeric sensor (green ≥ 60, amber 30–59, red < 30)
+- **Grid status** — `ON GRID` / `OFF GRID` driven by a HA binary sensor, color-coded
+- **Low-power alert** — when a designated HA binary sensor goes on, the panel bypasses sleep mode, force-navigates to `energy_page` (if the page is in the swipe cycle), and flashes the page background red. All three reverse when the sensor clears
+- **Opt-in via nav** — the page is always compiled; register it with `nav_page_N: energy_page` and bump `nav_page_count` to expose it. Sleep bypass + flash fire on alert even when the page isn't in the swipe cycle
 
 ### General
 - **OTA updates** — backlight fades out during flash to avoid visual glitches
@@ -63,6 +70,7 @@ Available on AliExpress — search: *"ESP32-S3 Arduino LVGL Wifi 4.0 inch 480x48
 | `packages/alarm-keypad-ui.yaml` | Alarm keypad UI — globals, HA sensors, animations, fonts, LVGL page |
 | `packages/thermostat-ui.yaml` | Thermostat UI — target/current temp, HVAC modes, presets, LVGL page |
 | `packages/cover-ui.yaml` | Cover UI — any `cover.*` entity (garage door, blinds, gate), open/stop/close + state + progress, LVGL page |
+| `packages/energy-ui.yaml` | Energy UI — battery state of charge + grid status + low-power alert (bypasses sleep, force-navigates, flashes page bg) |
 | `packages/nav.yaml` | Navigation orchestrator — swipe cycling, connecting overlay, idle auto-return |
 | `packages/sleep-mode.yaml` | Bedroom sleep mode — touch-to-wake backlight + idle auto-off, exposed to HA as a switch + number |
 | `tests/secrets.yaml` | Dummy secrets for CI config validation |
@@ -80,6 +88,7 @@ esp32-hass-panel.yaml                ← substitutions + device setup
   ├─ packages/alarm-keypad-ui.yaml   ← alarm LVGL page (reusable UI component)
   ├─ packages/thermostat-ui.yaml     ← thermostat LVGL page (reusable UI component)
   ├─ packages/cover-ui.yaml          ← cover LVGL page (garage / blinds / gate)
+  ├─ packages/energy-ui.yaml         ← energy LVGL page (battery / grid / low-power alert)
   └─ packages/nav.yaml               ← swipe nav, connecting overlay, idle return
 ```
 
@@ -132,6 +141,10 @@ The YAML uses ESPHome [substitutions](https://esphome.io/components/substitution
 | `thermostat_temp_step` | `0.5` | Temperature increment per button press |
 | **Cover** | | |
 | `cover_entity_id` | `cover.garage_door` | HA `cover.*` entity (garage door, blinds, gate, …) shown on the cover page |
+| **Energy** | | |
+| `energy_battery_entity_id` | `sensor.home_battery_charge` | HA numeric sensor (0-100) for whole-home battery state of charge |
+| `energy_grid_status_entity_id` | `binary_sensor.grid_online` | HA binary sensor: on = on-grid, off = islanded / off-grid |
+| `energy_low_power_entity_id` | `binary_sensor.home_low_power_alert` | HA binary sensor: when on, bypasses sleep mode, force-navigates to `energy_page` (if registered), and flashes the page background |
 | **Navigation** | | |
 | `nav_page_1` | `alarm_page` | LVGL page ID at swipe slot 1 (leftmost) |
 | `nav_page_2` | `alarm_page` | Page at slot 2 (unused slots fall back to `nav_page_1`) |
@@ -223,6 +236,7 @@ packages:
 | 1 page — alarm only | `nav_page_count: "1"` |
 | 2 pages — alarm + thermostat | `nav_page_1: alarm_page`, `nav_page_2: thermostat_page`, `nav_page_count: "2"`, `thermostat_entity_id: …` |
 | 3 pages — alarm + thermostat + cover (default) | `nav_page_count: "3"` (other defaults already match) |
+| 4 pages — add energy monitoring | `nav_page_4: energy_page`, `nav_page_count: "4"`, `energy_battery_entity_id: …`, `energy_grid_status_entity_id: …`, `energy_low_power_entity_id: …` |
 | Reorder, e.g. cover-first / alarm-second | `nav_page_1: cover_page`, `nav_page_2: alarm_page`, `nav_page_count: "2"`, `cover_entity_id: …` |
 | Keep swipe order but pin home to a different slot | `nav_home_page: "2"` (must be ≤ `nav_page_count`) |
 | Bedroom sleep behaviour | `sleep_mode_default_state: "ON"` and optionally `sleep_mode_default_timeout: "<seconds>"` |

--- a/esp32-hass-panel.yaml
+++ b/esp32-hass-panel.yaml
@@ -63,6 +63,7 @@ packages:
   alarm_ui: !include packages/alarm-keypad-ui.yaml
   thermostat_ui: !include packages/thermostat-ui.yaml
   cover_ui: !include packages/cover-ui.yaml
+  energy_ui: !include packages/energy-ui.yaml
   nav: !include packages/nav.yaml
   sleep_mode: !include packages/sleep-mode.yaml
 

--- a/packages/energy-ui.yaml
+++ b/packages/energy-ui.yaml
@@ -1,0 +1,283 @@
+# Energy UI — whole-home battery + grid + low-power alert page
+#
+# Renders three Home Assistant entities on a dedicated LVGL page
+# (`energy_page`):
+#
+#   sensor.<...>       — battery state of charge, 0-100%
+#   binary_sensor.<…>  — grid online (on = on-grid, off = islanded)
+#   binary_sensor.<…>  — low-power alert (on = critical)
+#
+# When the low-power alert turns on, this package:
+#   1. Sets the sleep-mode bypass flag so the screen can't auto-sleep
+#      (also wakes it immediately if it was asleep).
+#   2. Force-navigates to `energy_page` IF a per-device wrapper has it
+#      registered in a nav_page_N slot. No-op otherwise — homes that
+#      don't expose this page get the sleep override but stay where
+#      they were.
+#   3. Flashes the page background red so the alert is visible from
+#      across the room.
+#
+# When the alert clears, all three reverse: stop flashing, clear bypass,
+# stop forcing the page. Navigation isn't undone — the user can swipe
+# away whenever they want.
+#
+# Dependencies:
+#   - sleep-mode.yaml — sleep_bypass_set / sleep_bypass_clear scripts.
+#   - nav.yaml       — g_nav_status_0..3 globals + nav_refresh_status.
+
+substitutions:
+  # HA entities this page binds to. Override per device. Defaults point at
+  # plausibly-named entities so a fresh build subscribes to something —
+  # if the entity doesn't exist in HA the subscription stays dormant and
+  # the page just shows "--".
+  energy_battery_entity_id: sensor.home_battery_charge
+  energy_grid_status_entity_id: binary_sensor.grid_online
+  energy_low_power_entity_id: binary_sensor.home_low_power_alert
+
+globals:
+  - id: g_battery_pct
+    type: int
+    restore_value: no
+    initial_value: '0'
+  # True while the low-power alert is active. Drives the flash loop's
+  # while-condition (self-terminating) and gates whether
+  # sleep_bypass_clear is safe to call.
+  - id: g_low_power_active
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+
+sensor:
+  - platform: homeassistant
+    id: energy_battery_pct
+    entity_id: ${energy_battery_entity_id}
+    on_value:
+      - lambda: |-
+          int pct = (int) x;
+          if (pct < 0) pct = 0;
+          if (pct > 100) pct = 100;
+          id(g_battery_pct) = pct;
+      - lvgl.label.update:
+          id: lbl_energy_battery_pct
+          text: !lambda 'return str_sprintf("%d%%", id(g_battery_pct));'
+      - lvgl.bar.update:
+          id: bar_energy_battery
+          value: !lambda 'return id(g_battery_pct);'
+          animated: true
+      # Color the % readout: green >= 60, amber 30-59, red < 30.
+      - if:
+          condition: {lambda: 'return id(g_battery_pct) >= 60;'}
+          then:
+            - lvgl.label.update: {id: lbl_energy_battery_pct, text_color: 0x66dd66}
+      - if:
+          condition:
+            lambda: 'return id(g_battery_pct) >= 30 && id(g_battery_pct) < 60;'
+          then:
+            - lvgl.label.update: {id: lbl_energy_battery_pct, text_color: 0xffaa33}
+      - if:
+          condition: {lambda: 'return id(g_battery_pct) < 30;'}
+          then:
+            - lvgl.label.update: {id: lbl_energy_battery_pct, text_color: 0xe94560}
+      # Navbar status: "Battery NN%" — whichever nav_page_N slot maps to
+      # energy_page picks up the line. Same routing pattern as the other
+      # UI packages.
+      - lambda: |-
+          char buf[32];
+          snprintf(buf, sizeof(buf), "Battery %d%%", id(g_battery_pct));
+          if (strcmp("${nav_page_1}", "energy_page") == 0) id(g_nav_status_0) = buf;
+          if (strcmp("${nav_page_2}", "energy_page") == 0) id(g_nav_status_1) = buf;
+          if (strcmp("${nav_page_3}", "energy_page") == 0) id(g_nav_status_2) = buf;
+          if (strcmp("${nav_page_4}", "energy_page") == 0) id(g_nav_status_3) = buf;
+      - script.execute: nav_refresh_status
+
+binary_sensor:
+  - platform: homeassistant
+    id: energy_grid_online
+    entity_id: ${energy_grid_status_entity_id}
+    on_press:    # OFF -> ON  → grid came up
+      - lvgl.label.update:
+          id: lbl_energy_grid_status
+          text: "ON GRID"
+          text_color: 0x66dd66
+      - lvgl.label.update:
+          id: lbl_energy_grid_icon
+          text_color: 0x66dd66
+    on_release:  # ON -> OFF  → grid dropped
+      - lvgl.label.update:
+          id: lbl_energy_grid_status
+          text: "OFF GRID"
+          text_color: 0xe94560
+      - lvgl.label.update:
+          id: lbl_energy_grid_icon
+          text_color: 0xe94560
+
+  - platform: homeassistant
+    id: energy_low_power
+    entity_id: ${energy_low_power_entity_id}
+    on_press:    # alert begins
+      - lambda: 'id(g_low_power_active) = true;'
+      - script.execute: sleep_bypass_set
+      - script.execute: energy_page_force_home
+      - lvgl.widget.show: {id: energy_low_power_banner}
+      - script.execute: anim_energy_low_power_flash
+    on_release:  # alert clears
+      - lambda: 'id(g_low_power_active) = false;'
+      - script.stop: anim_energy_low_power_flash
+      - lvgl.widget.hide: {id: energy_low_power_banner}
+      - lvgl.widget.update: {id: energy_page_root, bg_color: 0x1a1a2e}
+      - script.execute: sleep_bypass_clear
+
+script:
+  # If the panel has energy_page registered in one of its nav_page_N
+  # slots, jump there. No-op for panels that don't expose the page —
+  # the sleep bypass + flash still fire, but the user sees them on
+  # whatever page is currently active.
+  - id: energy_page_force_home
+    then:
+      - lambda: |-
+          int target = -1;
+          if      (strcmp("${nav_page_1}", "energy_page") == 0) target = 0;
+          else if (strcmp("${nav_page_2}", "energy_page") == 0) target = 1;
+          else if (strcmp("${nav_page_3}", "energy_page") == 0) target = 2;
+          else if (strcmp("${nav_page_4}", "energy_page") == 0) target = 3;
+          if (target >= 0) id(nav_idx) = target;
+      - if:
+          condition:
+            lambda: |-
+              return (strcmp("${nav_page_1}", "energy_page") == 0) ||
+                     (strcmp("${nav_page_2}", "energy_page") == 0) ||
+                     (strcmp("${nav_page_3}", "energy_page") == 0) ||
+                     (strcmp("${nav_page_4}", "energy_page") == 0);
+          then:
+            - script.execute: nav_show_page
+
+  # Page-bg flash while the low-power alert is active. Alternates between
+  # the dark default and HA-red on a 500ms tick. `mode: restart` so any
+  # caller can re-arm idempotently; the while loop self-terminates
+  # when g_low_power_active goes false.
+  - id: anim_energy_low_power_flash
+    mode: restart
+    then:
+      - while:
+          condition:
+            lambda: 'return id(g_low_power_active);'
+          then:
+            - lvgl.widget.update: {id: energy_page_root, bg_color: 0xe94560}
+            - delay: 500ms
+            - lvgl.widget.update: {id: energy_page_root, bg_color: 0x1a1a2e}
+            - delay: 500ms
+
+font:
+  - file: "https://github.com/Templarian/MaterialDesign-Webfont/raw/master/fonts/materialdesignicons-webfont.ttf"
+    id: mdi_icons_energy
+    size: 40
+    glyphs:
+      - "\U000F06A5"  # mdi:power-plug
+      - "\U000F0079"  # mdi:battery
+      - "\U000F0026"  # mdi:alert-circle
+
+lvgl:
+  pages:
+    - id: energy_page
+      widgets:
+        - obj:
+            id: energy_page_root
+            width: ${display_width}
+            height: ${display_height}
+            pad_all: 0
+            bg_color: 0x1a1a2e
+            border_width: 0
+            scrollbar_mode: "off"
+            scrollable: false
+            widgets:
+
+              # ── Battery section ───────────────────────────────────
+              - label:
+                  align: TOP_MID
+                  y: 70
+                  text: "\U000F0079"  # mdi:battery
+                  text_font: mdi_icons_energy
+                  text_color: 0xcccccc
+              - label:
+                  id: lbl_energy_battery_pct
+                  align: TOP_MID
+                  y: 120
+                  text: "--%"
+                  text_font: montserrat_48
+                  text_color: 0xcccccc
+              - bar:
+                  id: bar_energy_battery
+                  align: TOP_MID
+                  y: 180
+                  width: 360
+                  height: 20
+                  min_value: 0
+                  max_value: 100
+                  value: 0
+                  bg_color: 0x0f3460
+                  border_width: 0
+                  radius: 10
+                  indicator:
+                    bg_color: 0x66dd66
+                    radius: 10
+
+              # ── Grid status row ───────────────────────────────────
+              - obj:
+                  align: TOP_MID
+                  y: 230
+                  width: 360
+                  height: 60
+                  bg_color: 0x16213e
+                  border_width: 0
+                  radius: 8
+                  pad_all: 0
+                  scrollbar_mode: "off"
+                  scrollable: false
+                  layout:
+                    type: FLEX
+                    flex_flow: ROW
+                    flex_align_main: CENTER
+                    flex_align_cross: CENTER
+                    pad_column: 14
+                  widgets:
+                    - label:
+                        id: lbl_energy_grid_icon
+                        text: "\U000F06A5"  # mdi:power-plug
+                        text_font: mdi_icons_energy
+                        text_color: 0xcccccc
+                    - label:
+                        id: lbl_energy_grid_status
+                        text: "--"
+                        text_font: montserrat_28
+                        text_color: 0xcccccc
+
+              # ── Low-power banner (hidden when ok; shown + page bg
+              #     flashing while the alert is active) ──────────────
+              - obj:
+                  id: energy_low_power_banner
+                  align: BOTTOM_MID
+                  y: -30
+                  width: 440
+                  height: 80
+                  bg_color: 0xe94560
+                  border_width: 0
+                  radius: 12
+                  pad_all: 0
+                  scrollbar_mode: "off"
+                  scrollable: false
+                  hidden: true
+                  layout:
+                    type: FLEX
+                    flex_flow: ROW
+                    flex_align_main: CENTER
+                    flex_align_cross: CENTER
+                    pad_column: 14
+                  widgets:
+                    - label:
+                        text: "\U000F0026"  # mdi:alert-circle
+                        text_font: mdi_icons_energy
+                        text_color: 0xffffff
+                    - label:
+                        text: "LOW POWER"
+                        text_font: montserrat_28
+                        text_color: 0xffffff

--- a/packages/sleep-mode.yaml
+++ b/packages/sleep-mode.yaml
@@ -55,6 +55,15 @@ globals:
     type: bool
     restore_value: no
     initial_value: 'false'
+  # Sleep bypass: when true, sleep_mode_sleep is a no-op and
+  # sleep_mode_auto_off's countdown skipped. Set/cleared by other packages
+  # via the sleep_bypass_set / sleep_bypass_clear scripts to keep the
+  # screen forcibly on for an alert condition (e.g. energy-ui's
+  # low-power binary sensor).
+  - id: g_sleep_bypass
+    type: bool
+    restore_value: no
+    initial_value: 'false'
 
 switch:
   - platform: template
@@ -113,23 +122,29 @@ script:
 
   # Sleep: reset to the configured home page (nav_home_page) so wake always
   # lands there rather than wherever the last user left it. Then
-  # show black overlay, fade backlight off.
+  # show black overlay, fade backlight off. No-op while g_sleep_bypass
+  # is set (an alert condition needs the screen on).
   - id: sleep_mode_sleep
     mode: restart
     then:
-      - lambda: |-
-          id(g_screen_awake) = false;
-          id(nav_idx) = ${nav_home_page} - 1;
-      - script.execute: nav_show_page
-      - lvgl.widget.show:
-          id: sleep_overlay
-      - light.turn_off:
-          id: display_backlight
-          transition_length: 500ms
+      - if:
+          condition:
+            lambda: 'return !id(g_sleep_bypass);'
+          then:
+            - lambda: |-
+                id(g_screen_awake) = false;
+                id(nav_idx) = ${nav_home_page} - 1;
+            - script.execute: nav_show_page
+            - lvgl.widget.show:
+                id: sleep_overlay
+            - light.turn_off:
+                id: display_backlight
+                transition_length: 500ms
 
   # Idle auto-off. Restart-mode → each touch (board.yaml) re-arms it.
-  # Disabled when sleep mode is off, the screen is already asleep, or the
-  # configured timeout is below the 6 s usability floor.
+  # Disabled when sleep mode is off, the screen is already asleep, the
+  # configured timeout is below the 6 s usability floor, or another
+  # package has flipped g_sleep_bypass (e.g. an active low-power alert).
   - id: sleep_mode_auto_off
     mode: restart
     then:
@@ -138,11 +153,31 @@ script:
             lambda: |-
               return id(sleep_mode_enable).state &&
                      id(g_screen_awake) &&
-                     id(sleep_mode_timeout).state >= 6.0f;
+                     id(sleep_mode_timeout).state >= 6.0f &&
+                     !id(g_sleep_bypass);
           then:
             - delay: !lambda |-
                 return (uint32_t)(id(sleep_mode_timeout).state * 1000);
             - script.execute: sleep_mode_sleep
+
+  # Generic sleep-bypass entry point for other packages. Setting the
+  # flag also wakes the screen if it was asleep so the caller's alert
+  # is visible immediately.
+  - id: sleep_bypass_set
+    then:
+      - lambda: 'id(g_sleep_bypass) = true;'
+      - if:
+          condition:
+            lambda: 'return !id(g_screen_awake);'
+          then:
+            - script.execute: sleep_mode_wake
+
+  # Clear the bypass and re-arm the idle timer (which will only do
+  # anything if sleep mode is enabled and the timeout is sane).
+  - id: sleep_bypass_clear
+    then:
+      - lambda: 'id(g_sleep_bypass) = false;'
+      - script.execute: sleep_mode_auto_off
 
 # If sleep mode was on before a reboot, RESTORE_DEFAULT_OFF brings the
 # switch back as ON (template switch restores user state). This on_boot

--- a/tests/esp32-hass-panel.yaml
+++ b/tests/esp32-hass-panel.yaml
@@ -21,6 +21,12 @@ substitutions:
   sleep_mode_default_state: "ON"
   # Non-`-1` default — exercises the >= 6s auto-off timer path.
   sleep_mode_default_timeout: "30"
+  # Register energy_page in the swipe cycle so CI actually wires the
+  # strcmp("${nav_page_N}", "energy_page") routing in energy-ui.yaml.
+  # Without this, the page compiles but every strcmp resolves to
+  # false at YAML-merge time and the navbar status routing is dead.
+  nav_page_4: energy_page
+  nav_page_count: "4"
 
 packages:
   base: !include ../esp32-hass-panel.yaml


### PR DESCRIPTION
## Summary

New `packages/energy-ui.yaml` adds an `energy_page` bound to three Home Assistant entities — battery state of charge, grid online binary sensor, and a low-power alert binary sensor. When the low-power sensor fires, the panel bypasses sleep mode, force-navigates to the energy page if it''s registered, and flashes the page background red.

## What''s in the page

| Substitution | Default | Purpose |
|---|---|---|
| `energy_battery_entity_id` | `sensor.home_battery_charge` | Numeric sensor (0–100 %) for whole-home battery |
| `energy_grid_status_entity_id` | `binary_sensor.grid_online` | On = on-grid, off = islanded |
| `energy_low_power_entity_id` | `binary_sensor.home_low_power_alert` | On = critical state → bypass + flash |

Layout: large color-graded battery readout + LVGL bar (green ≥ 60, amber 30–59, red < 30), grid status row, low-power banner (hidden when ok).

## Low-power alert override

When the low-power binary sensor transitions to `on`:

1. **Bypass sleep mode** — `sleep_bypass_set` flips `g_sleep_bypass`, which gates both `sleep_mode_sleep` (no-op while set) and `sleep_mode_auto_off` (idle countdown skipped). If the screen was asleep, it wakes immediately.
2. **Force-navigate to `energy_page`** — `energy_page_force_home` scans `nav_page_1..4` for `energy_page`, sets `nav_idx`, runs `nav_show_page`. **No-op for panels that don''t expose the page** — those still get the bypass and flash but stay where they were.
3. **Flash the page bg** — a self-terminating `while`-loop pulses `energy_page_root` between dark (`0x1a1a2e`) and HA-red (`0xe94560`) on 500 ms ticks.

When the sensor clears, all three reverse: stop flashing, hide banner, `sleep_bypass_clear` re-arms the idle timer. Navigation isn''t undone — the user can swipe away whenever they want.

## sleep-mode.yaml changes

Added a **generic** programmatic bypass mechanism — not energy-specific:

- `g_sleep_bypass` (global, default `false`)
- `script.sleep_bypass_set` — flip on + wake if asleep
- `script.sleep_bypass_clear` — flip off + re-arm `sleep_mode_auto_off`

Both `sleep_mode_sleep` and `sleep_mode_auto_off` gain `&& !g_sleep_bypass`. Existing callers see no behavior change because the global defaults to false.

## Wiring

- `esp32-hass-panel.yaml` — adds `energy_ui: !include packages/energy-ui.yaml` to the `packages:` block. The page is **always compiled**; per-device wrappers opt it into the swipe cycle via `nav_page_N: energy_page` + bumping `nav_page_count`.
- README — file table, architecture diagram, "Energy monitoring page" feature row, "Energy" substitution group, 4-page cheat-sheet entry, programmatic-bypass bullet under sleep mode.

## Test plan

- [ ] CI: yamllint + the three ESPHome compile jobs pass (main + sleep-override fixture + bedroom one-page fixture). Bedroom test doesn''t include `energy-ui`, so the new sleep_bypass scripts compile but go unused.
- [ ] On a real panel with battery telemetry: add `nav_page_4: energy_page` + `nav_page_count: "4"` + the three `energy_*_entity_id` overrides. Verify the page renders battery %, color grades correctly, and the grid status row updates.
- [ ] Manually trigger the low-power binary sensor in HA: verify the screen wakes (if it was asleep), navigates to `energy_page`, and the bg flashes red. Verify swipe is still possible during the flash.
- [ ] Clear the low-power sensor in HA: flash stops, banner hides, sleep auto-off re-arms on next touch.
- [ ] On a bedroom panel WITHOUT `energy_page` registered: trigger low-power. Verify the screen wakes + (no flash since the page isn''t visible) + sleep stays bypassed until the alert clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)