### PR TITLE
fix: wake backlight on touch when light is turned off

### DIFF
--- a/packages/board.yaml
+++ b/packages/board.yaml
@@ -126,6 +126,9 @@ globals:
 #                    panel is asleep, the first touch only wakes the backlight
 #                    — it does not propagate to swipe tracking or to nav, so a
 #                    sleepy hand can't drag the wake gesture into a swipe.
+#   The backlight light entity is exposed to HA, so a user can turn it off
+#   from outside this firmware. If that happens, a touch must turn it back
+#   on — otherwise the panel is stuck dark with no recovery path.
 touchscreen:
   - platform: ${touchscreen_platform}
     id: tft_touch
@@ -137,6 +140,14 @@ touchscreen:
           then:
             - lambda: 'id(g_swallow_touch) = true;'
             - script.execute: sleep_mode_wake
+      - if:
+          condition:
+            lambda: 'return !id(g_swallow_touch) && !id(display_backlight).remote_values.is_on();'
+          then:
+            - lambda: 'id(g_swallow_touch) = true;'
+            - light.turn_on:
+                id: display_backlight
+                transition_length: 200ms
       - if:
           condition:
             lambda: 'return !id(g_swallow_touch);'


### PR DESCRIPTION
## Summary
- Touching the panel now turns the backlight back on when it has been switched off externally (e.g. via the HA `Backlight` light entity).
- Previously the only `on_touch` wake path required sleep mode to be enabled AND `g_screen_awake` to be false, so a user-initiated off left the panel stuck dark.
- New branch is gated on `!g_swallow_touch && !display_backlight.remote_values.is_on()`; it swallows the touch (no nav/swipe propagation) and fades the backlight on over 200 ms. Sleep-mode wake still wins when both conditions would match.

## Test plan
- [ ] In HA, turn off `light.<panel>_backlight`; touch the screen → backlight fades on, no page change.
- [ ] With sleep mode enabled and screen asleep, touch → wakes via the existing sleep-mode path (overlay hidden, returns to home page).
- [ ] With backlight on, normal swipes/taps still behave as before.