### PR TITLE
fix: fall back unused nav slots to nav_page_1 for slim builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,3 +122,21 @@ jobs:
               echo "::error::Unexpected warning(s) in area-panel build (above)"
               exit 1
           fi
+
+      - name: Compile cover panel (slim nav-slot fallback test)
+        # Slim single-page (nav_page_count: 1) config that registers ONLY
+        # cover_page in slot 1 and sets ONLY nav_page_1 — leaving nav_page_2/3/4
+        # at their nav.yaml default. Guards that the default resolves to
+        # ${nav_page_1} (a compiled page); if it reverts to the hardcoded
+        # alarm_page, nav_show_page's unreachable lvgl.page.show branches fail
+        # config validation in this alarm-less build. Uses cover_page (not
+        # area_page) so the fallback is proven page-agnostic.
+        shell: bash
+        run: |
+          set -o pipefail
+          python tests/compile.py compile tests/cover-panel.yaml 2>&1 \
+              | tee cover-build.log
+          if grep -E '^WARNING ' cover-build.log; then
+              echo "::error::Unexpected warning(s) in cover-panel build (above)"
+              exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ packages:
       # other UI pages omitted -> not compiled
 ```
 
-This drops the unused pages from flash (~140 KB measured for four). When composing slim, point **every** active `nav_page_N` at a page you actually included — unused slots fall back to `alarm_page`, which won't exist unless you include the alarm UI.
+This drops the unused pages from flash (~140 KB measured for four). When composing slim, point every active `nav_page_N` at a page you actually included. You only need to set as many `nav_page_N` as you have active pages — unused slots fall back to `nav_page_1`, so they always resolve to a compiled page (the alarm UI need not be included).
 
 #### When the image still doesn't fit — opt-in 16 MB flash
 
@@ -206,9 +206,9 @@ The YAML uses ESPHome [substitutions](https://esphome.io/components/substitution
 | `area_humidity_entity_id` | `sensor.none` | *Optional.* HA humidity sensor. Left at `sensor.none` → hidden |
 | **Navigation** | | |
 | `nav_page_1` | `alarm_page` | LVGL page ID at swipe slot 1 (leftmost) |
-| `nav_page_2` | `alarm_page` | Page at slot 2 (unused slots fall back to `nav_page_1`) |
-| `nav_page_3` | `alarm_page` | Page at slot 3 |
-| `nav_page_4` | `alarm_page` | Page at slot 4 |
+| `nav_page_2` | `${nav_page_1}` | Page at slot 2 (unused slots fall back to `nav_page_1`) |
+| `nav_page_3` | `${nav_page_1}` | Page at slot 3 |
+| `nav_page_4` | `${nav_page_1}` | Page at slot 4 |
 | `nav_page_count` | `1` | Number of active pages in the swipe cycle (1–4) |
 | `nav_home_page` | `"1"` | 1-based index (1…`nav_page_count`) of the landing page. The home page is shown on connect, when sleep mode wakes, and as the idle auto-return target. Must be ≤ `nav_page_count`. |
 | `nav_auto_return_delay` | `30s` | Idle time before auto-returning to home page |

--- a/packages/core.yaml
+++ b/packages/core.yaml
@@ -15,9 +15,9 @@
 #     area_ui: {url: ..., file: packages/area-ui.yaml}
 #
 # When composing slim, every active nav_page_N must point at a page that one
-# of your included UI packages defines. Unused slots default to alarm_page
-# (nav.yaml's fallback), which only exists if you include the alarm UI — set
-# them to a page you actually include (see tests/area-panel.yaml).
+# of your included UI packages defines. You only need to set as many nav_page_N
+# as you have active pages — unused slots default to ${nav_page_1}, so they
+# always resolve to a compiled page (see tests/area-panel.yaml).
 
 substitutions:
   name: esp32-hass-panel

--- a/packages/nav.yaml
+++ b/packages/nav.yaml
@@ -15,9 +15,12 @@
 #   substitutions:
 #     nav_page_1:     alarm_page      # leftmost swipe slot
 #     nav_page_2:     thermostat_page
-#     nav_page_3:     alarm_page      # unused slots fall back to nav_page_1
-#     nav_page_4:     alarm_page
 #     nav_page_count: "2"             # how many slots are active (1–4)
+#
+#   Only set as many nav_page_N as you have active pages. Unused slots default
+#   to ${nav_page_1}, so they always resolve to a compiled page — important for
+#   slim builds that don't include alarm_page (the unreachable lvgl.page.show
+#   branches are still validated at compile time).
 #     nav_home_page:  "1"             # 1-based index of the landing page
 #                                     # (shown on connect, target of idle return).
 #                                     # Defaults to "1". Must be <= nav_page_count.
@@ -37,9 +40,9 @@
 
 substitutions:
   nav_page_1: alarm_page      # leftmost swipe slot (default first page)
-  nav_page_2: alarm_page      # unused slots fall back to nav_page_1 (safe no-op)
-  nav_page_3: alarm_page
-  nav_page_4: alarm_page
+  nav_page_2: ${nav_page_1}   # unused slots fall back to nav_page_1 (safe no-op):
+  nav_page_3: ${nav_page_1}   # always a compiled page, so the unreachable
+  nav_page_4: ${nav_page_1}   # lvgl.page.show branches still validate in slim builds
   nav_page_count: "1"
   nav_home_page: "1"          # 1-based index of the landing page (1..nav_page_count)
   nav_auto_return_delay: 30s

--- a/tests/area-panel.yaml
+++ b/tests/area-panel.yaml
@@ -21,12 +21,10 @@ substitutions:
   area_locks_entity_id: lock.test_area
   area_temp_entity_id: sensor.test_area_temperature
   area_humidity_entity_id: sensor.test_area_humidity
-  # area_page in slot 1; unused slots must also resolve to a compiled page,
-  # so point them at area_page too (their alarm_page default isn't built here).
+  # area_page in slot 1 only — exactly like a real slim deployment. The unused
+  # slots must inherit ${nav_page_1} (nav.yaml default) so they resolve to a
+  # compiled page; setting them here would mask a regression in that fallback.
   nav_page_1: area_page
-  nav_page_2: area_page
-  nav_page_3: area_page
-  nav_page_4: area_page
   nav_page_count: "1"
 
 packages:

--- a/tests/cover-panel.yaml
+++ b/tests/cover-panel.yaml
@@ -1,0 +1,28 @@
+# CI fixture — single-page Cover panel (slim composition).
+#
+# Regression guard for the slim nav-slot fallback. A slim build omits
+# alarm-keypad-ui, so alarm_page is never defined. This fixture registers
+# ONLY cover_page in slot 1 and sets ONLY nav_page_1 — leaving nav_page_2/3/4
+# at their nav.yaml default. That default must resolve to ${nav_page_1}
+# (= cover_page, a compiled page); if it ever reverts to the hardcoded
+# alarm_page, nav_show_page's unreachable lvgl.page.show branches fail config
+# validation with "Couldn't find ID 'alarm_page'" and this build breaks.
+#
+# Uses cover_page (not area_page) on purpose, so the fallback is proven to be
+# page-agnostic rather than coincidental to one UI package.
+#
+# Compile-only — never flashed to a real device.
+
+substitutions:
+  name: test-cover-panel
+  friendly_name: Test Cover Panel
+  cover_entity_id: cover.test_garage
+  # cover_page in slot 1 only — exactly like a real slim deployment. The unused
+  # slots must inherit ${nav_page_1} (nav.yaml default) so they resolve to a
+  # compiled page; setting them here would mask a regression in that fallback.
+  nav_page_1: cover_page
+  nav_page_count: "1"
+
+packages:
+  core: !include ../packages/core.yaml
+  cover_ui: !include ../packages/cover-ui.yaml


### PR DESCRIPTION
## Problem

A slim build that omits `alarm-keypad-ui.yaml` (e.g. an area-only panel) never defines `alarm_page`. But `nav.yaml` hardcoded the unused-slot defaults `nav_page_2/3/4` to `alarm_page`, and `nav_show_page` emits an `lvgl.page.show: ${nav_page_N}` action per slot. ESPHome validates the page ID at **config** time even for unreachable `if` branches, so a real slim config (only `nav_page_1` set) failed:

```
Couldn't find ID 'alarm_page'. ... These IDs look similar: "area_page".
```

The CI `area-panel.yaml` fixture masked this by manually setting `nav_page_2/3/4: area_page`.

## Fix

- `packages/nav.yaml` — default unused slots to `${nav_page_1}` instead of `alarm_page`, so they always resolve to a compiled page. (The comment already claimed this behavior; it was never implemented.)
- `tests/area-panel.yaml` — set only `nav_page_1` (like a real slim deployment) so CI exercises and protects the fallback.
- `README.md`, `packages/core.yaml` — docs updated to describe the `${nav_page_1}` fallback.

## Validation

`esphome config tests/area-panel.yaml` → `INFO Configuration is valid!` (previously failed on the missing `alarm_page` ID).